### PR TITLE
return sa key from bond as json

### DIFF
--- a/service/src/main/java/bio/terra/drshub/models/DrsMetadata.java
+++ b/service/src/main/java/bio/terra/drshub/models/DrsMetadata.java
@@ -15,7 +15,7 @@ public interface DrsMetadata extends WithDrsMetadata {
 
   Optional<AccessURL> getAccessUrl();
 
-  Optional<Object> getBondSaKey();
+  Optional<String> getBondSaKey();
 
   class Builder extends ImmutableDrsMetadata.Builder {}
 }

--- a/service/src/main/java/bio/terra/drshub/models/DrsMetadata.java
+++ b/service/src/main/java/bio/terra/drshub/models/DrsMetadata.java
@@ -15,7 +15,7 @@ public interface DrsMetadata extends WithDrsMetadata {
 
   Optional<AccessURL> getAccessUrl();
 
-  Optional<String> getBondSaKey();
+  Optional<Object> getBondSaKey();
 
   class Builder extends ImmutableDrsMetadata.Builder {}
 }

--- a/service/src/main/java/bio/terra/drshub/services/MetadataService.java
+++ b/service/src/main/java/bio/terra/drshub/services/MetadataService.java
@@ -9,6 +9,8 @@ import bio.terra.drshub.generated.model.ResourceMetadata;
 import bio.terra.drshub.models.AccessUrlAuthEnum;
 import bio.terra.drshub.models.DrsMetadata;
 import bio.terra.drshub.models.Fields;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.ga4gh.drs.model.AccessMethod;
 import io.github.ga4gh.drs.model.AccessURL;
 import io.github.ga4gh.drs.model.Checksum;
@@ -77,16 +79,19 @@ public class MetadataService {
   private final BondApiFactory bondApiFactory;
   private final ExternalCredsApiFactory externalCredsApiFactory;
   private final DrsApiFactory drsApiFactory;
+  private final ObjectMapper objectMapper;
 
   public MetadataService(
       DrsHubConfig drsHubConfig,
       BondApiFactory bondApiFactory,
       ExternalCredsApiFactory externalCredsApiFactory,
-      DrsApiFactory drsApiFactory) {
+      DrsApiFactory drsApiFactory,
+      ObjectMapper objectMapper) {
     this.drsHubConfig = drsHubConfig;
     this.bondApiFactory = bondApiFactory;
     this.externalCredsApiFactory = externalCredsApiFactory;
     this.drsApiFactory = drsApiFactory;
+    this.objectMapper = objectMapper;
   }
 
   public ResourceMetadata fetchResourceMetadata(
@@ -198,11 +203,16 @@ public class MetadataService {
       var bondApi = bondApiFactory.getApi(bearerToken);
 
       // TODO: are we getting the key in a usable format?
-      bondSaKey =
-          bondApi
-              .getLinkSaKey(drsProvider.getBondProvider().orElseThrow().toString())
-              .getData()
-              .toString();
+      try {
+        bondSaKey =
+            new ObjectMapper()
+                .writeValueAsString(
+                    bondApi
+                        .getLinkSaKey(drsProvider.getBondProvider().orElseThrow().toString())
+                        .getData());
+      } catch (JsonProcessingException e) {
+        throw new DrsHubException("Unable to parse SA key response from Bond", e);
+      }
     }
 
     Optional<AccessURL> accessUrl = Optional.empty();

--- a/service/src/main/java/bio/terra/drshub/services/MetadataService.java
+++ b/service/src/main/java/bio/terra/drshub/services/MetadataService.java
@@ -79,19 +79,16 @@ public class MetadataService {
   private final BondApiFactory bondApiFactory;
   private final ExternalCredsApiFactory externalCredsApiFactory;
   private final DrsApiFactory drsApiFactory;
-  private final ObjectMapper objectMapper;
 
   public MetadataService(
       DrsHubConfig drsHubConfig,
       BondApiFactory bondApiFactory,
       ExternalCredsApiFactory externalCredsApiFactory,
-      DrsApiFactory drsApiFactory,
-      ObjectMapper objectMapper) {
+      DrsApiFactory drsApiFactory) {
     this.drsHubConfig = drsHubConfig;
     this.bondApiFactory = bondApiFactory;
     this.externalCredsApiFactory = externalCredsApiFactory;
     this.drsApiFactory = drsApiFactory;
-    this.objectMapper = objectMapper;
   }
 
   public ResourceMetadata fetchResourceMetadata(

--- a/service/src/test/java/bio/terra/drshub/controllers/DrsHubApiControllerTest.java
+++ b/service/src/test/java/bio/terra/drshub/controllers/DrsHubApiControllerTest.java
@@ -211,7 +211,7 @@ public class DrsHubApiControllerTest extends BaseTest {
     var provider = "bioDataCatalyst";
     var compactIdAndHost = getProviderHosts(provider);
 
-    String bondSaKey = objectMapper.writeValueAsString(Map.of("foo", "sa key"));
+    var bondSaKey = Map.of("foo", "sa key");
     mockBondLinkSaKeyApi(
         config.getDrsProviders().get(provider).getBondProvider().get(),
         TEST_ACCESS_TOKEN,
@@ -227,7 +227,9 @@ public class DrsHubApiControllerTest extends BaseTest {
             content()
                 .json(
                     objectMapper.writeValueAsString(
-                        Map.of(Fields.GOOGLE_SERVICE_ACCOUNT, bondSaKey))));
+                        Map.of(
+                            Fields.GOOGLE_SERVICE_ACCOUNT,
+                            new ObjectMapper().writeValueAsString(bondSaKey)))));
   }
 
   @Test // 20


### PR DESCRIPTION
Previously, it was serialized as `key=value` instead of json.