### PR TITLE
[ID-83] Intentionally throwing Internal Server Error to test error reporting.

### DIFF
--- a/service/src/main/java/bio/terra/drshub/controllers/DrsHubApiController.java
+++ b/service/src/main/java/bio/terra/drshub/controllers/DrsHubApiController.java
@@ -2,6 +2,7 @@ package bio.terra.drshub.controllers;
 
 import bio.terra.common.exception.BadRequestException;
 import bio.terra.common.iam.BearerTokenFactory;
+import bio.terra.drshub.DrsHubException;
 import bio.terra.drshub.generated.api.DrsHubApi;
 import bio.terra.drshub.generated.model.RequestObject;
 import bio.terra.drshub.generated.model.ResourceMetadata;
@@ -42,11 +43,10 @@ public class DrsHubApiController implements DrsHubApi {
 
     log.info("Received URL '{}' from agent '{}' on IP '{}'", body.getUrl(), userAgent, ip);
 
-    var resourceMetadata =
-        metadataService.fetchResourceMetadata(
-            body.getUrl(), body.getFields(), bearerToken, forceAccessUrl);
-
-    return ResponseEntity.ok(resourceMetadata);
+    throw new DrsHubException(
+        "Intentionally throwing Internal Server Error to test error reporting"
+            + " for https://broadworkbench.atlassian.net/browse/ID-83 on the dev env ; please do not"
+            + " send this change beyond the dev env");
   }
 
   private void validateRequest(RequestObject body) {


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/ID-83

## Context

Intentionally throwing an error to test [error reporting](https://console.cloud.google.com/errors;filter=%5B%22drs%22%5D;time=P7D?project=broad-dsde-dev&supportedpurview=project).

I'm expecting ~22 tests to fail here. I'd rather not change these tests in case someone else wants to merge a change on top of this change, in which case their changes won't be tested properly. I know that by not changing the tests here, it will cause the tests to fail for other PRs. I think I prefer that tests fail loudly rather than allowing another PR to get merged with tests that aren't running.

And so, I plan to force merge this (since tests will fail). And then after testing it on dev, I will revert it as quickly as possible.

Followup PR: https://github.com/DataBiosphere/terra-drs-hub/pull/32


## alternatives considered

I thought about adding this to a less-used endpoint to minimize disruptions. The other two endpoints are status and version. The status endpoint is used for health checks so I don't want to touch that. The version endpoint seemed like a good candidate. However, when I looked for log messages for the version endpoint, I could not find any in kibana or the google logs. So I ended up back to using the `resolve` endpoint

---

Side note: Local development is difficult without a README.