### PR TITLE
[ID-83] Revert -- Intentionally throwing Internal Server Error to test error reporting

### DIFF
--- a/service/src/main/java/bio/terra/drshub/controllers/DrsHubApiController.java
+++ b/service/src/main/java/bio/terra/drshub/controllers/DrsHubApiController.java
@@ -2,7 +2,6 @@ package bio.terra.drshub.controllers;
 
 import bio.terra.common.exception.BadRequestException;
 import bio.terra.common.iam.BearerTokenFactory;
-import bio.terra.drshub.DrsHubException;
 import bio.terra.drshub.generated.api.DrsHubApi;
 import bio.terra.drshub.generated.model.RequestObject;
 import bio.terra.drshub.generated.model.ResourceMetadata;
@@ -43,10 +42,11 @@ public class DrsHubApiController implements DrsHubApi {
 
     log.info("Received URL '{}' from agent '{}' on IP '{}'", body.getUrl(), userAgent, ip);
 
-    throw new DrsHubException(
-        "Intentionally throwing Internal Server Error to test error reporting"
-            + " for https://broadworkbench.atlassian.net/browse/ID-83 on the dev env ; please do not"
-            + " send this change beyond the dev env");
+    var resourceMetadata =
+        metadataService.fetchResourceMetadata(
+            body.getUrl(), body.getFields(), bearerToken, forceAccessUrl);
+
+    return ResponseEntity.ok(resourceMetadata);
   }
 
   private void validateRequest(RequestObject body) {


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/ID-83

as planned, as a followup to https://github.com/DataBiosphere/terra-drs-hub/pull/31. See that PR for context.

I plan to merge this in as quickly as possible to minimize disruption to other PRs and the dev env.