### PR TITLE
[ID-117] fix version bumping

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -11,7 +11,7 @@ jobs:
           token: ${{ secrets.BROADBOT_TOKEN }} # this allows the push to succeed later
       - name: Bump the tag to a new version
         # https://github.com/DataBiosphere/github-actions/tree/master/actions/bumper
-        uses: databiosphere/github-actions/actions/bumper@bumper-0.0.3
+        uses: databiosphere/github-actions/actions/bumper@bumper-0.0.6
         id: tag
         env:
           GITHUB_TOKEN: ${{ secrets.BROADBOT_TOKEN }}


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/ID-117

I found that the drshub versions weren't getting updated in argocd / helm files. I found that there's a github action for updating the version, using a github action called bumper.

Googling for this with the error message `fatal: unsafe repository ('/github/workspace' is owned by someone else)`, I found this which explains the context for this issue:
https://github.com/actions/checkout/issues/760

Funnily enough, I think I found it because of Yonghao's PRs which referenced the issue, which are listed in the thread. For example: https://github.com/broadinstitute/jacalloc/pull/2