### PR TITLE
ID-84 Sentry config and stackdriver logging support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,6 @@
+# Dr. Shub, MD
+## Also known as DrsHub
+
+## Logging
+By default, DrsHub will emit logs in the Stackdriver JSON format. 
+To disable this behavior for local development, add `DRSHUB_LOG_APPENDER=Console-Standard` to your environment when running DrsHub.

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -52,4 +52,9 @@ dependencies {
 	}
 	implementation 'org.broadinstitute.dsde.workbench:sam-client_2.13:0.1-1b67d8b'
 	implementation 'bio.terra:externalcreds-client-resttemplate:0.72.0-SNAPSHOT'
+	implementation 'io.sentry:sentry-logback:6.1.4'
+	implementation 'org.codehaus.janino:janino:3.1.7' // Provides if/else xml parsing for logback config
+	implementation('org.springframework.cloud:spring-cloud-gcp-starter-logging:1.2.8.RELEASE') {
+		exclude group: 'org.springframework', module: 'spring-jcl'
+	}
 }

--- a/service/src/main/resources/logback.xml
+++ b/service/src/main/resources/logback.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--We need this file to override the terra-commons-lib configuration for human-readable logging-->
+<configuration scan="true" scanPeriod="30 seconds">
+
+    <variable name="LOG_PATH" value="logs"/>
+
+    <if condition='!isDefined("DRSHUB_LOG_APPENDER")'>
+        <then>
+            <variable name="DRSHUB_LOG_APPENDER" value="Console-Stackdriver" />
+        </then>
+    </if>
+
+    <appender name="Console-Standard" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <Pattern>%date %-5level [%thread] %logger{36}: %message%n</Pattern>
+        </encoder>
+    </appender>
+
+    <appender name="Console-Stackdriver" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">
+            <layout class="org.springframework.cloud.gcp.logging.StackdriverJsonLayout">
+                <includeTraceId>true</includeTraceId>
+                <includeSpanId>true</includeSpanId>
+            </layout>
+        </encoder>
+    </appender>
+
+    <if condition='isDefined("SENTRY_DSN")'>
+        <then>
+            <appender name="Sentry" class="io.sentry.logback.SentryAppender"/>
+        </then>
+    </if>
+
+    <root level="INFO">
+        <appender-ref ref="${DRSHUB_LOG_APPENDER}"/>
+        <if condition='isDefined("SENTRY_DSN")'>
+            <then>
+                <appender-ref ref="Sentry"/>
+            </then>
+        </if>
+    </root>
+</configuration>


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/ID-84

Adding Sentry and Stackdriver logging support. The `SENTRY_DSN` environment variable still needs to be populated in deployed environments, but that will happen through terra-helmfile. 

This also adds support for human-readable logging. When running locally, set `DRSHUB_LOG_APPENDER=Console-Standard` in your env, and DrsHub will log normal lines instead of Stackdriver JSON. Useful for local development!