### PR TITLE
enable SonarCloud for drshub

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -28,8 +28,21 @@ jobs:
           key: v1-${{ runner.os }}-gradle-${{ github.ref }}-${{ github.sha }}
           restore-keys: v1-${{ runner.os }}-gradle-${{ github.ref }}
 
+      - name: Cache SonarCloud packages
+        uses: actions/cache@v1
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+
       - name: Gradle build service
         run: ./gradlew --build-cache :service:build -x test
+
+      - name: SonarQube scan service
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: ./gradlew --build-cache :service:sonarqube
 
       - name: Upload spotbugs results
         uses: github/codeql-action/upload-sarif@main

--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # Dr. Shub, MD
 ## Also known as DrsHub
 
+## SonarCloud Status
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=DataBiosphere_terra-drs-hub&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=DataBiosphere_terra-drs-hub)
+
 ## Logging
 By default, DrsHub will emit logs in the Stackdriver JSON format.
 To disable this behavior for local development, add `DRSHUB_LOG_APPENDER=Console-Standard` to your environment when running DrsHub.
 
-## SonarCloud Status
 
-[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=DataBiosphere_terra-drs-hub&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=DataBiosphere_terra-drs-hub)

--- a/README.md
+++ b/README.md
@@ -2,5 +2,9 @@
 ## Also known as DrsHub
 
 ## Logging
-By default, DrsHub will emit logs in the Stackdriver JSON format. 
+By default, DrsHub will emit logs in the Stackdriver JSON format.
 To disable this behavior for local development, add `DRSHUB_LOG_APPENDER=Console-Standard` to your environment when running DrsHub.
+
+## SonarCloud Status
+
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=DataBiosphere_terra-drs-hub&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=DataBiosphere_terra-drs-hub)

--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,7 @@ plugins {
 	// ^^ see https://github.com/GoogleContainerTools/jib/blob/master/docs/faq.md#i-am-seeing-method-not-found-or-class-not-found-errors-when-building
 	id 'io.freefair.lombok' version '6.4.1' apply false
 	id 'org.hidetake.swagger.generator' version '2.19.2' apply false
+	id 'org.sonarqube' version '3.3' apply false
 }
 
 repositories { mavenCentral() }

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -58,8 +58,8 @@ dependencies {
 // TODO: update this for drshub sonarcloud instance
 sonarqube {
 	properties {
-		property "sonar.projectName", "terra-external-credentials-manager-service"
-		property "sonar.projectKey", "DataBiosphere_terra-external-credentials-manager"
+		property "sonar.projectName", "terra-drs-hub"
+		property "sonar.projectKey", "DataBiosphere_terra-drs-hub"
 		property "sonar.organization", "broad-databiosphere"
 		property "sonar.host.url", "https://sonarcloud.io"
 		property "sonar.sources", "src/main/java,src/main/resources/templates"

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -55,7 +55,6 @@ dependencies {
 	implementation 'bio.terra:externalcreds-client-resttemplate:0.72.0-SNAPSHOT'
 }
 
-// TODO: update this for drshub sonarcloud instance
 sonarqube {
 	properties {
 		property "sonar.projectName", "terra-drs-hub"

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -12,6 +12,7 @@ plugins {
 	id 'com.gorylenko.gradle-git-properties' version '2.4.0'
 	id 'io.freefair.lombok'
 	id 'org.hidetake.swagger.generator'
+	id 'org.sonarqube'
 }
 
 repositories {
@@ -52,4 +53,15 @@ dependencies {
 	}
 	implementation 'org.broadinstitute.dsde.workbench:sam-client_2.13:0.1-1b67d8b'
 	implementation 'bio.terra:externalcreds-client-resttemplate:0.72.0-SNAPSHOT'
+}
+
+// TODO: update this for drshub sonarcloud instance
+sonarqube {
+	properties {
+		property "sonar.projectName", "terra-external-credentials-manager-service"
+		property "sonar.projectKey", "DataBiosphere_terra-external-credentials-manager"
+		property "sonar.organization", "broad-databiosphere"
+		property "sonar.host.url", "https://sonarcloud.io"
+		property "sonar.sources", "src/main/java,src/main/resources/templates"
+	}
 }


### PR DESCRIPTION
Enables SonarCloud and add it to github workflow `build-and-test.` Also adds a sonarcloud status badge to the readme. 

Linked terraform pr (merged): https://github.com/broadinstitute/terraform-ap-deployments/pull/712