### PR TITLE
[trivy] Add AppSec Docker vulnerability scanning step

### DIFF
--- a/.github/workflows/publish-branch-image.yml
+++ b/.github/workflows/publish-branch-image.yml
@@ -46,5 +46,9 @@ jobs:
         run: echo ::set-output name=name::gcr.io/${GOOGLE_PROJECT}/${SERVICE_NAME}:${{ steps.tag.outputs.tag }}
       - name: Build image locally with jib
         run: './gradlew :service:jibDockerBuild --image=${{ steps.image-name.outputs.name }} -Djib.console=plain'
+      - name: Scan for Docker vulnerabilities
+        uses: broadinstitute/dsp-appsec-trivy-action@v1
+        with:
+          image: ${{ steps.image-name.outputs.name }}
       - name: Push GCR image
         run: 'docker push ${{ steps.image-name.outputs.name }}'


### PR DESCRIPTION
This PR adds AppSec Trivy vulnerability scanner to the "branch publish" workflow, to detect critical vulnerabilities after the final image is built but before it's published.

Please let us know if this is undesirable for this workflow, as we already see Trivy is integrated with the other "Publish" workflow here: https://github.com/DataBiosphere/terra-drs-hub/blob/7f92c8f1efbeb94144efc0ac0f1a0c770ab60c64/.github/workflows/publish.yml#L59-L63