### PR TITLE
[ID-111] Add Options endpoint to Ga4GH OpenAPI YAML

### DIFF
--- a/service/src/main/resources/vendor/data-repository-service-1.2.0.yaml
+++ b/service/src/main/resources/vendor/data-repository-service-1.2.0.yaml
@@ -55,7 +55,7 @@ tags:
 
 
       * DRS IDs are strings made up of uppercase and lowercase letters, decimal
-      digits, hyphen, period, underscore and tilde [A-Za-z0-9.-_~]. See [RFC 3986
+      digits, hypen, period, underscore and tilde [A-Za-z0-9.-_~]. See [RFC 3986
       § 2.3](https://datatracker.ietf.org/doc/html/rfc3986#section-2.3).
 
       * DRS IDs can contain other characters, but they MUST be encoded into
@@ -337,7 +337,7 @@ tags:
       service philosophy. It uses JSON in requests and responses and standard
       HTTPS on port 443 for information transport.  Optionally, it
 
-      supports authentication and authorization using the [GA4GH
+      supports authenitcation and authorization using the [GA4GH
       Passport](https://github.com/ga4gh-duri/ga4gh-duri.github.io/tree/master/researcher_ids)
       standard.
   - name: Authorization & Authentication
@@ -404,7 +404,25 @@ tags:
       ## Authentication
 
 
-      ### BasicAuth
+      ### Discovery
+
+
+      The APIs to fetch [DrsObjects](l#tag/DrsObjectModel) and
+      [AccessURLs](#tag/AccessURLModel) may require authorization. The
+      authorization mode may vary between DRS objects hosted by a service. The
+      authorization mode may vary between the APIs to fetch a
+      [DrsObject](l#tag/DrsObjectModel) and an associated
+      [AccessURL](#tag/AccessURLModel). Implementers should indicate how to
+      authenticate to fetch a [DrsObject](l#tag/DrsObjectModel) by implementing
+      the [OptionsOjbect](#operation/OptionsObject) API. Implementers should
+      indicate how to authenticate to fetch an [AccessURL](#tag/AccessURLModel)
+      within a [DrsObject](l#tag/DrsObjectModel).
+
+
+      ### Modes
+
+
+      #### BasicAuth
 
 
       A valid authorization token must be passed in the 'Authorization' header,
@@ -418,7 +436,7 @@ tags:
       | **HTTP Authorization Scheme** | basic |
 
 
-      ### BearerAuth
+      #### BearerAuth
 
 
       A valid authorization token must be passed in the 'Authorization' header,
@@ -432,7 +450,7 @@ tags:
       | **HTTP Authorization Scheme** | bearer |
 
 
-      ### PassportAuth
+      #### PassportAuth
 
 
       A valid authorization [GA4GH
@@ -913,6 +931,32 @@ paths:
       tags:
         - Service Info
   /objects/{object_id}:
+    options:
+      summary: Get Authorization info about a DrsObject.
+      security:
+        - {}
+      description: >-
+        Returns a list of `Authorizations` that can be used to determine how to
+        authorize requests to `GetObject` or `PostObject`.
+      operationId: OptionsObject
+      parameters:
+        - $ref: '#/components/parameters/ObjectId'
+      responses:
+        '200':
+          $ref: '#/components/responses/200OkAuthorizations'
+        '204':
+          $ref: '#/components/responses/AuthorizationsNotSupported'
+        '400':
+          $ref: '#/components/responses/400BadRequest'
+        '404':
+          $ref: '#/components/responses/404NotFoundDrsObject'
+        '405':
+          $ref: '#/components/responses/AuthorizationsNotSupported'
+        '500':
+          $ref: '#/components/responses/500InternalServerError'
+      tags:
+        - Objects
+      x-swagger-router-controller: ga4gh.drs.server
     get:
       summary: Get info about a DrsObject.
       description: >-
@@ -946,7 +990,7 @@ paths:
         Returns object metadata, and a list of access methods that can be used
         to fetch object bytes.
 
-        Method is a POST to accommodate a JWT GA4GH Passport sent in the formData
+        Method is a POST to accomodate a JWT GA4GH Passport sent in the formData
         in order to authorize access.
       operationId: PostObject
       security:
@@ -973,30 +1017,6 @@ paths:
         - $ref: '#/components/parameters/ObjectId'
       requestBody:
         $ref: '#/components/requestBodies/PostObjectBody'
-    options:
-      summary: Get Authorization info about a DrsObject.
-      description: >-
-        Returns a list of Authorizations that can be used to determine how to authorize requests to GetObject or PostObject.
-      operationId: OptionsObject
-      parameters:
-        - $ref: '#/components/parameters/ObjectId'
-        - $ref: '#/components/parameters/Expand'
-      responses:
-        '200':
-          $ref: '#/components/responses/200AuthorizationsFound'
-        '204':
-          $ref: '#/components/responses/204AuthorizationsNotSupported'
-        '400':
-          $ref: '#/components/responses/400BadRequest'
-        '404':
-          $ref: '#/components/responses/404NotFoundDrsObject'
-        '405':
-          $ref: '#/components/responses/405AuthorizationsNotSupported'
-        '500':
-          $ref: '#/components/responses/500InternalServerError'
-      tags:
-        - Objects
-      x-swagger-router-controller: ga4gh.drs.server
   /objects/{object_id}/access/{access_id}:
     get:
       summary: Get a URL for fetching bytes
@@ -1037,7 +1057,7 @@ paths:
         contains an `access_id` (e.g., for servers that use signed URLs for
         fetching object bytes).
 
-        Method is a POST to accommodate a JWT GA4GH Passport sent in the formData
+        Method is a POST to accomodate a JWT GA4GH Passport sent in the formData
         in order to authorize access.
       operationId: PostAccessURL
       security:
@@ -1283,6 +1303,47 @@ components:
             These headers can be used to provide auth tokens required to fetch
             the object bytes.
           example: 'Authorization: Basic Z2E0Z2g6ZHJz'
+    Authorizations:
+      type: object
+      properties:
+        supported_types:
+          type: array
+          items:
+            type: string
+            enum:
+              - None
+              - BasicAuth
+              - BearerAuth
+              - PassportAuth
+          description: >-
+            An Optional list of support authorization types. More than one can
+            be supported and tried in sequence. Defaults to `None` if empty or
+            missing.
+        passport_auth_issuers:
+          type: array
+          items:
+            type: string
+          description: >-
+            If authorizations contains `PassportAuth` this is a required list of
+            visa issuers (as found in a visa's `iss` claim) that may authorize
+            access to this object. The caller must only provide passports that
+            contain visas from this list. It is strongly recommended that the
+            caller validate that it is appropriate to send the requested
+            passport/visa to the DRS server to mitigate attacks by malicious DRS
+            servers requesting credentials they should not have.
+        bearer_auth_issuers:
+          type: array
+          items:
+            type: string
+          description: >-
+            If authorizations contains `BearerAuth` this is an optional list of
+            issuers that may authorize access to this object. The caller must
+            provide a token from one of these issuers. If this is empty or
+            missing it assumed the caller knows which token to send via other
+            means. It is strongly recommended that the caller validate that it
+            is appropriate to send the requested token to the DRS server to
+            mitigate attacks by malicious DRS servers requesting credentials
+            they should not have.
     AccessMethod:
       type: object
       required:
@@ -1301,11 +1362,12 @@ components:
             - file
           description: Type of the access method.
         access_url:
-          $ref: '#/components/schemas/AccessURL'
-          description: >-
-            An `AccessURL` that can be used to fetch the actual object bytes.
-            Note that at least one of `access_url` and `access_id` must be
-            provided.
+          allOf:
+            - $ref: '#/components/schemas/AccessURL'
+            - description: >-
+                An `AccessURL` that can be used to fetch the actual object
+                bytes. Note that at least one of `access_url` and `access_id`
+                must be provided.
         access_id:
           type: string
           description: >-
@@ -1319,6 +1381,12 @@ components:
             Name of the region in the cloud service provider that the object
             belongs to.
           example: us-east-1
+        authorizations:
+          allOf:
+            - $ref: '#/components/schemas/Authorizations'
+            - description: >-
+                When `access_id` is provided, `authorizations` provides
+                information about how to authorize the `/access` method.
     ContentsObject:
       type: object
       required:
@@ -1331,7 +1399,7 @@ components:
             materialising this object, overriding any name directly associated
             with the object itself. The name must be unique with the containing
             bundle. This string is made up of uppercase and lowercase letters,
-            decimal digits, hyphen, period, and underscore [A-Za-z0-9.-_]. See
+            decimal digits, hypen, period, and underscore [A-Za-z0-9.-_]. See
             http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap03.html#tag_03_282[portable
             filenames].
         id:
@@ -1374,7 +1442,7 @@ components:
             A string that can be used to name a `DrsObject`.
 
             This string is made up of uppercase and lowercase letters, decimal
-            digits, hyphen, period, and underscore [A-Za-z0-9.-_]. See
+            digits, hypen, period, and underscore [A-Za-z0-9.-_]. See
             http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap03.html#tag_03_282[portable
             filenames].
         self_uri:
@@ -1559,47 +1627,20 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/Error'
+    200OkAuthorizations:
+      description: '`Authorizations` were found successfully'
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Authorizations'
+    AuthorizationsNotSupported:
+      description: '`Authorizations` are not supported for this object. Default to `None`.'
     200OkAccess:
       description: The `AccessURL` was found successfully
       content:
         application/json:
           schema:
             $ref: '#/components/schemas/AccessURL'
-    200AuthorizationsFound:
-      description: "`Authorizations` were found successfully"
-      content:
-        application/json:
-          schema:
-            type: object
-            properties:
-              supported_type:
-                type: array
-                items:
-                  type: string
-                  description: >-
-                    An Optional list of support authorization types. More than one can be supported and tried in sequence. Defaults to `None` if empty or missing.
-                  example: None
-                  enum:
-                    - None
-                    - BasicAuth
-                    - BearerAuth
-                    - PassportAuth
-              passport_auth_issuers:
-                type: array
-                items:
-                  type: string
-                  description: >-
-                    If authorizations contains `PassportAuth` this is a required list of visa issuers (as found in a visa's `iss` claim) that may authorize access to this object. The caller must only provide passports that contain visas from this list. It is strongly recommended that the caller validate that it is appropriate to send the requested passport/visa to the DRS server to mitigate attacks by malicious DRS servers requesting credentials they should not have.
-              bearer_auth_issuers:
-                type: array
-                items:
-                  type: string
-                  description: >-
-                    If authorizations contains `BearerAuth` this is an optional list of issuers that may authorize access to this object. The caller must provide a token from one of these issuers. If this is empty or missing it assumed the caller knows which token to send via other means. It is strongly recommended that the caller validate that it is appropriate to send the requested token to the DRS server to mitigate attacks by malicious DRS servers requesting credentials they should not have.
-    204AuthorizationsNotSupported:
-      description: "`Authorizations` are not supported for this object. Default to `None`"
-    405AuthorizationsNotSupported:
-      description: "`Authorizations` are not supported for this object. Default to `None`"
   parameters:
     ObjectId:
       in: path
@@ -1622,7 +1663,7 @@ components:
 
         If true and the object_id refers to a bundle, then the entire set of
         objects in the bundle is expanded. That is, if the bundle contains
-        other bundles, then those other bundles are recursively expanded and
+        aother bundles, then those other bundles are recursively expanded and
         included in the result. Recursion continues through the entire sub-tree
         of the bundle.
 
@@ -1654,7 +1695,7 @@ components:
 
                   If true and the object_id refers to a bundle, then the entire
                   set of objects in the bundle is expanded. That is, if the
-                  bundle contains other bundles, then those other bundles are
+                  bundle contains aother bundles, then those other bundles are
                   recursively expanded and included in the result. Recursion
                   continues through the entire sub-tree of the bundle.
 

--- a/service/src/main/resources/vendor/data-repository-service-1.2.0.yaml
+++ b/service/src/main/resources/vendor/data-repository-service-1.2.0.yaml
@@ -1301,7 +1301,8 @@ components:
             - file
           description: Type of the access method.
         access_url:
-          $ref: '#/components/schemas/AccessURL'
+          allOf:
+            - $ref: '#/components/schemas/AccessURL'
           description: >-
             An `AccessURL` that can be used to fetch the actual object bytes.
             Note that at least one of `access_url` and `access_id` must be
@@ -1566,23 +1567,40 @@ components:
           schema:
             $ref: '#/components/schemas/AccessURL'
     200AuthorizationsFound:
-      description: The `Authorizations` were found successfully
+      description: "`Authorizations` were found successfully"
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthFound'
+            type: object
+            properties:
+              supported_type:
+                type: array
+                items:
+                  type: string
+                  description: >-
+                    An Optional list of support authorization types. More than one can be supported and tried in sequence. Defaults to `None` if empty or missing.
+                  example: None
+                  enum:
+                    - None
+                    - BasicAuth
+                    - BearerAuth
+                    - PassportAuth
+              passport_auth_issuers:
+                type: array
+                items:
+                  type: string
+                  description: >-
+                    If authorizations contains `PassportAuth` this is a required list of visa issuers (as found in a visa's `iss` claim) that may authorize access to this object. The caller must only provide passports that contain visas from this list. It is strongly recommended that the caller validate that it is appropriate to send the requested passport/visa to the DRS server to mitigate attacks by malicious DRS servers requesting credentials they should not have.
+              bearer_auth_issuers:
+                type: array
+                items:
+                  type: string
+                  description: >-
+                    If authorizations contains `BearerAuth` this is an optional list of issuers that may authorize access to this object. The caller must provide a token from one of these issuers. If this is empty or missing it assumed the caller knows which token to send via other means. It is strongly recommended that the caller validate that it is appropriate to send the requested token to the DRS server to mitigate attacks by malicious DRS servers requesting credentials they should not have.
     204AuthorizationsNotSupported:
-      description: Currently `Authorizations` are not supported for this object. Default to `None`
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/AuthNotSupported'
+      description: "`Authorizations` are not supported for this object. Default to `None`"
     405AuthorizationsNotSupported:
-      description: Currently `Authorizations` are not supported for this object. Default to `None`
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/Error'
+      description: "`Authorizations` are not supported for this object. Default to `None`"
   parameters:
     ObjectId:
       in: path

--- a/service/src/main/resources/vendor/data-repository-service-1.2.0.yaml
+++ b/service/src/main/resources/vendor/data-repository-service-1.2.0.yaml
@@ -973,6 +973,30 @@ paths:
         - $ref: '#/components/parameters/ObjectId'
       requestBody:
         $ref: '#/components/requestBodies/PostObjectBody'
+    options:
+      summary: Get Authorization info about a DrsObject.
+      description: >-
+        Returns a list of Authorizations that can be used to determine how to authorize requests to GetObject or PostObject.
+      operationId: OptionsObject
+      parameters:
+        - $ref: '#/components/parameters/ObjectId'
+        - $ref: '#/components/parameters/Expand'
+      responses:
+        '200':
+          $ref: '#/components/responses/200AuthorizationsFound'
+        '204':
+          $ref: '#/components/responses/204AuthorizationsNotSupported'
+        '400':
+          $ref: '#/components/responses/400BadRequest'
+        '404':
+          $ref: '#/components/responses/404NotFoundDrsObject'
+        '405':
+          $ref: '#/components/responses/405AuthorizationsNotSupported'
+        '500':
+          $ref: '#/components/responses/500InternalServerError'
+      tags:
+        - Objects
+      x-swagger-router-controller: ga4gh.drs.server
   /objects/{object_id}/access/{access_id}:
     get:
       summary: Get a URL for fetching bytes
@@ -1541,6 +1565,24 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/AccessURL'
+    200AuthorizationsFound:
+      description: The `Authorizations` were found successfully
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/AuthFound'
+    204AuthorizationsNotSupported:
+      description: Currently `Authorizations` are not supported for this object. Default to `None`
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/AuthNotSupported'
+    405AuthorizationsNotSupported:
+      description: Currently `Authorizations` are not supported for this object. Default to `None`
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
   parameters:
     ObjectId:
       in: path

--- a/service/src/main/resources/vendor/data-repository-service-1.2.0.yaml
+++ b/service/src/main/resources/vendor/data-repository-service-1.2.0.yaml
@@ -55,7 +55,7 @@ tags:
 
 
       * DRS IDs are strings made up of uppercase and lowercase letters, decimal
-      digits, hypen, period, underscore and tilde [A-Za-z0-9.-_~]. See [RFC 3986
+      digits, hyphen, period, underscore and tilde [A-Za-z0-9.-_~]. See [RFC 3986
       § 2.3](https://datatracker.ietf.org/doc/html/rfc3986#section-2.3).
 
       * DRS IDs can contain other characters, but they MUST be encoded into
@@ -337,7 +337,7 @@ tags:
       service philosophy. It uses JSON in requests and responses and standard
       HTTPS on port 443 for information transport.  Optionally, it
 
-      supports authenitcation and authorization using the [GA4GH
+      supports authentication and authorization using the [GA4GH
       Passport](https://github.com/ga4gh-duri/ga4gh-duri.github.io/tree/master/researcher_ids)
       standard.
   - name: Authorization & Authentication
@@ -946,7 +946,7 @@ paths:
         Returns object metadata, and a list of access methods that can be used
         to fetch object bytes.
 
-        Method is a POST to accomodate a JWT GA4GH Passport sent in the formData
+        Method is a POST to accommodate a JWT GA4GH Passport sent in the formData
         in order to authorize access.
       operationId: PostObject
       security:
@@ -1013,7 +1013,7 @@ paths:
         contains an `access_id` (e.g., for servers that use signed URLs for
         fetching object bytes).
 
-        Method is a POST to accomodate a JWT GA4GH Passport sent in the formData
+        Method is a POST to accommodate a JWT GA4GH Passport sent in the formData
         in order to authorize access.
       operationId: PostAccessURL
       security:
@@ -1307,7 +1307,7 @@ components:
             materialising this object, overriding any name directly associated
             with the object itself. The name must be unique with the containing
             bundle. This string is made up of uppercase and lowercase letters,
-            decimal digits, hypen, period, and underscore [A-Za-z0-9.-_]. See
+            decimal digits, hyphen, period, and underscore [A-Za-z0-9.-_]. See
             http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap03.html#tag_03_282[portable
             filenames].
         id:
@@ -1350,7 +1350,7 @@ components:
             A string that can be used to name a `DrsObject`.
 
             This string is made up of uppercase and lowercase letters, decimal
-            digits, hypen, period, and underscore [A-Za-z0-9.-_]. See
+            digits, hyphen, period, and underscore [A-Za-z0-9.-_]. See
             http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap03.html#tag_03_282[portable
             filenames].
         self_uri:
@@ -1563,7 +1563,7 @@ components:
 
         If true and the object_id refers to a bundle, then the entire set of
         objects in the bundle is expanded. That is, if the bundle contains
-        aother bundles, then those other bundles are recursively expanded and
+        other bundles, then those other bundles are recursively expanded and
         included in the result. Recursion continues through the entire sub-tree
         of the bundle.
 
@@ -1595,7 +1595,7 @@ components:
 
                   If true and the object_id refers to a bundle, then the entire
                   set of objects in the bundle is expanded. That is, if the
-                  bundle contains aother bundles, then those other bundles are
+                  bundle contains other bundles, then those other bundles are
                   recursively expanded and included in the result. Recursion
                   continues through the entire sub-tree of the bundle.
 

--- a/service/src/main/resources/vendor/data-repository-service-1.2.0.yaml
+++ b/service/src/main/resources/vendor/data-repository-service-1.2.0.yaml
@@ -1301,8 +1301,7 @@ components:
             - file
           description: Type of the access method.
         access_url:
-          allOf:
-            - $ref: '#/components/schemas/AccessURL'
+          $ref: '#/components/schemas/AccessURL'
           description: >-
             An `AccessURL` that can be used to fetch the actual object bytes.
             Note that at least one of `access_url` and `access_id` must be

--- a/service/src/test/java/bio/terra/drshub/controllers/DrsHubApiControllerTest.java
+++ b/service/src/test/java/bio/terra/drshub/controllers/DrsHubApiControllerTest.java
@@ -30,6 +30,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.ga4gh.drs.model.AccessMethod;
 import io.github.ga4gh.drs.model.AccessMethod.TypeEnum;
 import io.github.ga4gh.drs.model.AccessURL;
+import io.github.ga4gh.drs.model.AllOfAccessMethodAccessUrl;
 import io.github.ga4gh.drs.model.Checksum;
 import io.github.ga4gh.drs.model.DrsObject;
 import java.time.format.DateTimeFormatter;
@@ -171,7 +172,7 @@ public class DrsHubApiControllerTest extends BaseTest {
             .accessMethods(
                 List.of(
                     new AccessMethod()
-                        .accessUrl(new AccessURL().url("gs://foobar"))
+                        .accessUrl((AllOfAccessMethodAccessUrl) new AccessURL().url("gs://foobar"))
                         .type(TypeEnum.GS)));
 
     mockDrsApi(host, drsObject);
@@ -358,7 +359,8 @@ public class DrsHubApiControllerTest extends BaseTest {
     drsObject
         .getAccessMethods()
         .get(0)
-        .setAccessUrl(new AccessURL().url("gs://bucket/bad.different.name.txt"));
+        .setAccessUrl(
+            (AllOfAccessMethodAccessUrl) new AccessURL().url("gs://bucket/bad.different.name.txt"));
 
     mockDrsApi(cidProviderHost.dnsHost, drsObject);
 
@@ -382,7 +384,7 @@ public class DrsHubApiControllerTest extends BaseTest {
     drsObject
         .getAccessMethods()
         .get(0)
-        .setAccessUrl(new AccessURL().url("gs://bucket/" + fileName));
+        .setAccessUrl((AllOfAccessMethodAccessUrl) new AccessURL().url("gs://bucket/" + fileName));
 
     mockDrsApi(cidProviderHost.dnsHost, drsObject);
 

--- a/service/src/test/java/bio/terra/drshub/controllers/DrsHubApiControllerTest.java
+++ b/service/src/test/java/bio/terra/drshub/controllers/DrsHubApiControllerTest.java
@@ -172,7 +172,9 @@ public class DrsHubApiControllerTest extends BaseTest {
             .accessMethods(
                 List.of(
                     new AccessMethod()
-                        .accessUrl((AllOfAccessMethodAccessUrl) new AccessURL().url("gs://foobar"))
+                        .accessUrl(
+                            (AllOfAccessMethodAccessUrl)
+                                new AllOfAccessMethodAccessUrl().url("gs://foobar"))
                         .type(TypeEnum.GS)));
 
     mockDrsApi(host, drsObject);
@@ -360,7 +362,8 @@ public class DrsHubApiControllerTest extends BaseTest {
         .getAccessMethods()
         .get(0)
         .setAccessUrl(
-            (AllOfAccessMethodAccessUrl) new AccessURL().url("gs://bucket/bad.different.name.txt"));
+            (AllOfAccessMethodAccessUrl)
+                new AllOfAccessMethodAccessUrl().url("gs://bucket/bad.different.name.txt"));
 
     mockDrsApi(cidProviderHost.dnsHost, drsObject);
 

--- a/service/src/test/java/bio/terra/drshub/controllers/DrsHubApiControllerTest.java
+++ b/service/src/test/java/bio/terra/drshub/controllers/DrsHubApiControllerTest.java
@@ -387,7 +387,7 @@ public class DrsHubApiControllerTest extends BaseTest {
     drsObject
         .getAccessMethods()
         .get(0)
-        .setAccessUrl((AllOfAccessMethodAccessUrl) new AccessURL().url("gs://bucket/" + fileName));
+        .setAccessUrl((AllOfAccessMethodAccessUrl) new AllOfAccessMethodAccessUrl().url("gs://bucket/" + fileName));
 
     mockDrsApi(cidProviderHost.dnsHost, drsObject);
 


### PR DESCRIPTION
Adds support for the Options endpoint request as per the spec found [here](https://editor.swagger.io/?url=https://ga4gh.github.io/data-repository-service-schemas/preview/develop/openapi.yaml). 

[Ticket](https://broadworkbench.atlassian.net/browse/ID-111)
