### PR TITLE
ID-180 Don't use mTLS (or Passports in general) on prod

### DIFF
--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -54,20 +54,6 @@ drshub:
         - type: s3
           auth: fence_token
           fetchAccessUrl: true
-    passport:
-      name: Passport Test Provider
-      hostRegex: 'ctds-test-env\.planx-pla\.net'
-      metadataAuth: false
-      bondProvider: dcf_fence
-      accessMethodConfigs:
-        - type: gs
-          auth: passport
-          fetchAccessUrl: true
-          fallbackAuth: fence_token
-        - type: s3
-          auth: passport
-          fetchAccessUrl: true
-          fallbackAuth: fence_token
 
     terraDataRepo:
       name: Terra Data Repo (TDR)
@@ -129,6 +115,19 @@ spring.config.activate.on-profile: '!prod'
 drshub:
   drsProviders:
     passport:
+      name: Passport Test Provider
+      hostRegex: 'ctds-test-env\.planx-pla\.net'
+      metadataAuth: false
+      bondProvider: dcf_fence
+      accessMethodConfigs:
+        - type: gs
+          auth: passport
+          fetchAccessUrl: true
+          fallbackAuth: fence_token
+        - type: s3
+          auth: passport
+          fetchAccessUrl: true
+          fallbackAuth: fence_token
       mTlsConfig:
         keyPath: rendered/ras-mtls-client.key
         certPath: rendered/ras-mtls-client.crt

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -68,9 +68,6 @@ drshub:
           auth: passport
           fetchAccessUrl: true
           fallbackAuth: fence_token
-      mTlsConfig:
-        keyPath: rendered/ras-mtls-client.key
-        certPath: rendered/ras-mtls-client.crt
 
     terraDataRepo:
       name: Terra Data Repo (TDR)
@@ -127,3 +124,12 @@ drshub:
     "dg.anv0": gen3.theanvil.io
     "dg.4dfc": nci-crdc.datacommons.io
     "dg.f82a1a": data.kidsfirstdrc.org
+---
+spring.config.activate.on-profile: '!prod'
+drshub:
+  drsProviders:
+    passport:
+      mTlsConfig:
+        keyPath: rendered/ras-mtls-client.key
+        certPath: rendered/ras-mtls-client.crt
+


### PR DESCRIPTION
We don't have prod certs from RAS yet, so we can't actually do RAS passports in prod yet.

I've tested this locally. When `DEPLOY_ENV=dev`, the `passport` DRS Provider shows up in the config. When `DEPLOY_ENV=prod`, it does not!