### PR TITLE
[ID-351] Enable signed urls for TDR 

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -100,6 +100,7 @@ jobs:
 
       - name: Secrets check
         run: |
+          sudo ln -s "$(which echo)" /usr/local/bin/say
           ./minnie-kenny.sh --force
           git secrets --scan-history
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DrsHub (Also known as Dr. Shub, MD)
 ## Overview
-DrsHub is the [DRS](https://ga4gh.github.io/data-repository-service-schemas/preview/develop/docs/) resolution service for Terra.  
+DrsHub is the [DRS](https://ga4gh.github.io/data-repository-service-schemas/preview/develop/docs/) resolution service for Terra.
 
 It is a Java Spring Boot rewrite of the deprecated Cloud Function [Martha](https://github.com/broadinstitute/martha), specifically, its v3 API.
 
@@ -31,7 +31,7 @@ Currently, DrsHub supports the following DRS Providers:
 To resolve a DRS URL, perform an HTTP `POST` to `/api/v4/drs/resolve`.
 The content-type of your request should be `application/json` with the content/body of your request encoded accordingly.
 
-Request bodies should look like 
+Request bodies should look like
 ```json
 {
   "url": "string",
@@ -78,16 +78,16 @@ Some architecture diagrams can be found in [LucidChart](https://lucid.app/docume
 ## Development
 
 ### Setup
-Install Java 17 SDK from your preferred provider. A common way to install and manage different JDK versions is to use [sdkman](https://sdkman.io/). 
+Install Java 17 SDK from your preferred provider. A common way to install and manage different JDK versions is to use [sdkman](https://sdkman.io/).
 
-If developing in IntelliJ, you can just configure the Project SDK to use Java 17. 
+If developing in IntelliJ, you can just configure the Project SDK to use Java 17.
 You'll also need to set the Gradle JVM, located at `Preferences | Build, Execution, Deployment | Build Tools | Gradle`.
 
 You must use [git-secrets](https://github.com/awslabs/git-secrets). You should be doing this anyway for all of your repositories.
 DrsHub uses [Minnie Kenny](https://minnie-kenny.readthedocs.io/en/latest/), and is configured to run `minnie_kenny.sh` on `./gradlew test` tasks, ensuring that git-secrets is set up.
 You can also run it manually to make sure `git-secrets` is set up without testing.
 
-Before running anything, make sure to run `./render_configs <ENV>` to render secrets locally. The default `<ENV>` is `dev`, which is what you should use for local running and testing.
+Before running anything, make sure to run `./render_config <ENV>` to render secrets locally. The default `<ENV>` is `dev`, which is what you should use for local running and testing.
 
 DrsHub uses Gradle as a build tool. Some common Gradle commands you may want to run are
 ```shell
@@ -106,7 +106,7 @@ To run the integration test suite, run
 Adding `--stacktrace` can give you more debugging information, if needed.
 
 ### Logging
-By default, DrsHub will emit logs in the Stackdriver JSON format. 
+By default, DrsHub will emit logs in the Stackdriver JSON format.
 To disable this behavior for local development, add `DRSHUB_LOG_APPENDER=Console-Standard` to your environment when running DrsHub.
 
 ## Deployment

--- a/client-resttemplate/swagger.gradle
+++ b/client-resttemplate/swagger.gradle
@@ -1,6 +1,6 @@
 // All version controlled by dependency management plugin
 dependencies {
-	api 'org.springframework.boot:spring-boot-starter-json:+'
+	api 'org.springframework.boot:spring-boot-starter-json:2.7.6'
 
 	implementation 'io.swagger.core.v3:swagger-annotations'
 	swaggerCodegen 'io.swagger.codegen.v3:swagger-codegen-cli'

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -63,7 +63,7 @@ drshub:
       accessMethodConfigs:
         - type: gs
           auth: current_request
-          fetchAccessUrl: false
+          fetchAccessUrl: true
         - type: https
           auth: current_request
           fetchAccessUrl: true # Used for Azure

--- a/service/src/test/java/bio/terra/drshub/config/DrsProviderInterfaceTest.java
+++ b/service/src/test/java/bio/terra/drshub/config/DrsProviderInterfaceTest.java
@@ -64,13 +64,13 @@ class DrsProviderInterfaceTest extends BaseTest {
     var passportProviderHost = getProviderHosts("passportRequestFallback");
     var passportTestUri = String.format("drs://%s/12345", passportProviderHost.drsUriHost());
     var passportUriComponent = drsProviderService.getUriComponents(passportTestUri);
-    DrsProvider passportDrsPorvider = drsProviderService.determineDrsProvider(passportUriComponent);
+    DrsProvider passportDrsProvider = drsProviderService.determineDrsProvider(passportUriComponent);
 
     assertFalse(
-        passportDrsPorvider.shouldFetchAccessUrl(
+        passportDrsProvider.shouldFetchAccessUrl(
             AccessMethod.TypeEnum.GS, Fields.ACCESS_ID_FIELDS, false));
     assertFalse(
-        passportDrsPorvider.shouldFetchAccessUrl(
+        passportDrsProvider.shouldFetchAccessUrl(
             AccessMethod.TypeEnum.S3, Fields.ACCESS_ID_FIELDS, false));
 
     var fenceProviderHost = getProviderHosts("fenceTokenOnly");


### PR DESCRIPTION
Signed URLs are already turned on for Azure workspaces, but now that TDR is capable of serving signed URLs for data in Google requester pays buckets, we can enable it for Google as well. This one line change just flips the switch on that.

I also corrected a typo in one of the tests while I was in there. 

The Martha PR required test updates but this PR does not, as testing returning signed URLS is not linked to specific data hosts in DRSHub tests so the code path is already being exercised. 

Parallel PR for Martha here (merged): https://github.com/broadinstitute/martha/pull/264