### PR TITLE
[ID-487] add new compact identifier for AnVIL

### DIFF
--- a/service/src/main/java/bio/terra/drshub/services/DrsProviderService.java
+++ b/service/src/main/java/bio/terra/drshub/services/DrsProviderService.java
@@ -16,7 +16,8 @@ import org.springframework.web.util.UriComponentsBuilder;
 public record DrsProviderService(DrsHubConfig drsHubConfig) {
 
   private static final Pattern compactIdRegex =
-      Pattern.compile("(?:dos|drs)://(?<compactId>dg\\.[0-9a-z-]+)", Pattern.CASE_INSENSITIVE);
+      Pattern.compile(
+          "(?:dos|drs)://(?<compactId>(dg|drs)\\.[0-9a-z-]+)", Pattern.CASE_INSENSITIVE);
 
   private static final Pattern hostNameRegex =
       Pattern.compile("(?:dos|drs)://(?<hostname>[^?/]+\\.[^?/]+)", Pattern.CASE_INSENSITIVE);
@@ -33,7 +34,8 @@ public record DrsProviderService(DrsHubConfig drsHubConfig) {
    * <p>Note: GA4GH Compact Identifier based URIs are incompatible with W3C/IETF URIs and the
    * various standard libraries that parse them because they use colons as a delimiter. However,
    * there are some Compact Identifier based URIs that use slashes as a delimiter. This code assumes
-   * that if the host part of the URI is of the form dg.[0-9a-z-]+ then it is a Compact Identifier.
+   * that if the host part of the URI is of the form dg.[0-9a-z-]+ or drs.[0-9a-z-]+ then it is a
+   * Compact Identifier.
    *
    * <p>If you update *any* of the below be sure to link to the supporting docs and update the
    * comments above!

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -10,6 +10,7 @@ drshub:
     "dg.4503": gen3.biodatacatalyst.nhlbi.nih.gov
     "dg.712c": staging.gen3.biodatacatalyst.nhlbi.nih.gov
     "dg.anv0": staging.theanvil.io
+    "drs.anv0": staging.data.terra.bio
     "dg.4dfc": nci-crdc-staging.datacommons.io
     "dg.f82a1a": gen3staging.kidsfirstdrc.org
     "dg.test0": ctds-test-env.planx-pla.net
@@ -54,7 +55,6 @@ drshub:
         - type: s3
           auth: fence_token
           fetchAccessUrl: true
-
     terraDataRepo:
       name: Terra Data Repo (TDR)
       hostRegex: '.*data.*[-.](?:broadinstitute\.org|terra\.bio)'
@@ -108,6 +108,7 @@ drshub:
     "dg.4503": gen3.biodatacatalyst.nhlbi.nih.gov
     "dg.712c": staging.gen3.biodatacatalyst.nhlbi.nih.gov
     "dg.anv0": gen3.theanvil.io
+    "drs.anv0": data.terra.bio
     "dg.4dfc": nci-crdc.datacommons.io
     "dg.f82a1a": data.kidsfirstdrc.org
 ---

--- a/service/src/test/resources/application-test.yaml
+++ b/service/src/test/resources/application-test.yaml
@@ -11,6 +11,7 @@ drshub:
     "dg.4503": gen3.biodatacatalyst.nhlbi.nih.gov
     "dg.712c": staging.gen3.biodatacatalyst.nhlbi.nih.gov
     "dg.anv0": staging.theanvil.io
+    "drs.anv0": staging.data.terra.bio
     "dg.4dfc": nci-crdc-staging.datacommons.io
     "dg.f82a1a": gen3staging.kidsfirstdrc.org
     "dg.test0": ctds-test-env.planx-pla.net
@@ -108,7 +109,7 @@ drshub:
           auth: passport
           fetchAccessUrl: false
           fallbackAuth: current_request
-          
+
     passportFenceFallback:
       name: Passport With Bearer Fallback
       hostRegex: '.*\.passport-fence-fallback\.test'


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/ID-487

This is to add support for the new AnVIL compact identifier (CIB) for DRS resolution drs.anv0 for data hosted in TDR. 

For background on the new CIB see this doc: https://docs.google.com/document/d/1aKlgpmgiK66Y_QV5Tj2LJugJkzSa0EXrubFUg3TGhhs/edit#heading=h.4fw3nl9lcepm

(parallel PR in Martha is here https://github.com/broadinstitute/martha/pull/275) 