### PR TITLE
[ID-374] fix case insensitive matching for compact IDs 

### DIFF
--- a/service/src/main/java/bio/terra/drshub/services/DrsProviderService.java
+++ b/service/src/main/java/bio/terra/drshub/services/DrsProviderService.java
@@ -61,15 +61,17 @@ public record DrsProviderService(DrsHubConfig drsHubConfig) {
   public UriComponents getUriComponents(String drsUri) {
     UriComponents uriComponents;
 
-    var compactIdMatch = compactIdRegex.matcher(drsUri);
-    var hostNameMatch = hostNameRegex.matcher(drsUri);
+    // explicitly lowercase the string because the built-in case-insensitive regex matching is unreliable
+    var drsUriLowerCase = drsUri.toLowerCase();
+    var compactIdMatch = compactIdRegex.matcher(drsUriLowerCase);
+    var hostNameMatch = hostNameRegex.matcher(drsUriLowerCase);
 
     if (compactIdMatch.find(0)) {
       uriComponents = getCompactIdUriComponents(compactIdMatch);
     } else if (hostNameMatch.find(0)) {
       uriComponents = getHostnameUriComponents(hostNameMatch);
     } else {
-      throw new BadRequestException(String.format("[%s] is not a valid DRS URI.", drsUri));
+      throw new BadRequestException(String.format("[%s] is not a valid DRS URI.", drsUriLowerCase));
     }
 
     // Validate url

--- a/service/src/main/java/bio/terra/drshub/services/DrsProviderService.java
+++ b/service/src/main/java/bio/terra/drshub/services/DrsProviderService.java
@@ -90,7 +90,7 @@ public record DrsProviderService(DrsHubConfig drsHubConfig) {
   // TODO ID-565: If ID is compact we need to url encode any slashes
   private UriComponents getCompactIdUriComponents(Matcher compactIdMatch) {
 
-    // lowercase the compact ID because the case-insensitive regex flag is not working correctly
+    // lowercase the compact ID to match the accepted IDs stored in the config
     var matchedPrefixGroup = compactIdMatch.group(COMPACT_ID_PREFIX_GROUP).toLowerCase();
     var host = Optional.ofNullable(drsHubConfig.getCompactIdHosts().get(matchedPrefixGroup));
     if (host.isEmpty()) {

--- a/service/src/main/java/bio/terra/drshub/services/DrsProviderService.java
+++ b/service/src/main/java/bio/terra/drshub/services/DrsProviderService.java
@@ -61,7 +61,7 @@ public record DrsProviderService(DrsHubConfig drsHubConfig) {
   public UriComponents getUriComponents(String drsUri) {
     UriComponents uriComponents;
 
-    // explicitly lowercase the string because the built-in case-insensitive regex matching is unreliable
+    // explicitly lowercase the uri because the case-insensitive regex flag is not working correctly
     var drsUriLowerCase = drsUri.toLowerCase();
     var compactIdMatch = compactIdRegex.matcher(drsUriLowerCase);
     var hostNameMatch = hostNameRegex.matcher(drsUriLowerCase);

--- a/service/src/test/java/bio/terra/drshub/services/DrsProviderServiceTest.java
+++ b/service/src/test/java/bio/terra/drshub/services/DrsProviderServiceTest.java
@@ -57,19 +57,32 @@ class DrsProviderServiceTest extends BaseTest {
   }
 
   @Test
+  void testHostnameMatchingIsCaseInsensitive() {
+    var expectedUrl =
+        "drs://jade.datarepo-dev.broadinstitute.org/v1_e2151834-13cd-4156-9ea2-168a1b7abf60_0761203d-d2a1-448e-8f71-9f81d80ddd9d";
+
+    var compactUrl =
+        "DRS://DRS.AnV0:v1_e2151834-13cd-4156-9ea2-168a1b7abf60_0761203d-d2a1-448e-8f71-9f81d80ddd9d";
+
+    assertEquals(expectedUrl, drsProviderService.getUriComponents(compactUrl).toUriString());
+  }
+
+  @Test
   void testCompactIdentifierGetUriComponents() {
-    var oldExpectedUrl =
+    var oldCidExpectedUrl =
         "drs://staging.theanvil.io/v1_e2151834-13cd-4156-9ea2-168a1b7abf60_0761203d-d2a1-448e-8f71-9f81d80ddd9d";
-    var newExpectedUrl =
+    var newCidExpectedUrl =
         "drs://jade.datarepo-dev.broadinstitute.org/v1_e2151834-13cd-4156-9ea2-168a1b7abf60_0761203d-d2a1-448e-8f71-9f81d80ddd9d";
 
     var newCompactUrl =
         "drs://drs.anv0:v1_e2151834-13cd-4156-9ea2-168a1b7abf60_0761203d-d2a1-448e-8f71-9f81d80ddd9d";
     var oldCompactUrl =
         "drs://dg.anv0:v1_e2151834-13cd-4156-9ea2-168a1b7abf60_0761203d-d2a1-448e-8f71-9f81d80ddd9d";
-    assertEquals(oldExpectedUrl, drsProviderService.getUriComponents(oldCompactUrl).toUriString());
+    assertEquals(
+        oldCidExpectedUrl, drsProviderService.getUriComponents(oldCompactUrl).toUriString());
 
-    assertEquals(newExpectedUrl, drsProviderService.getUriComponents(newCompactUrl).toUriString());
+    assertEquals(
+        newCidExpectedUrl, drsProviderService.getUriComponents(newCompactUrl).toUriString());
   }
 
   @ParameterizedTest

--- a/service/src/test/java/bio/terra/drshub/services/DrsProviderServiceTest.java
+++ b/service/src/test/java/bio/terra/drshub/services/DrsProviderServiceTest.java
@@ -62,7 +62,7 @@ class DrsProviderServiceTest extends BaseTest {
         "drs://jade.datarepo-dev.broadinstitute.org/v1_e2151834-13cd-4156-9ea2-168a1b7abf60_0761203d-d2a1-448e-8f71-9f81d80ddd9d";
 
     var compactUrl =
-        "DRS://DRS.AnV0:v1_e2151834-13cd-4156-9ea2-168a1b7abf60_0761203d-d2a1-448e-8f71-9f81d80ddd9d";
+        "drs://drs.ANV0:v1_e2151834-13cd-4156-9ea2-168a1b7abf60_0761203d-d2a1-448e-8f71-9f81d80ddd9d";
 
     assertEquals(expectedUrl, drsProviderService.getUriComponents(compactUrl).toUriString());
   }


### PR DESCRIPTION
This fixes a bug where the regex case insensitivity was not working correctly when matching DRS URI compact IDs, (for example dg.ANV0 would not match to dg.anv0). 

The regex patterns do have the `CASE_INSENSITIVE` flag already, however this did not seem to be behaving as expected. I suspect it may be something to do with the named capture groups. I wasn't able to make it work as is, so instead I am explicitly converting the URI string to lowercase before matching. 

Edited to add: realized that the problem was not the regex itself, it was the match to config values, which are all lowercase. So I do think that explicitly casting the compact ID to lowercase is the correct solution here. 