### PR TITLE
Update configs for lower envs

### DIFF
--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -5,15 +5,6 @@ drshub:
   samUrl: https://sam.dsde-${deploy_env}.broadinstitute.org
   externalcredsUrl: https://externalcreds.dsde-${deploy_env}.broadinstitute.org
 
-  compactIdHosts:
-    # it is important for case-insensitive matching that the keys here are all lower case
-    # these are the CIBs we want in all environments, env specific ones are below
-    "dg.anv0": staging.theanvil.io
-    "drs.anv0": jade.datarepo-dev.broadinstitute.org
-    "dg.4dfc": nci-crdc-staging.datacommons.io
-    "dg.f82a1a": gen3staging.kidsfirstdrc.org
-    "dg.test0": ctds-test-env.planx-pla.net
-
   drsProviders:
     anvil:
       name: NHGRI Analysis Visualization and Informatics Lab-space (The AnVIL)
@@ -129,6 +120,7 @@ drshub:
     "dg.anv0": staging.theanvil.io # this is the old anvil CIB, the new one (drs.anv0) is set explicitly for each env
     "dg.4dfc": nci-crdc-staging.datacommons.io
     "dg.f82a1a": gen3staging.kidsfirstdrc.org
+    "dg.test0": ctds-test-env.planx-pla.net
 ---
 # prod
 spring.config.activate.on-profile: prod

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -102,16 +102,9 @@ terra.common:
     samplingRate: ${SAMPLING_PROBABILITY:0}
 
 ---
-spring.config.activate.on-profile: prod
-drshub:
-  compactIdHosts:
-    "dg.4503": gen3.biodatacatalyst.nhlbi.nih.gov
-    "dg.712c": staging.gen3.biodatacatalyst.nhlbi.nih.gov
-    "dg.anv0": gen3.theanvil.io
-    "drs.anv0": data.terra.bio
-    "dg.4dfc": nci-crdc.datacommons.io
-    "dg.f82a1a": data.kidsfirstdrc.org
----
+# not-prod
+# we want this test passport provider in all non-prod envs
+# TDR is the only host that has specific values for each lower env
 spring.config.activate.on-profile: '!prod'
 drshub:
   drsProviders:
@@ -132,4 +125,42 @@ drshub:
       mTlsConfig:
         keyPath: rendered/ras-mtls-client.key
         certPath: rendered/ras-mtls-client.crt
+  compactIdHosts:
+    "dg.4503": staging.gen3.biodatacatalyst.nhlbi.nih.gov
+    "dg.712c": staging.gen3.biodatacatalyst.nhlbi.nih.gov
+    "dg.anv0": staging.theanvil.io # this is the old anvil CIB, the new one (drs.anv0) is set explicitly for each env
+    "dg.4dfc": nci-crdc-staging.datacommons.io
+    "dg.f82a1a": gen3staging.kidsfirstdrc.org
+---
+# prod configs
+spring.config.activate.on-profile: prod
+drshub:
+  compactIdHosts:
+    "dg.4503": gen3.biodatacatalyst.nhlbi.nih.gov # biodatacatalyst
+    # this compact ID intentionally maps to the BDC staging url in prod
+    "dg.712c": staging.gen3.biodatacatalyst.nhlbi.nih.gov # biodatacatalyst
+    "dg.anv0": gen3.theanvil.io # old anvil
+    "drs.anv0": data.terra.bio # new anvil (hosted on TDR)
+    "dg.4dfc": nci-crdc.datacommons.io # cancer research data commons
+    "dg.f82a1a": data.kidsfirstdrc.org # kidsfirst
+---
+# dev
+spring.config.activate.on-profile: dev
+drshub:
+  compactIdHosts:
+    "drs.anv0": jade.datarepo-dev.broadinstitute.org
+---
+# staging
+spring.config.activate.on-profile: staging
+drshub:
+  compactIdHosts:
+    "drs.anv0": data.staging.envs-terra.bio
+---
+# alpha
+spring.config.activate.on-profile: alpha
+drshub:
+  compactIdHosts:
+    "drs.anv0": data.alpha.envs-terra.bio
+
+
 

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -7,7 +7,7 @@ drshub:
 
   compactIdHosts:
     # it is important for case-insensitive matching that the keys here are all lower case
-    "dg.712c": staging.gen3.biodatacatalyst.nhlbi.nih.gov
+    # these are the CIBs we want in all environments, env specific ones are below
     "dg.anv0": staging.theanvil.io
     "drs.anv0": jade.datarepo-dev.broadinstitute.org
     "dg.4dfc": nci-crdc-staging.datacommons.io

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -132,7 +132,7 @@ drshub:
     "dg.4dfc": nci-crdc-staging.datacommons.io
     "dg.f82a1a": gen3staging.kidsfirstdrc.org
 ---
-# prod configs
+# prod
 spring.config.activate.on-profile: prod
 drshub:
   compactIdHosts:

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -7,7 +7,6 @@ drshub:
 
   compactIdHosts:
     # it is important for case-insensitive matching that the keys here are all lower case
-    "dg.4503": gen3.biodatacatalyst.nhlbi.nih.gov
     "dg.712c": staging.gen3.biodatacatalyst.nhlbi.nih.gov
     "dg.anv0": staging.theanvil.io
     "drs.anv0": jade.datarepo-dev.broadinstitute.org
@@ -126,7 +125,6 @@ drshub:
         keyPath: rendered/ras-mtls-client.key
         certPath: rendered/ras-mtls-client.crt
   compactIdHosts:
-    "dg.4503": staging.gen3.biodatacatalyst.nhlbi.nih.gov
     "dg.712c": staging.gen3.biodatacatalyst.nhlbi.nih.gov
     "dg.anv0": staging.theanvil.io # this is the old anvil CIB, the new one (drs.anv0) is set explicitly for each env
     "dg.4dfc": nci-crdc-staging.datacommons.io
@@ -137,8 +135,6 @@ spring.config.activate.on-profile: prod
 drshub:
   compactIdHosts:
     "dg.4503": gen3.biodatacatalyst.nhlbi.nih.gov # biodatacatalyst
-    # this compact ID intentionally maps to the BDC staging url in prod
-    "dg.712c": staging.gen3.biodatacatalyst.nhlbi.nih.gov # biodatacatalyst
     "dg.anv0": gen3.theanvil.io # old anvil
     "drs.anv0": data.terra.bio # new anvil (hosted on TDR)
     "dg.4dfc": nci-crdc.datacommons.io # cancer research data commons


### PR DESCRIPTION
ticket: https://broadworkbench.atlassian.net/browse/ID-546

This adds DRSHub config blocks to specify host URIs in specific lower environments (specifically alpha and staging). The configs should match the configs in Martha in functionality, although they are organized differently. It should map to the Martha configs (found [here](https://github.com/broadinstitute/martha/blob/dev/common/config.js)). 

The main change in this PR is to explicitly set the TDR URI (expanded from the new anvil CIB which is drs.anv0) to different values in dev, staging, and alpha. 

I went back and forth a bit on the best way to structure the config blocks, I think I landed on something that makes sense, but if this doesn't look right please let me know. 