### PR TITLE
[ID-543] update deprecated github action commands

### DIFF
--- a/.github/workflows/publish-branch-image.yml
+++ b/.github/workflows/publish-branch-image.yml
@@ -10,17 +10,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Parse tag
         id: tag
-        run: echo ::set-output name=tag::$(git branch --show-current)
+        run: echo tag=$(git branch --show-current) >> $GITHUB_OUTPUT
       - name: Set up JDK 17
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: '17'
           distribution: 'temurin'
       - name: Cache Gradle packages
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.gradle/caches
@@ -43,7 +43,7 @@ jobs:
         run: gcloud auth configure-docker --quiet
       - name: Construct docker image name and tag
         id: image-name
-        run: echo ::set-output name=name::gcr.io/${GOOGLE_PROJECT}/${SERVICE_NAME}:${{ steps.tag.outputs.tag }}
+        run: echo name=gcr.io/${GOOGLE_PROJECT}/${SERVICE_NAME}:${{ steps.tag.outputs.tag }} >> $GITHUB_OUTPUT
       - name: Build image locally with jib
         run: './gradlew :service:jibDockerBuild --image=${{ steps.image-name.outputs.name }} -Djib.console=plain'
       - name: Push GCR image

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,15 +10,15 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up JDK 17
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: '17'
           distribution: 'temurin'
 
       - name: Cache Gradle packages
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.gradle/caches
@@ -27,7 +27,7 @@ jobs:
 
       - name: Parse tag
         id: tag
-        run: echo ::set-output name=tag::$(git describe --tags)
+        run: echo tag=$(git describe --tags) >> $GITHUB_OUTPUT
 
       #    - name: "Publish to Artifactory"
       #      run: ./gradlew --build-cache :client:artifactoryPublish
@@ -45,7 +45,7 @@ jobs:
 
       - name: Construct docker image name and tag
         id: image-name
-        run: echo ::set-output name=name::gcr.io/${GOOGLE_PROJECT}/${SERVICE_NAME}:${{ steps.tag.outputs.tag }}
+        run: echo name=gcr.io/${GOOGLE_PROJECT}/${SERVICE_NAME}:${{ steps.tag.outputs.tag }} >> $GITHUB_OUTPUT
 
       - name: Add Google Cloud Profiler to Docker Image
         run: docker build ./service -t drshub:local

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -116,11 +116,11 @@ drshub:
         keyPath: rendered/ras-mtls-client.key
         certPath: rendered/ras-mtls-client.crt
   compactIdHosts:
-    "dg.712c": staging.gen3.biodatacatalyst.nhlbi.nih.gov
+    "dg.712c": staging.gen3.biodatacatalyst.nhlbi.nih.gov # biodatacatalyst staging
     "dg.anv0": staging.theanvil.io # this is the old anvil CIB, the new one (drs.anv0) is set explicitly for each env
-    "dg.4dfc": nci-crdc-staging.datacommons.io
-    "dg.f82a1a": gen3staging.kidsfirstdrc.org
-    "dg.test0": ctds-test-env.planx-pla.net
+    "dg.4dfc": nci-crdc-staging.datacommons.io # cancer research data commons
+    "dg.f82a1a": gen3staging.kidsfirstdrc.org # kidsfirst
+    "dg.test0": ctds-test-env.planx-pla.net # passport test
 ---
 # prod
 spring.config.activate.on-profile: prod


### PR DESCRIPTION
ticket: https://broadworkbench.atlassian.net/browse/ID-543

This updates gha to remove deprecated commands (save-state, set-output, @v2) 

Also realized I had comment changes left over from my config PR. Since they're only comments I threw 'em in here. 