### PR TITLE
ID-377 Fix response serialization.

### DIFF
--- a/service/src/main/java/bio/terra/drshub/models/AnnotatedResourceMetadata.java
+++ b/service/src/main/java/bio/terra/drshub/models/AnnotatedResourceMetadata.java
@@ -3,11 +3,13 @@ package bio.terra.drshub.models;
 import bio.terra.drshub.config.DrsProvider;
 import bio.terra.drshub.generated.model.ResourceMetadata;
 import java.util.List;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import lombok.Builder;
 import lombok.Getter;
 
 @Builder
 @Getter
+@JsonSerialize(using = AnnotatedResourceMetadataSerializer.class)
 public class AnnotatedResourceMetadata extends ResourceMetadata {
 
   private List<String> requestedFields;


### PR DESCRIPTION
When working on adding contract provider tests I found that the responses weren't being serialized in the way that I expected. Turns out that the `AnnotatedResourceMetadataSerializer` wasn't being used to serialize responses, which was causing weird behavior.

In the [api controller](https://github.com/DataBiosphere/terra-drs-hub/blob/021e90b999ae1ae189b3f3800f444809786d2d1e/service/src/main/java/bio/terra/drshub/controllers/DrsHubApiController.java#L46), `drsResolutionService.resolveDrsObject` returns a `AnnotatedResourceMetadata` object, which is then supposed to be processed into the json response via the serializer. Instead of being properly serialized, the response was just the raw `AnnotatedResourceMetadata` object converted to json. 