### PR TITLE
[DR-3078] Pass through the google project to bill when requesting a signed URL

### DIFF
--- a/service/src/main/java/bio/terra/drshub/controllers/DrsHubApiController.java
+++ b/service/src/main/java/bio/terra/drshub/controllers/DrsHubApiController.java
@@ -39,12 +39,13 @@ public class DrsHubApiController implements DrsHubApi {
     var userAgent = request.getHeader("user-agent");
     var forceAccessUrl = Objects.equals(request.getHeader("drshub-force-access-url"), "true");
     var ip = request.getHeader("X-Forwarded-For");
+    var googleProject = request.getHeader("x-user-project");
 
     log.info("Received URL {} from agent {} on IP {}", body.getUrl(), userAgent, ip);
 
     var resourceMetadata =
         drsResolutionService.resolveDrsObject(
-            body.getUrl(), body.getFields(), bearerToken, forceAccessUrl, ip);
+            body.getUrl(), body.getFields(), bearerToken, forceAccessUrl, ip, googleProject);
 
     return ResponseEntity.ok(resourceMetadata);
   }

--- a/service/src/main/java/bio/terra/drshub/models/DrsApi.java
+++ b/service/src/main/java/bio/terra/drshub/models/DrsApi.java
@@ -13,4 +13,8 @@ public class DrsApi extends ObjectsApi {
   public void setBearerToken(String bearerToken) {
     ((OAuth) this.getApiClient().getAuthentication("BearerAuth")).setAccessToken(bearerToken);
   }
+
+  public void setHeader(String name, String value) {
+    this.getApiClient().addDefaultHeader(name, value);
+  }
 }

--- a/service/src/main/java/bio/terra/drshub/services/SignedUrlService.java
+++ b/service/src/main/java/bio/terra/drshub/services/SignedUrlService.java
@@ -41,7 +41,9 @@ public record SignedUrlService(
 
     final BlobInfo blobInfo;
     if (bucket == null || objectName == null) {
-      blobInfo = BlobInfo.newBuilder(getBlobIdFromDrsUri(dataObjectUri, bearerToken, ip)).build();
+      blobInfo =
+          BlobInfo.newBuilder(getBlobIdFromDrsUri(dataObjectUri, bearerToken, ip, googleProject))
+              .build();
     } else {
       blobInfo = BlobInfo.newBuilder(BlobId.of(bucket, objectName)).build();
     }
@@ -61,10 +63,11 @@ public record SignedUrlService(
         blobInfo, duration.toMinutes(), TimeUnit.MINUTES, Storage.SignUrlOption.withV4Signature());
   }
 
-  private BlobId getBlobIdFromDrsUri(String dataObjectUri, BearerToken bearerToken, String ip) {
+  private BlobId getBlobIdFromDrsUri(
+      String dataObjectUri, BearerToken bearerToken, String ip, String googleProject) {
     var object =
         drsResolutionService.resolveDrsObject(
-            dataObjectUri, Fields.CORE_FIELDS, bearerToken, true, ip);
+            dataObjectUri, Fields.CORE_FIELDS, bearerToken, true, ip, googleProject);
     var gsUri = object.getGsUri();
     return BlobId.fromGsUtilUri(gsUri);
   }

--- a/service/src/test/java/bio/terra/drshub/controllers/GcsApiControllerTest.java
+++ b/service/src/test/java/bio/terra/drshub/controllers/GcsApiControllerTest.java
@@ -62,7 +62,7 @@ public class GcsApiControllerTest extends BaseTest {
 
     SignedUrlTestUtils.setupSignedUrlMocks(authService, googleStorageService, googleProject, url);
     SignedUrlTestUtils.setupDrsResolutionServiceMocks(
-        drsResolutionService, drsUri, bucketName, objectName);
+        drsResolutionService, drsUri, bucketName, objectName, googleProject);
 
     var response = getSignedUrlRequest(TEST_ACCESS_TOKEN, null, null, drsUri, googleProject);
     response.andExpect(content().string(url.toString()));
@@ -72,7 +72,8 @@ public class GcsApiControllerTest extends BaseTest {
             eq(Fields.CORE_FIELDS),
             eq(new BearerToken(TEST_ACCESS_TOKEN)),
             eq(true),
-            eq(null));
+            eq(null),
+            eq(googleProject));
   }
 
   private ResultActions getSignedUrlRequest(
@@ -87,14 +88,15 @@ public class GcsApiControllerTest extends BaseTest {
       body.putAll(Map.of("bucket", bucketName, "object", objectName));
     }
     var requestBody = objectMapper.writeValueAsString(body);
-    return getSignedUrlRequestRaw(accessToken, requestBody);
+    return getSignedUrlRequestRaw(accessToken, requestBody, googleProject);
   }
 
-  private ResultActions getSignedUrlRequestRaw(String accessToken, String requestBody)
+  private ResultActions getSignedUrlRequestRaw(String accessToken, String requestBody, String googleProject)
       throws Exception {
     return mvc.perform(
         post("/api/v4/gcs/getSignedUrl")
             .header("authorization", "bearer " + accessToken)
+            .header("x-user-project", googleProject)
             .contentType(MediaType.APPLICATION_JSON)
             .content(requestBody));
   }

--- a/service/src/test/java/bio/terra/drshub/services/SignedUrlServiceTest.java
+++ b/service/src/test/java/bio/terra/drshub/services/SignedUrlServiceTest.java
@@ -48,7 +48,7 @@ public class SignedUrlServiceTest extends BaseTest {
 
     SignedUrlTestUtils.setupSignedUrlMocks(authService, googleStorageService, googleProject, url);
     SignedUrlTestUtils.setupDrsResolutionServiceMocks(
-        drsResolutionService, drsUri, bucketName, objectName);
+        drsResolutionService, drsUri, bucketName, objectName, googleProject);
     var signedUrl =
         signedUrlService.getSignedUrl(
             null, null, drsUri, googleProject, new BearerToken("12345"), "127.0.0.1");

--- a/service/src/test/java/bio/terra/drshub/util/SignedUrlTestUtils.java
+++ b/service/src/test/java/bio/terra/drshub/util/SignedUrlTestUtils.java
@@ -68,14 +68,20 @@ public class SignedUrlTestUtils {
       DrsResolutionService drsResolutionService,
       String drsUri,
       String bucketName,
-      String objectName) {
+      String objectName,
+      String googleProject) {
     doReturn(
             AnnotatedResourceMetadata.builder()
                 .build()
                 .gsUri("gs://" + bucketName + "/" + objectName))
         .when(drsResolutionService)
         .resolveDrsObject(
-            eq(drsUri), any(List.class), any(BearerToken.class), eq(true), nullable(String.class));
+            eq(drsUri),
+            any(List.class),
+            any(BearerToken.class),
+            eq(true),
+            nullable(String.class),
+            nullable(String.class));
   }
 
   public static String generateSaKeyObjectString()


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DR-3078

The Data Repo [getAccessURL](https://data.terra.bio/swagger-ui.html#/DataRepositoryService/GetAccessURL) and [postAccessURL](https://data.terra.bio/swagger-ui.html#/DataRepositoryService/PostAccessURL) endpoints have a "x-user-project" header that specifies which GCP project to bill when accessing the signed URL. 

**Changes**:
This PR passes in the `googleProject` from the DrsHub [getSignedUrl](https://drshub.dsde-dev.broadinstitute.org/#/gcs/getSignedUrl) endpoint as the "x-user-project" header when getting the access URL.

The [resolveDrs](https://drshub.dsde-dev.broadinstitute.org/#/drsHub/resolveDrs) endpoint can also fetch the access URL if certain conditions are met, but the google project is not specified in the post body. Would it be passed in as a header?