### PR TITLE
ID-610 ID-667 Sam Signs Terra-Authed DRS Object Paths

### DIFF
--- a/integration/src/main/java/scripts/testscripts/GetSignedUrlSam.java
+++ b/integration/src/main/java/scripts/testscripts/GetSignedUrlSam.java
@@ -1,0 +1,31 @@
+package scripts.testscripts;
+
+import bio.terra.drshub.api.GcsApi;
+import bio.terra.drshub.model.GetSignedUrlRequest;
+import bio.terra.testrunner.runner.TestScript;
+import bio.terra.testrunner.runner.config.TestUserSpecification;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Assertions;
+import scripts.utils.ClientTestUtils;
+
+@Slf4j
+public class GetSignedUrlSam extends TestScript {
+  private static String TDR_TEST_DRS_URI =
+      "drs://jade.datarepo-dev.broadinstitute.org/v1_93dc1e76-8f1c-4949-8f9b-07a087f3ce7b_8b07563a-542f-4b5c-9e00-e8fe6b1861de";
+
+  @Override
+  public void userJourney(TestUserSpecification testUser) throws Exception {
+    var apiClient = ClientTestUtils.getClientWithTestUserAuth(testUser, server);
+    var gcsApi = new GcsApi(apiClient);
+
+    var request =
+        new GetSignedUrlRequest()
+            .bucket("broad-jade-dev-data-bucket")
+            .object("fd8d8492-ad02-447d-b54e-35a7ffd0e7a5/8b07563a-542f-4b5c-9e00-e8fe6b1861de")
+            .dataObjectUri(TDR_TEST_DRS_URI)
+            .googleProject("terra-dev-149e1673");
+
+    var signedUrl = gcsApi.getSignedUrl(request);
+    Assertions.assertTrue(signedUrl.contains("broad-jade-dev-data-bucket"));
+  }
+}

--- a/integration/src/main/resources/configs/integration/GetSignedUrlSam.json
+++ b/integration/src/main/resources/configs/integration/GetSignedUrlSam.json
@@ -1,0 +1,17 @@
+{
+  "name": "GetSignedUrlSam",
+  "description": "Get a Signed URL from Sam for a DRS Object in TDR",
+  "serverSpecificationFile": "drshub-local.json",
+  "kubernetes": {},
+  "application": {},
+  "testScripts": [
+    {
+      "name": "GetSignedUrlSam",
+      "numberOfUserJourneyThreadsToRun": 1,
+      "userJourneyThreadPoolSize": 2,
+      "expectedTimeForEach": 10,
+      "expectedTimeForEachUnit": "SECONDS"
+    }
+  ],
+  "testUserFiles": ["scarlett.json"]
+}

--- a/integration/src/main/resources/suites/FullIntegration.json
+++ b/integration/src/main/resources/suites/FullIntegration.json
@@ -5,7 +5,8 @@
   "testConfigurationFiles": [
     "integration/GetStatus.json",
     "integration/GetVersion.json",
-    "integration/ResolveTdrDrs.json"
+    "integration/ResolveTdrDrs.json",
+    "integration/GetSignedUrlSam.json"
   ]
 }
 

--- a/service/generators.gradle
+++ b/service/generators.gradle
@@ -35,6 +35,11 @@ swaggerSources {
 		inputFile = file('src/main/resources/vendor/bond.yaml')
 		code(makeClientCodeClosure('bio.terra.bond'))
 	}
+
+	sam {
+		inputFile = file('src/main/resources/vendor/sam.yaml')
+		code(makeClientCodeClosure('bio.terra.sam'))
+	}
 }
 
 def makeClientCodeClosure(String id) {
@@ -60,6 +65,7 @@ Set<String> swaggerSourcePaths = [
 		"${swaggerSources.server.code.outputDir}/src/main/java",
 		"${swaggerSources.ga4gh.code.outputDir}/src/main/java",
 		"${swaggerSources.bond.code.outputDir}/src/main/java",
+		"${swaggerSources.sam.code.outputDir}/src/main/java",
 ]
 
 

--- a/service/src/main/java/bio/terra/drshub/services/AuthService.java
+++ b/service/src/main/java/bio/terra/drshub/services/AuthService.java
@@ -261,6 +261,6 @@ public class AuthService {
             .bucketName(bucketName)
             .blobName(objectName)
             .requesterPays(false);
-    return samApi.signedUrlForBlob(requestBody, googleProject);
+    return samApi.signedUrlForBlob(requestBody, googleProject).replaceAll("^\"|\"$", "");
   }
 }

--- a/service/src/main/java/bio/terra/drshub/services/AuthService.java
+++ b/service/src/main/java/bio/terra/drshub/services/AuthService.java
@@ -261,6 +261,6 @@ public class AuthService {
             .bucketName(bucketName)
             .blobName(objectName)
             .requesterPays(false);
-    return samApi.signedUrlForBlob(requestBody, googleProject).replaceAll("^\"|\"$", "");
+    return samApi.signedUrlForBlob(requestBody, googleProject).replaceAll("(^\")|(\"$)", "");
   }
 }

--- a/service/src/main/java/bio/terra/drshub/services/AuthService.java
+++ b/service/src/main/java/bio/terra/drshub/services/AuthService.java
@@ -6,6 +6,7 @@ import bio.terra.drshub.DrsHubException;
 import bio.terra.drshub.config.DrsProvider;
 import bio.terra.drshub.models.AccessUrlAuthEnum;
 import bio.terra.drshub.models.DrsHubAuthorization;
+import bio.terra.sam.model.ProjectSignedUrlForBlobBody;
 import com.google.common.annotations.VisibleForTesting;
 import io.github.ga4gh.drs.model.AccessMethod;
 import io.github.ga4gh.drs.model.Authorizations;
@@ -29,6 +30,7 @@ public class AuthService {
 
   private final BondApiFactory bondApiFactory;
   private final DrsApiFactory drsApiFactory;
+  private final SamApiFactory samApiFactory;
   private final ExternalCredsApiFactory externalCredsApiFactory;
 
   // To avoid absolutely hammering the ECM API during large batch analyses,
@@ -41,9 +43,11 @@ public class AuthService {
   public AuthService(
       BondApiFactory bondApiFactory,
       DrsApiFactory drsApiFactory,
+      SamApiFactory samApiFactory,
       ExternalCredsApiFactory externalCredsApiFactory) {
     this.bondApiFactory = bondApiFactory;
     this.drsApiFactory = drsApiFactory;
+    this.samApiFactory = samApiFactory;
     this.externalCredsApiFactory = externalCredsApiFactory;
   }
 
@@ -247,5 +251,16 @@ public class AuthService {
             }
           }
         });
+  }
+
+  public String getSignedUrlForBlob(
+      BearerToken bearerToken, String googleProject, String bucketName, String objectName) {
+    var samApi = samApiFactory.getApi(bearerToken);
+    var requestBody =
+        new ProjectSignedUrlForBlobBody()
+            .bucketName(bucketName)
+            .blobName(objectName)
+            .requesterPays(false);
+    return samApi.signedUrlForBlob(requestBody, googleProject);
   }
 }

--- a/service/src/main/java/bio/terra/drshub/services/SamApiFactory.java
+++ b/service/src/main/java/bio/terra/drshub/services/SamApiFactory.java
@@ -1,0 +1,18 @@
+package bio.terra.drshub.services;
+
+import bio.terra.common.iam.BearerToken;
+import bio.terra.drshub.config.DrsHubConfig;
+import bio.terra.sam.api.SamApi;
+import org.springframework.stereotype.Service;
+
+@Service
+public record SamApiFactory(DrsHubConfig drsHubConfig) {
+
+  public SamApi getApi(BearerToken bearerToken) {
+    var samApi = new SamApi();
+    samApi.getApiClient().setBasePath(drsHubConfig.getSamUrl());
+    samApi.getApiClient().setAccessToken(bearerToken.getToken());
+
+    return samApi;
+  }
+}

--- a/service/src/main/java/bio/terra/drshub/services/SignedUrlService.java
+++ b/service/src/main/java/bio/terra/drshub/services/SignedUrlService.java
@@ -2,14 +2,19 @@ package bio.terra.drshub.services;
 
 import bio.terra.bond.model.SaKeyObject;
 import bio.terra.common.iam.BearerToken;
+import bio.terra.drshub.DrsHubException;
 import bio.terra.drshub.config.DrsHubConfig;
+import bio.terra.drshub.config.DrsProvider;
 import bio.terra.drshub.logging.AuditLogEvent;
 import bio.terra.drshub.logging.AuditLogEventType;
 import bio.terra.drshub.logging.AuditLogger;
+import bio.terra.drshub.models.AccessUrlAuthEnum;
 import bio.terra.drshub.models.Fields;
 import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.Storage;
+import io.github.ga4gh.drs.model.AccessMethod;
+import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
@@ -36,6 +41,43 @@ public record SignedUrlService(
 
     var components = drsProviderService.getUriComponents(dataObjectUri);
     var drsProvider = drsProviderService.determineDrsProvider(components);
+
+    var logEvent =
+        new AuditLogEvent.Builder()
+            .dRSUrl(dataObjectUri)
+            .providerName(drsProvider.getName())
+            .auditLogEventType(AuditLogEventType.GetSignedUrl)
+            .clientIP(Optional.ofNullable(ip))
+            .build();
+    auditLogger.logEvent(logEvent);
+
+    if (drsProvider.getAccessMethodByType(AccessMethod.TypeEnum.GS).getAuth()
+        == AccessUrlAuthEnum.current_request) {
+      return getSignedUrlFromSam(bearerToken, googleProject, bucket, objectName);
+    } else {
+      return getSignedUrlFromDrsProvider(
+          bearerToken, drsProvider, googleProject, bucket, objectName, dataObjectUri, ip);
+    }
+  }
+
+  private URL getSignedUrlFromSam(
+      BearerToken bearerToken, String googleProject, String bucketName, String blobName) {
+    try {
+      return new URL(
+          authService.getSignedUrlForBlob(bearerToken, googleProject, bucketName, blobName));
+    } catch (MalformedURLException ex) {
+      throw new DrsHubException("Could not parse signed URL from Sam", ex);
+    }
+  }
+
+  private URL getSignedUrlFromDrsProvider(
+      BearerToken bearerToken,
+      DrsProvider drsProvider,
+      String googleProject,
+      String bucket,
+      String objectName,
+      String dataObjectUri,
+      String ip) {
     SaKeyObject saKey = authService.fetchUserServiceAccount(drsProvider, bearerToken);
     Storage storage = googleStorageService.getAuthedStorage(saKey, googleProject);
 
@@ -47,15 +89,6 @@ public record SignedUrlService(
     }
 
     var duration = drsHubConfig.getSignedUrlDuration();
-
-    var logEvent =
-        new AuditLogEvent.Builder()
-            .dRSUrl(dataObjectUri)
-            .providerName(drsProvider.getName())
-            .auditLogEventType(AuditLogEventType.GetSignedUrl)
-            .clientIP(Optional.ofNullable(ip))
-            .build();
-    auditLogger.logEvent(logEvent);
 
     return storage.signUrl(
         blobInfo, duration.toMinutes(), TimeUnit.MINUTES, Storage.SignUrlOption.withV4Signature());

--- a/service/src/main/resources/vendor/sam.yaml
+++ b/service/src/main/resources/vendor/sam.yaml
@@ -89,3 +89,22 @@ components:
                 type: boolean
                 description: Use the pet service account project as the user project in the request.
                 default: true
+  securitySchemes:
+    authorization:
+      type: oauth2
+      flows:
+        implicit:
+          authorizationUrl: https://accounts.google.com/o/oauth2/auth
+          scopes:
+            openid: open id authorization
+            email: email authorization
+            profile: profile authorization
+    googleAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: GCloud access token
+      description: Use your GCP auth token, i.e. `gcloud auth print-access-token`
+
+security:
+  - authorization: [ openid, email, profile ]
+  - googleAuth: [ ]

--- a/service/src/main/resources/vendor/sam.yaml
+++ b/service/src/main/resources/vendor/sam.yaml
@@ -1,0 +1,91 @@
+openapi: 3.0.3
+info:
+  title: Sam API
+  description: Service for IAM management in Terra
+  version: "1.0"
+
+servers:
+  - url: /
+    # '/' is a relative path to this host.
+    description: The server hosting this Swagger UI
+  - url: https://sam.dsde-staging.broadinstitute.org/
+    description: Production
+  - url: https://sam.dsde-staging.broadinstitute.org/
+    description: Staging
+  - url: https://sam.dsde-alpha.broadinstitute.org/
+    description: Alpha
+  - url: https://sam.dsde-dev.broadinstitute.org/
+    description: Development
+
+paths:
+  /api/google/v1/user/petServiceAccount/{project}/signedUrlForBlob:
+    post:
+      summary: gets a signed url for a blob using the pet service account for the user in the provided project
+      tags: [ sam ]
+      operationId: signedUrlForBlob
+      parameters:
+        - name: project
+          in: path
+          required: true
+          description: The Google Project to get the Pet Service Account from for URL signing.
+          schema:
+            type: string
+            example: terra-abcd1234
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - bucketName
+                - blobName
+              properties:
+                bucketName:
+                  type: string
+                  description: bucket of the blob
+                blobName:
+                  type: string
+                  description: path to the blob in the bucket
+                duration:
+                  type: number
+                  description: Optional validity duration of the link in minutes. Defaults to 1 hour.
+                  default: 60
+                requesterPays:
+                  type: boolean
+                  description: Use the pet service account project as the user project in the request.
+                  default: true
+      responses:
+        200:
+          description: signed URL for the blob, signed by the Pet Service Account key
+          content:
+            application/json:
+              schema:
+                type: string
+
+components:
+  requestBodies:
+    SignedUrlRequest:
+      required: true
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - bucketName
+              - blobName
+            properties:
+              bucketName:
+                type: string
+                description: bucket of the blob
+              blobName:
+                type: string
+                description: path to the blob in the bucket
+              duration:
+                type: number
+                description: Optional validity duration of the link in minutes. Defaults to 1 hour.
+                default: 60
+              requesterPays:
+                type: boolean
+                description: Use the pet service account project as the user project in the request.
+                default: true

--- a/service/src/test/java/bio/terra/drshub/controllers/GcsApiControllerTest.java
+++ b/service/src/test/java/bio/terra/drshub/controllers/GcsApiControllerTest.java
@@ -39,7 +39,7 @@ public class GcsApiControllerTest extends BaseTest {
 
   @Test
   void testSignsUrls() throws Exception {
-    var drsUri = "drs://drs.anv0:1234/456/2315asd";
+    var drsUri = "drs://dg.4503:1234/456/2315asd";
     var bucketName = "my-test-bucket";
     var objectName = "my-test-folder/my-test-object.txt";
     var googleProject = "test-google-project";
@@ -54,7 +54,7 @@ public class GcsApiControllerTest extends BaseTest {
 
   @Test
   void testSignsUrlsDrsUriOnly() throws Exception {
-    var drsUri = "drs://drs.anv0:1234/456/2315asd";
+    var drsUri = "drs://dg.4503:1234/456/2315asd";
     var bucketName = "my-test-bucket";
     var objectName = "my-test-folder/my-test-object.txt";
     var googleProject = "test-google-project";

--- a/service/src/test/java/bio/terra/drshub/services/SamApiFactoryTest.java
+++ b/service/src/test/java/bio/terra/drshub/services/SamApiFactoryTest.java
@@ -1,0 +1,24 @@
+package bio.terra.drshub.services;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import bio.terra.common.iam.BearerToken;
+import bio.terra.drshub.BaseTest;
+import bio.terra.sam.client.auth.OAuth;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@Tag("Unit")
+public class SamApiFactoryTest extends BaseTest {
+
+  @Autowired private SamApiFactory samApiFactory;
+
+  @Test
+  void testApiFactory() {
+    var token = "12345";
+    var api = samApiFactory.getApi(new BearerToken(token));
+    OAuth auth = (OAuth) api.getApiClient().getAuthentication("authorization");
+    assertEquals(token, auth.getAccessToken());
+  }
+}

--- a/service/src/test/java/bio/terra/drshub/services/SignedUrlServiceTest.java
+++ b/service/src/test/java/bio/terra/drshub/services/SignedUrlServiceTest.java
@@ -38,6 +38,24 @@ public class SignedUrlServiceTest extends BaseTest {
   }
 
   @Test
+  void testGetSignedUrlFromSam() throws MalformedURLException {
+
+    var drsUri = "drs://drs.anv0:1234/456/2315asd";
+    var bucketName = "my-test-bucket";
+    var objectName = "my-test-folder/my-test-object.txt";
+    var googleProject = "test-google-project";
+    var url = new URL("https", "storage.cloud.google.com", "/" + bucketName + "/" + objectName);
+
+    SignedUrlTestUtils.setupSignedUrlMocksForSam(
+        authService, googleProject, bucketName, objectName, url);
+
+    var signedUrl =
+        signedUrlService.getSignedUrl(
+            bucketName, objectName, drsUri, googleProject, new BearerToken("12345"), "127.0.0.1");
+    assertEquals(url, signedUrl);
+  }
+
+  @Test
   void testGetSignedUrlDataObjectUriOnly() throws Exception {
 
     var drsUri = "drs://dg.4503:1234/456/2315asd";

--- a/service/src/test/java/bio/terra/drshub/services/SignedUrlServiceTest.java
+++ b/service/src/test/java/bio/terra/drshub/services/SignedUrlServiceTest.java
@@ -23,7 +23,7 @@ public class SignedUrlServiceTest extends BaseTest {
   @Test
   void testGetSignedUrl() throws MalformedURLException {
 
-    var drsUri = "drs://drs.anv0:1234/456/2315asd";
+    var drsUri = "drs://dg.4503:1234/456/2315asd";
     var bucketName = "my-test-bucket";
     var objectName = "my-test-folder/my-test-object.txt";
     var googleProject = "test-google-project";
@@ -40,7 +40,7 @@ public class SignedUrlServiceTest extends BaseTest {
   @Test
   void testGetSignedUrlDataObjectUriOnly() throws Exception {
 
-    var drsUri = "drs://drs.anv0:1234/456/2315asd";
+    var drsUri = "drs://dg.4503:1234/456/2315asd";
     var bucketName = "my-test-bucket";
     var objectName = "my-test-folder/my-test-object.txt";
     var googleProject = "test-google-project";

--- a/service/src/test/java/bio/terra/drshub/services/SignedUrlServiceTest.java
+++ b/service/src/test/java/bio/terra/drshub/services/SignedUrlServiceTest.java
@@ -1,9 +1,13 @@
 package bio.terra.drshub.services;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 
 import bio.terra.common.iam.BearerToken;
 import bio.terra.drshub.BaseTest;
+import bio.terra.drshub.DrsHubException;
 import bio.terra.drshub.util.SignedUrlTestUtils;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -71,5 +75,28 @@ public class SignedUrlServiceTest extends BaseTest {
         signedUrlService.getSignedUrl(
             null, null, drsUri, googleProject, new BearerToken("12345"), "127.0.0.1");
     assertEquals(url, signedUrl);
+  }
+
+  @Test
+  void testFailsToParseInvalidURLsFromSam() {
+
+    when(authService.getSignedUrlForBlob(
+            any(BearerToken.class), any(String.class), any(String.class), any(String.class)))
+        .thenReturn("not_a_valid_url");
+
+    var drsUri = "drs://drs.anv0:1234/456/2315asd";
+    var bucketName = "my-test-bucket";
+    var objectName = "my-test-folder/my-test-object.txt";
+    var googleProject = "test-google-project";
+    assertThrows(
+        DrsHubException.class,
+        () ->
+            signedUrlService.getSignedUrl(
+                bucketName,
+                objectName,
+                drsUri,
+                googleProject,
+                new BearerToken("12345"),
+                "127.0.0.1"));
   }
 }

--- a/service/src/test/java/bio/terra/drshub/util/SignedUrlTestUtils.java
+++ b/service/src/test/java/bio/terra/drshub/util/SignedUrlTestUtils.java
@@ -64,6 +64,18 @@ public class SignedUrlTestUtils {
         .thenReturn(url);
   }
 
+  public static void setupSignedUrlMocksForSam(
+      AuthService authService,
+      String googleProject,
+      String bucketName,
+      String objectName,
+      URL url) {
+
+    when(authService.getSignedUrlForBlob(
+            any(BearerToken.class), eq(googleProject), eq(bucketName), eq(objectName)))
+        .thenReturn(url.toString());
+  }
+
   public static void setupDrsResolutionServiceMocks(
       DrsResolutionService drsResolutionService,
       String drsUri,


### PR DESCRIPTION
DRSHub needs to sign URLs for DRS Objects using the `current_auth` authentication. We don't want to be passing around Service Account Keys anymore, and have made Sam to this for us. DRSHub needs to call out to Sam and return the response to the user.