### PR TITLE
ID-704 DRSHub should handle null dates

### DIFF
--- a/service/src/main/java/bio/terra/drshub/models/AnnotatedResourceMetadataSerializer.java
+++ b/service/src/main/java/bio/terra/drshub/models/AnnotatedResourceMetadataSerializer.java
@@ -9,6 +9,7 @@ import io.github.ga4gh.drs.model.Checksum;
 import io.github.ga4gh.drs.model.DrsObject;
 import java.io.IOException;
 import java.time.format.DateTimeFormatter;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -57,12 +58,18 @@ public class AnnotatedResourceMetadataSerializer extends JsonSerializer<Annotate
         var formatter = DateTimeFormatter.ISO_INSTANT;
 
         if (f.equals(Fields.TIME_CREATED)) {
-          jsonGenerator.writeStringField(
-              Fields.TIME_CREATED, formatter.format(response.getCreatedTime().toInstant()));
+          var maybeDate =
+              Optional.ofNullable(response.getCreatedTime())
+                  .map(Date::toInstant)
+                  .map(formatter::format);
+          jsonGenerator.writeStringField(Fields.TIME_CREATED, maybeDate.orElse(null));
         }
         if (f.equals(Fields.TIME_UPDATED)) {
-          jsonGenerator.writeStringField(
-              Fields.TIME_UPDATED, formatter.format(response.getUpdatedTime().toInstant()));
+          var maybeDate =
+              Optional.ofNullable(response.getUpdatedTime())
+                  .map(Date::toInstant)
+                  .map(formatter::format);
+          jsonGenerator.writeStringField(Fields.TIME_UPDATED, maybeDate.orElse(null));
         }
         if (f.equals(Fields.HASHES)) {
           jsonGenerator.writePOJOField(Fields.HASHES, getHashesMap(response.getChecksums()));

--- a/service/src/test/java/bio/terra/drshub/models/AnnotatedResourceMetadataSerializerTest.java
+++ b/service/src/test/java/bio/terra/drshub/models/AnnotatedResourceMetadataSerializerTest.java
@@ -1,0 +1,36 @@
+package bio.terra.drshub.models;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import bio.terra.drshub.BaseTest;
+import io.github.ga4gh.drs.model.DrsObject;
+import java.io.IOException;
+import java.util.List;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.json.AutoConfigureJson;
+import org.springframework.boot.test.autoconfigure.json.AutoConfigureJsonTesters;
+import org.springframework.boot.test.json.JacksonTester;
+
+@Tag("Unit")
+@AutoConfigureJson
+@AutoConfigureJsonTesters
+class AnnotatedResourceMetadataSerializerTest extends BaseTest {
+
+  @Autowired private JacksonTester<AnnotatedResourceMetadata> jacksonTester;
+
+  @Test
+  void testHandlesNullDates() throws IOException {
+    var drsResponse = new DrsObject().accessMethods(List.of()); // 2020-04-27T15:56:09.696Z
+    AnnotatedResourceMetadata metadata =
+        new AnnotatedResourceMetadata(
+            List.of(Fields.TIME_CREATED, Fields.TIME_UPDATED),
+            new DrsMetadata.Builder().drsResponse(drsResponse).build(),
+            config.getDrsProviders().get("terraDataRepo"));
+
+    var written = jacksonTester.write(metadata);
+    assertTrue(written.getJson().contains("\"timeCreated\" : null"));
+    assertTrue(written.getJson().contains("\"timeUpdated\" : null"));
+  }
+}


### PR DESCRIPTION
DRSHub should handle null dates, just like Martha. Martha returns an object with 
```json
{
  "timeCreated": null,
  "timeUpdated": null,
}
``` 

but DRSHub errors out when trying to return the same object. This is blocking the tests of DRSHub in live envs!