### PR TITLE
ID-725 Cache Bond Responses

### DIFF
--- a/service/src/main/java/bio/terra/drshub/services/AuthService.java
+++ b/service/src/main/java/bio/terra/drshub/services/AuthService.java
@@ -41,6 +41,14 @@ public class AuthService {
   private final Map<String, Optional<List<String>>> passportCache =
       Collections.synchronizedMap(new PassiveExpiringMap<>(1, TimeUnit.MINUTES));
 
+  // For every DRS Resolution requiring a signed URL using Bond authorization,
+  // we need to reach out to Bond twice:
+  //   1. Get the fence token
+  //   2. Get the fence service account.
+  // These two caches, keyed on a combination of the user's bearer token and the Bond provider.
+  // This means that the cache entries are per-user and per-Bond provider. So, if a single user
+  // is making requests using two different auth providers from Bond, they will have 2 entries
+  // in the cache, one per provider.
   private final Map<Pair<String, String>, SaKeyObject> serviceAccountKeyCache =
       Collections.synchronizedMap(new PassiveExpiringMap<>(1, TimeUnit.MINUTES));
 

--- a/service/src/main/java/bio/terra/drshub/services/AuthService.java
+++ b/service/src/main/java/bio/terra/drshub/services/AuthService.java
@@ -281,4 +281,11 @@ public class AuthService {
             .requesterPays(false);
     return samApi.signedUrlForBlob(requestBody, googleProject).replaceAll("(^\")|(\"$)", "");
   }
+
+  @VisibleForTesting
+  public void clearCaches() {
+    passportCache.clear();
+    serviceAccountKeyCache.clear();
+    fenceAccessTokenCache.clear();
+  }
 }

--- a/service/src/main/java/bio/terra/drshub/services/AuthService.java
+++ b/service/src/main/java/bio/terra/drshub/services/AuthService.java
@@ -45,10 +45,11 @@ public class AuthService {
   // we need to reach out to Bond twice:
   //   1. Get the fence token
   //   2. Get the fence service account.
-  // These two caches, keyed on a combination of the user's bearer token and the Bond provider.
-  // This means that the cache entries are per-user and per-Bond provider. So, if a single user
-  // is making requests using two different auth providers from Bond, they will have 2 entries
-  // in the cache, one per provider.
+  // These two caches, keyed on a combination of the user's bearer token and the Bond provider,
+  // keep the responses from Bond around to keep us from making multiple redundant requests.
+  // The cache entries are per-user and per-Bond provider.
+  // So, if a single user is making requests using two different auth providers from Bond,
+  // they will have 2 entries in the cache, one per provider.
   private final Map<Pair<String, String>, SaKeyObject> serviceAccountKeyCache =
       Collections.synchronizedMap(new PassiveExpiringMap<>(1, TimeUnit.MINUTES));
 

--- a/service/src/test/java/bio/terra/drshub/controllers/DrsHubApiControllerTest.java
+++ b/service/src/test/java/bio/terra/drshub/controllers/DrsHubApiControllerTest.java
@@ -18,6 +18,7 @@ import bio.terra.drshub.BaseTest;
 import bio.terra.drshub.models.BondProviderEnum;
 import bio.terra.drshub.models.DrsApi;
 import bio.terra.drshub.models.Fields;
+import bio.terra.drshub.services.AuthService;
 import bio.terra.drshub.services.BondApiFactory;
 import bio.terra.drshub.services.DrsApiFactory;
 import bio.terra.drshub.services.ExternalCredsApiFactory;
@@ -47,6 +48,7 @@ import java.util.Optional;
 import java.util.Random;
 import java.util.UUID;
 import java.util.stream.Collectors;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -78,9 +80,15 @@ public class DrsHubApiControllerTest extends BaseTest {
   public static final String TDR_TEST_HOST = "jade.datarepo-dev.broadinstitute.org";
   @Autowired private MockMvc mvc;
   @Autowired private ObjectMapper objectMapper;
+  @Autowired private AuthService authService;
   @MockBean BondApiFactory bondApiFactory;
   @MockBean DrsApiFactory drsApiFactory;
   @MockBean ExternalCredsApiFactory externalCredsApiFactory;
+
+  @BeforeEach
+  void before() {
+    authService.clearCaches();
+  }
 
   @Test
   void testCallsCorrectEndpointsWhenOnlyAccessUrlRequestedWithPassports() throws Exception {


### PR DESCRIPTION
DRSHub makes 1 or 2 requests to Bond for each DRS URL Resolution, depending on what fields are requested. This means that DRSHub makes a huge amount of requests for a single user’s workflow. If we cache Bond responses by Bearer Token and DRS Provider, we should be able to drastically cut down on the number of requests.