### PR TITLE
DR-3193 Point original AnVIL compact id prefixes to TDR

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Note: there are a few tricky cases with the **compact IDs (CID)**:
 ### Dev
 | Provider            | Compact Id (CIB)  | Host URI                                   |
 |---------------------|-------------------|--------------------------------------------|
-| AnVIL (gen3 hosted) | dg.anv0           | staging.theanvil.io                        |
+| AnVIL (gen3 hosted) | dg.anv0           | jade.datarepo-dev.broadinstitute.org       |
 | AnVIL (TDR hosted)  | drs.anv0          | jade.datarepo-dev.broadinstitute.org       |
 | BDC                 | dg.712c           | staging.gen3.biodatacatalyst.nhlbi.nih.gov |
 | CRDC                | dg.4dfc           | nci-crdc-staging.datacommons.io            |
@@ -159,7 +159,7 @@ Note: there are a few tricky cases with the **compact IDs (CID)**:
 ### Alpha
 | Provider            | Compact Id (CIB)  | Host URI                                   |
 |---------------------|-------------------|--------------------------------------------|
-| AnVIL (gen3 hosted) | dg.anv0           | staging.theanvil.io                        |
+| AnVIL (gen3 hosted) | dg.anv0           | data.alpha.envs-terra.bio                  |
 | AnVIL (TDR hosted)  | drs.anv0          | data.alpha.envs-terra.bio                  |
 | BDC                 | dg.712c           | staging.gen3.biodatacatalyst.nhlbi.nih.gov |
 | CRDC                | dg.4dfc           | nci-crdc-staging.datacommons.io            |
@@ -170,7 +170,7 @@ Note: there are a few tricky cases with the **compact IDs (CID)**:
 
 | Provider            | Compact Id (CIB)  | Host URI                                   |
 |---------------------|-------------------|--------------------------------------------|
-| AnVIL (gen3 hosted) | dg.anv0           | staging.theanvil.io                        |
+| AnVIL (gen3 hosted) | dg.anv0           | data.staging.envs-terra.bio                |
 | AnVIL (TDR hosted)  | drs.anv0          | data.staging.envs-terra.bio                |
 | BDC                 | dg.712c           | staging.gen3.biodatacatalyst.nhlbi.nih.gov |
 | CRDC                | dg.4dfc           | nci-crdc-staging.datacommons.io            |
@@ -181,7 +181,7 @@ Note: there are a few tricky cases with the **compact IDs (CID)**:
 
 | Provider            | Compact Id (CIB)  | Host URI                           |
 |---------------------|-------------------|------------------------------------|
-| AnVIL (gen3 hosted) | dg.anv0           | gen3.theanvil.io                   |
+| AnVIL (gen3 hosted) | dg.anv0           | data.terra.bio                     |
 | AnVIL (TDR hosted)  | drs.anv0          | data.terra.bio                     |
 | BDC                 | dg.4503           | gen3.biodatacatalyst.nhlbi.nih.gov |
 | CRDC                | dg.4dfc           | nci-crdc.datacommons.io            |

--- a/README.md
+++ b/README.md
@@ -142,14 +142,14 @@ DrsHub runs in Kubernetes in GCP. Current deployments for each env can be found 
 Note: there are a few tricky cases with the **compact IDs (CID)**:
 - BioDataCatalyst uses the CIB `dg.4503` in production, and `dg.712c` in non-prod environments
 - The AnVIL currently has two CIBs in use
-  - `dg.anv0` for old gen3 hosted data
+  - `dg.anv0` for old gen3 and TDR hosted data
   - `drs.anv0` (note the **dg** vs **drs** prefix) for TDR hosted data, this will be used going forward
 - Most of these providers have only `prod` and `not prod` URIs, TDR is the only one that has specific URIs for each lower environment
 
 ### Dev
 | Provider            | Compact Id (CIB)  | Host URI                                   |
 |---------------------|-------------------|--------------------------------------------|
-| AnVIL (gen3 hosted) | dg.anv0           | jade.datarepo-dev.broadinstitute.org       |
+| AnVIL (TDR hosted)  | dg.anv0           | jade.datarepo-dev.broadinstitute.org       |
 | AnVIL (TDR hosted)  | drs.anv0          | jade.datarepo-dev.broadinstitute.org       |
 | BDC                 | dg.712c           | staging.gen3.biodatacatalyst.nhlbi.nih.gov |
 | CRDC                | dg.4dfc           | nci-crdc-staging.datacommons.io            |
@@ -159,7 +159,7 @@ Note: there are a few tricky cases with the **compact IDs (CID)**:
 ### Alpha
 | Provider            | Compact Id (CIB)  | Host URI                                   |
 |---------------------|-------------------|--------------------------------------------|
-| AnVIL (gen3 hosted) | dg.anv0           | data.alpha.envs-terra.bio                  |
+| AnVIL (TDR hosted)  | dg.anv0           | data.alpha.envs-terra.bio                  |
 | AnVIL (TDR hosted)  | drs.anv0          | data.alpha.envs-terra.bio                  |
 | BDC                 | dg.712c           | staging.gen3.biodatacatalyst.nhlbi.nih.gov |
 | CRDC                | dg.4dfc           | nci-crdc-staging.datacommons.io            |
@@ -170,7 +170,7 @@ Note: there are a few tricky cases with the **compact IDs (CID)**:
 
 | Provider            | Compact Id (CIB)  | Host URI                                   |
 |---------------------|-------------------|--------------------------------------------|
-| AnVIL (gen3 hosted) | dg.anv0           | data.staging.envs-terra.bio                |
+| AnVIL (TDR hosted)  | dg.anv0           | data.staging.envs-terra.bio                |
 | AnVIL (TDR hosted)  | drs.anv0          | data.staging.envs-terra.bio                |
 | BDC                 | dg.712c           | staging.gen3.biodatacatalyst.nhlbi.nih.gov |
 | CRDC                | dg.4dfc           | nci-crdc-staging.datacommons.io            |
@@ -179,14 +179,14 @@ Note: there are a few tricky cases with the **compact IDs (CID)**:
 
 ### Prod
 
-| Provider            | Compact Id (CIB)  | Host URI                           |
-|---------------------|-------------------|------------------------------------|
-| AnVIL (gen3 hosted) | dg.anv0           | data.terra.bio                     |
-| AnVIL (TDR hosted)  | drs.anv0          | data.terra.bio                     |
-| BDC                 | dg.4503           | gen3.biodatacatalyst.nhlbi.nih.gov |
-| CRDC                | dg.4dfc           | nci-crdc.datacommons.io            |
-| KidsFirst           | dg.f82a1a         | data.kidsfirstdrc.org              |
-| Passport Test       |                   |                                    |
+| Provider             | Compact Id (CIB)  | Host URI                           |
+|----------------------|-------------------|------------------------------------|
+| AnVIL (TDR hosted)   | dg.anv0           | data.terra.bio                     |
+| AnVIL (TDR hosted)   | drs.anv0          | data.terra.bio                     |
+| BDC                  | dg.4503           | gen3.biodatacatalyst.nhlbi.nih.gov |
+| CRDC                 | dg.4dfc           | nci-crdc.datacommons.io            |
+| KidsFirst            | dg.f82a1a         | data.kidsfirstdrc.org              |
+| Passport Test        |                   |                                    |
 
 ## SonarCloud Status
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=DataBiosphere_terra-drs-hub&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=DataBiosphere_terra-drs-hub)

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -135,7 +135,7 @@ spring.config.activate.on-profile: prod
 drshub:
   compactIdHosts:
     "dg.4503": gen3.biodatacatalyst.nhlbi.nih.gov # biodatacatalyst
-    "dg.anv0": data.terra.bio # old anvil (now hosted on TDR)
+    "dg.anv0": data.terra.bio # old anvil (hosted on TDR)
     "drs.anv0": data.terra.bio # new anvil (hosted on TDR)
     "dg.4dfc": nci-crdc.datacommons.io # cancer research data commons
     "dg.f82a1a": data.kidsfirstdrc.org # kidsfirst

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -126,7 +126,6 @@ drshub:
   signedUrlDuration: 1h
   compactIdHosts:
     "dg.712c": staging.gen3.biodatacatalyst.nhlbi.nih.gov # biodatacatalyst staging
-    "dg.anv0": staging.theanvil.io # this is the old anvil CIB, the new one (drs.anv0) is set explicitly for each env
     "dg.4dfc": nci-crdc-staging.datacommons.io # cancer research data commons
     "dg.f82a1a": gen3staging.kidsfirstdrc.org # kidsfirst
     "dg.test0": ctds-test-env.planx-pla.net # passport test
@@ -136,7 +135,7 @@ spring.config.activate.on-profile: prod
 drshub:
   compactIdHosts:
     "dg.4503": gen3.biodatacatalyst.nhlbi.nih.gov # biodatacatalyst
-    "dg.anv0": gen3.theanvil.io # old anvil
+    "dg.anv0": data.terra.bio # old anvil (now hosted on TDR)
     "drs.anv0": data.terra.bio # new anvil (hosted on TDR)
     "dg.4dfc": nci-crdc.datacommons.io # cancer research data commons
     "dg.f82a1a": data.kidsfirstdrc.org # kidsfirst
@@ -146,15 +145,18 @@ spring.config.activate.on-profile: dev
 drshub:
   compactIdHosts:
     "drs.anv0": jade.datarepo-dev.broadinstitute.org
+    "dg.anv0": jade.datarepo-dev.broadinstitute.org
 ---
 # staging
 spring.config.activate.on-profile: staging
 drshub:
   compactIdHosts:
     "drs.anv0": data.staging.envs-terra.bio
+    "dg.anv0": data.staging.envs-terra.bio
 ---
 # alpha
 spring.config.activate.on-profile: alpha
 drshub:
   compactIdHosts:
     "drs.anv0": data.alpha.envs-terra.bio
+    "dg.anv0": data.alpha.envs-terra.bio


### PR DESCRIPTION
Since all files are aliased in TDR now, we should be good to go