### PR TITLE
DR-3214 Set Headers per-request for DRS API Clients

### DIFF
--- a/service/src/main/java/bio/terra/drshub/services/SignedUrlService.java
+++ b/service/src/main/java/bio/terra/drshub/services/SignedUrlService.java
@@ -98,7 +98,8 @@ public record SignedUrlService(
         blobInfo, duration.toMinutes(), TimeUnit.MINUTES, Storage.SignUrlOption.withV4Signature());
   }
 
-  private BlobId getBlobIdFromDrsUri(String dataObjectUri, BearerToken bearerToken, String ip, String googleProject) {
+  private BlobId getBlobIdFromDrsUri(
+      String dataObjectUri, BearerToken bearerToken, String ip, String googleProject) {
     var objectFuture =
         drsResolutionService.resolveDrsObject(
             dataObjectUri, Fields.CORE_FIELDS, bearerToken, true, ip, googleProject);

--- a/service/src/test/java/bio/terra/drshub/controllers/GcsApiControllerTest.java
+++ b/service/src/test/java/bio/terra/drshub/controllers/GcsApiControllerTest.java
@@ -91,8 +91,8 @@ public class GcsApiControllerTest extends BaseTest {
     return getSignedUrlRequestRaw(accessToken, requestBody, googleProject);
   }
 
-  private ResultActions getSignedUrlRequestRaw(String accessToken, String requestBody, String googleProject)
-      throws Exception {
+  private ResultActions getSignedUrlRequestRaw(
+      String accessToken, String requestBody, String googleProject) throws Exception {
     return mvc.perform(
         post("/api/v4/gcs/getSignedUrl")
             .header("authorization", "bearer " + accessToken)

--- a/service/src/test/java/bio/terra/drshub/services/DrsApiFactoryTest.java
+++ b/service/src/test/java/bio/terra/drshub/services/DrsApiFactoryTest.java
@@ -43,9 +43,8 @@ public class DrsApiFactoryTest extends BaseTest {
   void testIndependentApiClients() {
     var drsProvider = DrsProvider.create().setName("testDrsProvider");
     var client1 =
-        spy(
-            drsApiFactory.getApiFromUriComponents(
-                UriComponentsBuilder.newInstance().host("test").build(), drsProvider));
+        drsApiFactory.getApiFromUriComponents(
+            UriComponentsBuilder.newInstance().host("test").build(), drsProvider);
     var separateApiClient =
         spy(
             drsApiFactory
@@ -53,6 +52,6 @@ public class DrsApiFactoryTest extends BaseTest {
                     UriComponentsBuilder.newInstance().host("test").build(), drsProvider)
                 .getApiClient());
     client1.setHeader("test-header", "test-value");
-    verify(separateApiClient.addDefaultHeader(anyString(), anyString()), never());
+    verify(separateApiClient, never()).addDefaultHeader(anyString(), anyString());
   }
 }

--- a/service/src/test/java/bio/terra/drshub/services/DrsApiFactoryTest.java
+++ b/service/src/test/java/bio/terra/drshub/services/DrsApiFactoryTest.java
@@ -38,4 +38,21 @@ public class DrsApiFactoryTest extends BaseTest {
 
     verify(spy, never()).makeMTlsRestTemplateWithPooling(anyString(), anyString());
   }
+
+  @Test
+  void testIndependentApiClients() {
+    var drsProvider = DrsProvider.create().setName("testDrsProvider");
+    var client1 =
+        spy(
+            drsApiFactory.getApiFromUriComponents(
+                UriComponentsBuilder.newInstance().host("test").build(), drsProvider));
+    var separateApiClient =
+        spy(
+            drsApiFactory
+                .getApiFromUriComponents(
+                    UriComponentsBuilder.newInstance().host("test").build(), drsProvider)
+                .getApiClient());
+    client1.setHeader("test-header", "test-value");
+    verify(separateApiClient.addDefaultHeader(anyString(), anyString()), never());
+  }
 }


### PR DESCRIPTION
We need to use different `DrsApi` objects because, if we don't, all calls to the same provider will share headers.