### PR TITLE
[DR-3077] Log DRS resolution and URL signing to Bard

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -75,8 +75,9 @@ dependencies {
 		exclude group: 'com.vaadin.external.google', module: 'android-json'
 	}
 
-	testImplementation("au.com.dius.pact.provider:junit5:4.1.7")
+	testImplementation('au.com.dius.pact.provider:junit5:4.1.7')
 	testImplementation('au.com.dius.pact.provider:junit5spring:4.1.7')
+	testImplementation('org.awaitility:awaitility:4.2.0')
 }
 
 sonarqube {

--- a/service/generators.gradle
+++ b/service/generators.gradle
@@ -31,6 +31,11 @@ swaggerSources {
 		code(makeClientCodeClosure('io.github.ga4gh.drs', true))
 	}
 
+	bard {
+		inputFile = file('src/main/resources/vendor/bard.yaml')
+		code(makeClientCodeClosure('bio.terra.bard', false))
+	}
+
 	bond {
 		inputFile = file('src/main/resources/vendor/bond.yaml')
 		code(makeClientCodeClosure('bio.terra.bond', false))
@@ -75,6 +80,7 @@ Set<String> swaggerSourcePaths = [
 		"${swaggerSources.ga4gh.code.outputDir}/src/main/java",
 		"${swaggerSources.bond.code.outputDir}/src/main/java",
 		"${swaggerSources.sam.code.outputDir}/src/main/java",
+		"${swaggerSources.bard.code.outputDir}/src/main/java",
 ]
 
 

--- a/service/src/main/java/bio/terra/drshub/config/DrsHubConfigInterface.java
+++ b/service/src/main/java/bio/terra/drshub/config/DrsHubConfigInterface.java
@@ -9,6 +9,8 @@ import org.immutables.value.Value;
 @PropertiesInterfaceStyle
 public interface DrsHubConfigInterface {
 
+  String getBardUrl();
+
   String getBondUrl();
 
   String getSamUrl();
@@ -30,4 +32,8 @@ public interface DrsHubConfigInterface {
   Integer getPencilsDownSeconds();
 
   Integer asyncThreads();
+
+  // If this is true, then we will track calls to the Bard API in MixPanel in addition to the
+  // BigQuery Data warehouse.
+  Boolean trackInMixPanel();
 }

--- a/service/src/main/java/bio/terra/drshub/config/WebConfig.java
+++ b/service/src/main/java/bio/terra/drshub/config/WebConfig.java
@@ -1,6 +1,7 @@
 package bio.terra.drshub.config;
 
 import bio.terra.drshub.logging.LoggerInterceptor;
+import bio.terra.drshub.tracking.TrackingInterceptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
@@ -9,9 +10,11 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @Component
 public class WebConfig implements WebMvcConfigurer {
   @Autowired private LoggerInterceptor loggerInterceptor;
+  @Autowired private TrackingInterceptor trackingInterceptor;
 
   @Override
   public void addInterceptors(InterceptorRegistry registry) {
     registry.addInterceptor(loggerInterceptor);
+    registry.addInterceptor(trackingInterceptor);
   }
 }

--- a/service/src/main/java/bio/terra/drshub/controllers/DrsHubApiController.java
+++ b/service/src/main/java/bio/terra/drshub/controllers/DrsHubApiController.java
@@ -7,6 +7,7 @@ import bio.terra.drshub.generated.model.RequestObject;
 import bio.terra.drshub.generated.model.ResourceMetadata;
 import bio.terra.drshub.models.Fields;
 import bio.terra.drshub.services.DrsResolutionService;
+import bio.terra.drshub.tracking.TrackCall;
 import bio.terra.drshub.util.AsyncUtils;
 import java.util.ArrayList;
 import java.util.Objects;
@@ -25,6 +26,7 @@ public record DrsHubApiController(
     implements DrsHubApi {
 
   @Override
+  @TrackCall
   public ResponseEntity<ResourceMetadata> resolveDrs(RequestObject body) {
     var bearerToken = bearerTokenFactory.from(request);
     validateRequest(body);

--- a/service/src/main/java/bio/terra/drshub/controllers/GcsApiController.java
+++ b/service/src/main/java/bio/terra/drshub/controllers/GcsApiController.java
@@ -4,6 +4,7 @@ import bio.terra.common.iam.BearerTokenFactory;
 import bio.terra.drshub.generated.api.GcsApi;
 import bio.terra.drshub.generated.model.GetSignedUrlRequest;
 import bio.terra.drshub.services.SignedUrlService;
+import bio.terra.drshub.tracking.TrackCall;
 import javax.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -27,6 +28,7 @@ public class GcsApiController implements GcsApi {
   }
 
   @Override
+  @TrackCall
   public ResponseEntity<String> getSignedUrl(GetSignedUrlRequest body) {
     var bearerToken = bearerTokenFactory.from(request);
     var ip = request.getHeader("X-Forwarded-For");

--- a/service/src/main/java/bio/terra/drshub/services/BardApiFactory.java
+++ b/service/src/main/java/bio/terra/drshub/services/BardApiFactory.java
@@ -1,0 +1,94 @@
+package bio.terra.drshub.services;
+
+import bio.terra.bard.api.BardApi;
+import bio.terra.bard.client.ApiClient;
+import bio.terra.bard.model.EventProperties;
+import bio.terra.common.iam.BearerToken;
+import bio.terra.drshub.DrsHubException;
+import bio.terra.drshub.config.DrsHubConfig;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import com.google.common.annotations.VisibleForTesting;
+import java.io.IOException;
+import java.util.List;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+@Service
+public record BardApiFactory(DrsHubConfig drsHubConfig) {
+
+  public BardApi getApi(BearerToken bearerToken) {
+    var bardApi = new BardApi(new BardApiClient());
+
+    bardApi.getApiClient().setBasePath(drsHubConfig.getBardUrl());
+    bardApi.getApiClient().setAccessToken(bearerToken.getToken());
+
+    return bardApi;
+  }
+
+  /**
+   * Extension of the BardApiClient that overrides the buildRestTemplate method to add a custom
+   * serializer for EventProperties
+   */
+  private static class BardApiClient extends ApiClient {
+    @Override
+    protected RestTemplate buildRestTemplate() {
+      RestTemplate restTemplate = super.buildRestTemplate();
+
+      MappingJackson2HttpMessageConverter converter = new MappingJackson2HttpMessageConverter();
+      converter.setObjectMapper(configureObjectMapper());
+      restTemplate.setMessageConverters(List.of(converter));
+      return restTemplate;
+    }
+  }
+
+  @VisibleForTesting
+  static ObjectMapper configureObjectMapper() {
+    ObjectMapper objectMapper = new ObjectMapper();
+    SimpleModule module = new SimpleModule();
+    module.addSerializer(EventProperties.class, new EventPropertiesSerializer());
+    objectMapper.registerModule(module);
+    return objectMapper;
+  }
+
+  /**
+   * Custom serializer for EventProperties. This is needed because the Bard API expects the
+   * arbitrary user properties to be serialized as top-level fields in the JSON object along with
+   * the first class fields (e.g. appId and pushToMixpanel)
+   */
+  private static class EventPropertiesSerializer extends StdSerializer<EventProperties> {
+    private static final List<String> RESERVED_FIELDS = List.of("appId", "pushToMixpanel");
+
+    public EventPropertiesSerializer() {
+      this(null);
+    }
+
+    public EventPropertiesSerializer(Class<EventProperties> t) {
+      super(t);
+    }
+
+    @Override
+    public void serialize(EventProperties value, JsonGenerator jgen, SerializerProvider provider)
+        throws IOException {
+      jgen.writeStartObject();
+      jgen.writeStringField("appId", value.getAppId());
+      jgen.writeBooleanField("pushToMixpanel", value.isPushToMixpanel());
+      value.forEach(
+          (key, val) -> {
+            try {
+              // Ignore reserved fields since they are already written above
+              if (!RESERVED_FIELDS.contains(key)) {
+                jgen.writeObjectField(key, val);
+              }
+            } catch (IOException e) {
+              throw new DrsHubException("Error serializing event properties", e);
+            }
+          });
+      jgen.writeEndObject();
+    }
+  }
+}

--- a/service/src/main/java/bio/terra/drshub/tracking/TrackCall.java
+++ b/service/src/main/java/bio/terra/drshub/tracking/TrackCall.java
@@ -1,0 +1,14 @@
+package bio.terra.drshub.tracking;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Add this annotation to a method to track its call as a user event in Bard. Note this should just
+ * be used within Controller classes
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface TrackCall {}

--- a/service/src/main/java/bio/terra/drshub/tracking/TrackCall.java
+++ b/service/src/main/java/bio/terra/drshub/tracking/TrackCall.java
@@ -7,7 +7,8 @@ import java.lang.annotation.Target;
 
 /**
  * Add this annotation to a method to track its call as a user event in Bard. Note this should just
- * be used within Controller classes
+ * be used within Controller classes since these represent the explicit API calls that users are
+ * making. Tracking internal calls is not useful and likely too noisy.
  */
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)

--- a/service/src/main/java/bio/terra/drshub/tracking/TrackingInterceptor.java
+++ b/service/src/main/java/bio/terra/drshub/tracking/TrackingInterceptor.java
@@ -55,6 +55,7 @@ public record TrackingInterceptor(
 
       properties.putAll(readBody(request));
 
+      // There are all the known headers that are potentially sent to DRSHub that we want to track
       addToPropertiesIfPresentInHeader(request, properties, "x-user-project", "userProject");
       addToPropertiesIfPresentInHeader(request, properties, "X-Forwarded-For", "ip");
       addToPropertiesIfPresentInHeader(

--- a/service/src/main/java/bio/terra/drshub/tracking/TrackingInterceptor.java
+++ b/service/src/main/java/bio/terra/drshub/tracking/TrackingInterceptor.java
@@ -1,0 +1,103 @@
+package bio.terra.drshub.tracking;
+
+import bio.terra.bard.model.EventProperties;
+import bio.terra.common.iam.BearerTokenFactory;
+import bio.terra.drshub.services.TrackingService;
+import bio.terra.drshub.util.AsyncUtils;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.util.ContentCachingRequestWrapper;
+
+/**
+ * Class to intercept requests and log them to the tracking service (Bard). Methods annotated with
+ * the {@link TrackCall} annotation will be tracked.
+ */
+@Component
+@Slf4j
+public record TrackingInterceptor(
+    TrackingService trackingService,
+    AsyncUtils asyncUtils,
+    BearerTokenFactory bearerTokenFactory,
+    ObjectMapper objectMapper)
+    implements HandlerInterceptor {
+
+  public static final String EVENT_NAME = "drshub:api";
+
+  @Override
+  public void afterCompletion(
+      HttpServletRequest request,
+      @NotNull HttpServletResponse response,
+      @NotNull Object handler,
+      Exception ex) {
+    var path = request.getRequestURI();
+    var responseStatus = HttpStatus.valueOf(response.getStatus());
+    // Note: invalid responses will not be logged since there are no sessions to associate users
+    // with
+    if (handler instanceof HandlerMethod handlerMethod
+        && handlerMethod.getMethod().getAnnotation(TrackCall.class) != null
+        && responseStatus.is2xxSuccessful()) {
+      var bearerToken = bearerTokenFactory.from(request);
+      var properties =
+          new HashMap<String, Object>(
+              Map.of("statusCode", responseStatus.value(), "requestUrl", path));
+
+      properties.putAll(readBody(request));
+
+      addToPropertiesIfPresentInHeader(request, properties, "x-user-project", "userProject");
+      addToPropertiesIfPresentInHeader(request, properties, "X-Forwarded-For", "ip");
+      addToPropertiesIfPresentInHeader(
+          request, properties, "drshub-force-access-url", "forceAccessUrl");
+
+      trackingService.logEvent(bearerToken, EVENT_NAME, properties);
+    }
+  }
+
+  private Map<String, Object> readBody(HttpServletRequest request) {
+    var rawRequest =
+        new String(
+            ((ContentCachingRequestWrapper) request).getContentAsByteArray(),
+            StandardCharsets.UTF_8);
+
+    try {
+      return objectMapper.readValue(rawRequest, new TypeReference<>() {});
+    } catch (JsonProcessingException e) {
+      // Note: log a warning but do not fail so that at least part of the request is logged
+      log.warn("Failed to parse request body for tracking", e);
+      return Map.of();
+    }
+  }
+
+  /**
+   * If a given header is present in the request and has a value, add it to the properties map to be
+   * tracked in Bard
+   *
+   * @param request The request being logged
+   * @param properties The properties map that will be sent to Bard for tracking as an {@link
+   *     EventProperties} object
+   * @param headerName The name of the header to examine
+   * @param propertyName The name of the map key to use when adding the header value to the
+   *     properties map
+   */
+  private void addToPropertiesIfPresentInHeader(
+      HttpServletRequest request,
+      Map<String, Object> properties,
+      String headerName,
+      String propertyName) {
+    var headerValue = request.getHeader(headerName);
+    if (headerValue != null) {
+      properties.put(propertyName, headerValue);
+    }
+  }
+}

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -1,6 +1,7 @@
 deploy_env: ${DEPLOY_ENV:dev} # since there's a default, define this once
 
 drshub:
+  bardUrl: https://terra-bard-${deploy_env}.appspot.com
   samUrl: https://sam.dsde-${deploy_env}.broadinstitute.org
   externalcredsUrl: https://externalcreds.dsde-${deploy_env}.broadinstitute.org
 
@@ -58,6 +59,7 @@ drshub:
           fetchAccessUrl: true # Used for Azure
   pencilsDownSeconds: 58
   asyncThreads: ${TOMCAT_MAX_THREADS:200}
+  trackInMixpanel: false
 
 server:
   compression:

--- a/service/src/main/resources/vendor/bard.yaml
+++ b/service/src/main/resources/vendor/bard.yaml
@@ -43,7 +43,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Itentify'
+              $ref: '#/components/schemas/Identify'
       responses:
         '200':
           description: Session was identified successfully
@@ -99,7 +99,7 @@ components:
         type: object
       required:
         - appId
-    Itentify:
+    Identify:
       type: object
       properties:
         anonId:

--- a/service/src/main/resources/vendor/bard.yaml
+++ b/service/src/main/resources/vendor/bard.yaml
@@ -1,0 +1,110 @@
+openapi: 3.0.3
+info:
+  title: Bard API
+  description: >-
+    A lightweight service to handle tracking user and api events in a compliant
+    manner
+  version: 1.0.0
+servers:
+  - url: /
+paths:
+  /api/event:
+    post:
+      summary: Log a user event
+      tags: [ bard ]
+      description: >-
+        Records the event to a log and optionally forwards it to mixpanel.
+        Optionally takes an authorization token which must be verified with Sam.
+        If properties['pushToMixpanel'] is false, only log the event (the property defaults to true).
+        The logs will still get sent to BigQuery via a log sink.
+      operationId: event
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Event'
+      responses:
+        '200':
+          description: Event was logged successfully
+  /api/identify:
+    post:
+      summary: Merge two user id's
+      tags: [ bard ]
+      description: >-
+        Calls MixPanel's `$identify` endpoint to merge the included
+        distinct_ids. This merges the client generated id, used for anonymous,
+        non-authenticated metrics with the Bard auto-generated `distinct_id` to
+        link an anonymous session with a user. Requires an authorization token
+        that is verified with Sam
+      operationId: identify
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Itentify'
+      responses:
+        '200':
+          description: Session was identified successfully
+  /api/syncProfile:
+    post:
+      summary: Update mixpanel profile
+      tags: [ bard ]
+      description: >-
+        Syncs profile info from orchestration to mixpanel. Requires an
+        authorization token, which pulls the corresponding profile from
+        Orchestration to sync into mixpanel
+      operationId: syncProfile
+      responses:
+        '200':
+          description: Profile was synced successfully
+  /status:
+    get:
+      summary: System status
+      tags: [ bard ]
+      operationId: status
+      responses:
+        '200':
+          description: Service is up and running
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+  schemas:
+    Event:
+      type: object
+      properties:
+        event:
+          type: string
+        properties:
+          # Putting the body as an allOf coaxes the client to use a typed object that extents
+          # Map rather than a raw Map.
+          $ref: '#/components/schemas/EventProperties'
+      required:
+        - event
+        - properties
+    EventProperties:
+      type: object
+      properties:
+        # Note: there is a bug in the codegen that makes Jackson ignore these values.  In this
+        # repo we add a customer serializer to work around this issue.
+        # See bio.terra.drshub.services.BardApiFactory.EventPropertiesSerializer
+        appId:
+          type: string
+        pushToMixpanel:
+          type: boolean
+      additionalProperties:
+        type: object
+      required:
+        - appId
+    Itentify:
+      type: object
+      properties:
+        anonId:
+          type: string
+      required:
+        - anonId
+security:
+  - bearerAuth: []

--- a/service/src/test/java/bio/terra/drshub/controllers/GcsApiControllerTest.java
+++ b/service/src/test/java/bio/terra/drshub/controllers/GcsApiControllerTest.java
@@ -62,7 +62,7 @@ public class GcsApiControllerTest extends BaseTest {
 
     SignedUrlTestUtils.setupSignedUrlMocks(authService, googleStorageService, googleProject, url);
     SignedUrlTestUtils.setupDrsResolutionServiceMocks(
-        drsResolutionService, drsUri, bucketName, objectName, googleProject);
+        drsResolutionService, drsUri, bucketName, objectName, googleProject, true);
 
     var response = getSignedUrlRequest(TEST_ACCESS_TOKEN, null, null, drsUri, googleProject);
     response.andExpect(content().string(url.toString()));

--- a/service/src/test/java/bio/terra/drshub/services/BardApiFactoryTest.java
+++ b/service/src/test/java/bio/terra/drshub/services/BardApiFactoryTest.java
@@ -1,0 +1,31 @@
+package bio.terra.drshub.services;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import bio.terra.bard.model.Event;
+import bio.terra.bard.model.EventProperties;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("Unit")
+class BardApiFactoryTest {
+
+  @Test
+  void testObjectMapper() throws JsonProcessingException {
+    ObjectMapper objectMapper = BardApiFactory.configureObjectMapper();
+
+    EventProperties eventProperties = new EventProperties().appId("appId").pushToMixpanel(false);
+    eventProperties.put("foo", "bar");
+    eventProperties.put("appId", "otherAppId");
+    Event event = new Event().event("event").properties(eventProperties);
+    assertThat(
+        "Event serializes properly",
+        objectMapper.writeValueAsString(event),
+        equalTo(
+            """
+            {"event":"event","properties":{"appId":"appId","pushToMixpanel":false,"foo":"bar"}}"""));
+  }
+}

--- a/service/src/test/java/bio/terra/drshub/services/SignedUrlServiceTest.java
+++ b/service/src/test/java/bio/terra/drshub/services/SignedUrlServiceTest.java
@@ -70,7 +70,7 @@ public class SignedUrlServiceTest extends BaseTest {
 
     SignedUrlTestUtils.setupSignedUrlMocks(authService, googleStorageService, googleProject, url);
     SignedUrlTestUtils.setupDrsResolutionServiceMocks(
-        drsResolutionService, drsUri, bucketName, objectName, googleProject);
+        drsResolutionService, drsUri, bucketName, objectName, googleProject, true);
     var signedUrl =
         signedUrlService.getSignedUrl(
             null, null, drsUri, googleProject, new BearerToken("12345"), "127.0.0.1");

--- a/service/src/test/java/bio/terra/drshub/services/TrackingServiceTest.java
+++ b/service/src/test/java/bio/terra/drshub/services/TrackingServiceTest.java
@@ -1,0 +1,83 @@
+package bio.terra.drshub.services;
+
+import static bio.terra.drshub.services.TrackingService.APP_ID;
+import static org.awaitility.Awaitility.await;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import bio.terra.bard.api.BardApi;
+import bio.terra.bard.model.Event;
+import bio.terra.bard.model.EventProperties;
+import bio.terra.common.iam.BearerToken;
+import bio.terra.drshub.BaseTest;
+import java.time.Duration;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.ResponseEntity;
+
+@Tag("Unit")
+class TrackingServiceTest extends BaseTest {
+  private static final String TEST_ACCESS_TOKEN = "I_am_an_access_token";
+  private static final BearerToken TEST_BEARER_TOKEN = new BearerToken(TEST_ACCESS_TOKEN);
+
+  @MockBean BardApiFactory bardApiFactory;
+  BardApi bardApi;
+  @Autowired TrackingService trackingService;
+
+  @BeforeEach
+  void setUp() {
+    trackingService.clearCache();
+    bardApi = mock(BardApi.class);
+    when(bardApiFactory.getApi(TEST_BEARER_TOKEN)).thenReturn(bardApi);
+  }
+
+  @Test
+  void testLogEventHappyPath() {
+    when(bardApi.syncProfileWithHttpInfo()).thenReturn(ResponseEntity.ok(null));
+    when(bardApi.eventWithHttpInfo(any())).thenReturn(ResponseEntity.ok(null));
+    trackingService.logEvent(TEST_BEARER_TOKEN, "foo", Map.of("bar", "baz"));
+
+    await()
+        .atMost(Duration.ofSeconds(10))
+        .untilAsserted(() -> verify(bardApi).syncProfileWithHttpInfo());
+
+    var expectedEventProperties = new EventProperties().appId(APP_ID).pushToMixpanel(false);
+    expectedEventProperties.put("bar", "baz");
+    await()
+        .atMost(Duration.ofSeconds(10))
+        .untilAsserted(
+            () ->
+                verify(bardApi, times(1))
+                    .eventWithHttpInfo(
+                        new Event().event("foo").properties(expectedEventProperties)));
+  }
+
+  @Test
+  void testLogEventWhenBardIsDown() {
+    when(bardApi.syncProfileWithHttpInfo())
+        .thenReturn(ResponseEntity.internalServerError().build());
+    when(bardApi.eventWithHttpInfo(any())).thenReturn(ResponseEntity.internalServerError().build());
+    trackingService.logEvent(TEST_BEARER_TOKEN, "foo", Map.of("bar", "baz"));
+
+    await()
+        .atMost(Duration.ofSeconds(10))
+        .untilAsserted(() -> verify(bardApi).syncProfileWithHttpInfo());
+
+    var expectedEventProperties = new EventProperties().appId(APP_ID).pushToMixpanel(false);
+    expectedEventProperties.put("bar", "baz");
+    await()
+        .atMost(Duration.ofSeconds(10))
+        .untilAsserted(
+            () ->
+                verify(bardApi, times(1))
+                    .eventWithHttpInfo(
+                        new Event().event("foo").properties(expectedEventProperties)));
+  }
+}

--- a/service/src/test/java/bio/terra/drshub/tracking/TrackingInterceptorTest.java
+++ b/service/src/test/java/bio/terra/drshub/tracking/TrackingInterceptorTest.java
@@ -1,0 +1,107 @@
+package bio.terra.drshub.tracking;
+
+import static bio.terra.drshub.tracking.TrackingInterceptor.EVENT_NAME;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import bio.terra.common.iam.BearerToken;
+import bio.terra.drshub.BaseTest;
+import bio.terra.drshub.services.DrsResolutionService;
+import bio.terra.drshub.services.TrackingService;
+import bio.terra.drshub.util.SignedUrlTestUtils;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+@Tag("Unit")
+@AutoConfigureMockMvc
+class TrackingInterceptorTest extends BaseTest {
+  private static final String TEST_ACCESS_TOKEN = "I_am_an_access_token";
+  private static final BearerToken TEST_BEARER_TOKEN = new BearerToken(TEST_ACCESS_TOKEN);
+  private static final String DRS_URI = "drs://foo/object_id";
+  private static final String TEST_IP_ADDRESS = "1.1.1.1";
+  private static final String GOOGLE_PROJECT = "myproject";
+
+  @Autowired private MockMvc mvc;
+  @Autowired private ObjectMapper objectMapper;
+  @MockBean private DrsResolutionService drsResolutionService;
+  @MockBean private TrackingService trackingService;
+
+  @BeforeEach
+  void setUp() {
+    SignedUrlTestUtils.setupDrsResolutionServiceMocks(
+        drsResolutionService, DRS_URI, "bucket", "path", GOOGLE_PROJECT, false);
+  }
+
+  @Test
+  void testHappyPathEmittingToBard() throws Exception {
+    String url = "/api/v4/drs/resolve";
+    postRequest(url, objectMapper.writeValueAsString(Map.of("url", DRS_URI, "fields", List.of())))
+        .andExpect(status().isOk());
+
+    verify(trackingService, times(1))
+        .logEvent(
+            TEST_BEARER_TOKEN,
+            EVENT_NAME,
+            Map.of(
+                "statusCode",
+                200,
+                "requestUrl",
+                url,
+                "url",
+                DRS_URI,
+                "fields",
+                List.of(),
+                "ip",
+                TEST_IP_ADDRESS));
+  }
+
+  @Test
+  void testDoesNotLogOn404() throws Exception {
+    postRequest(
+            "/api/v4/foo",
+            objectMapper.writeValueAsString(Map.of("url", DRS_URI, "fields", List.of())))
+        .andExpect(status().isNotFound());
+    verify(trackingService, never()).logEvent(any(BearerToken.class), anyString(), any(Map.class));
+  }
+
+  @Test
+  void testDoesNotLogOnUntrackedMethods() throws Exception {
+    getRequest(
+            "/status", objectMapper.writeValueAsString(Map.of("url", DRS_URI, "fields", List.of())))
+        .andExpect(status().isOk());
+    verify(trackingService, never()).logEvent(any(BearerToken.class), anyString(), any(Map.class));
+  }
+
+  private ResultActions postRequest(String url, String requestBody) throws Exception {
+    return mvc.perform(
+        post(url)
+            .header("authorization", "bearer " + TEST_ACCESS_TOKEN)
+            .header("X-Forwarded-For", TEST_IP_ADDRESS)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(requestBody));
+  }
+
+  private ResultActions getRequest(String url, String requestBody) throws Exception {
+    return mvc.perform(
+        get(url)
+            .header("authorization", "bearer " + TEST_ACCESS_TOKEN)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(requestBody));
+  }
+}

--- a/service/src/test/java/bio/terra/drshub/util/SignedUrlTestUtils.java
+++ b/service/src/test/java/bio/terra/drshub/util/SignedUrlTestUtils.java
@@ -82,10 +82,12 @@ public class SignedUrlTestUtils {
       String drsUri,
       String bucketName,
       String objectName,
-      String googleProject) {
+      String googleProject,
+      boolean forceAccessUrl) {
     doReturn(
             CompletableFuture.completedFuture(
                 AnnotatedResourceMetadata.builder()
+                    .requestedFields(List.of())
                     .build()
                     .gsUri("gs://" + bucketName + "/" + objectName)))
         .when(drsResolutionService)
@@ -93,7 +95,7 @@ public class SignedUrlTestUtils {
             eq(drsUri),
             any(List.class),
             any(BearerToken.class),
-            eq(true),
+            eq(forceAccessUrl),
             nullable(String.class),
             nullable(String.class));
   }


### PR DESCRIPTION
This PR:
- Adds a Bard client definition and client to send events to Bard for it to track all successful drs resolution calls.  The `EventProperties` is interesting since it's a combination of set fields and random extra values.  I needed to add a custom serializer to properly handle that
- Adds a request interceptor to asynchronously send these events (these are non-blocking so there should be no perf impact other that this will add Runnables to the async queue).  Only methods tagged with the newly created `@TrackEvent` annotation will be tracked.
- Worth calling out again: only successful drs resolutions will be logged since this is to track what files folks are using.  We should use the usual methods (e.g. grafana) for logging excessive 404s for instance
- It's configurable but by default, the flag is set to NOT send events to Mixpanel when they reach Bard so the requests will be logged in the Warehouse.

At the end of the day, this ends up sending events to Bard that look like:
```json
{
  "event": "drshub:api",
  "properties": {
    "appId": "drshub",
    "pushToMixpanel": false,
    "statusCode": 200,
    "requestUrl": "/api/v4/drs/resolve or /api/v4/gcs/getSignedUrl",
    "userProject": "<the x-user-project header value>",
    "ip": "<the X-Forwarded-For header value>",
    "forceAccessUrl": "<the drshub-force-access-url header value>"
  }
}
```

where the last three are only sent if there is a header value set. This should give us enough information (the `userProject` field in particular)

This is better reviewed commit-by-commit