### PR TITLE
ID-822 Use new Sam endpoint for Signed URLs

### DIFF
--- a/service/src/main/java/bio/terra/drshub/services/AuthService.java
+++ b/service/src/main/java/bio/terra/drshub/services/AuthService.java
@@ -6,7 +6,7 @@ import bio.terra.drshub.DrsHubException;
 import bio.terra.drshub.config.DrsProvider;
 import bio.terra.drshub.models.AccessUrlAuthEnum;
 import bio.terra.drshub.models.DrsHubAuthorization;
-import bio.terra.sam.model.ProjectSignedUrlForBlobBody;
+import bio.terra.sam.model.UserSignedUrlForBlobBody;
 import com.google.common.annotations.VisibleForTesting;
 import io.github.ga4gh.drs.model.AccessMethod;
 import io.github.ga4gh.drs.model.Authorizations;
@@ -298,15 +298,15 @@ public class AuthService {
   }
 
   public String getSignedUrlForBlob(
-      BearerToken bearerToken, String googleProject, String bucketName, String objectName) {
+      BearerToken bearerToken, String bucketName, String objectName, String requesterPaysProject) {
     var samApi = samApiFactory.getApi(bearerToken);
     var requestBody =
-        new ProjectSignedUrlForBlobBody()
+        new UserSignedUrlForBlobBody()
             .bucketName(bucketName)
             .blobName(objectName)
-            .requesterPays(false);
+            .requesterPaysProject(requesterPaysProject);
     log.info("Fetching signed URL from Sam for 'gs://{}/{}'", bucketName, objectName);
-    return samApi.signedUrlForBlob(requestBody, googleProject).replaceAll("(^\")|(\"$)", "");
+    return samApi.signedUrlForBlob(requestBody).replaceAll("(^\")|(\"$)", "");
   }
 
   @VisibleForTesting

--- a/service/src/main/java/bio/terra/drshub/services/AuthService.java
+++ b/service/src/main/java/bio/terra/drshub/services/AuthService.java
@@ -298,14 +298,11 @@ public class AuthService {
   }
 
   public String getSignedUrlForBlob(
-      BearerToken bearerToken, String bucketName, String objectName, String requesterPaysProject) {
+      BearerToken bearerToken, String gsPath, String requesterPaysProject) {
     var samApi = samApiFactory.getApi(bearerToken);
     var requestBody =
-        new UserSignedUrlForBlobBody()
-            .bucketName(bucketName)
-            .blobName(objectName)
-            .requesterPaysProject(requesterPaysProject);
-    log.info("Fetching signed URL from Sam for 'gs://{}/{}'", bucketName, objectName);
+        new UserSignedUrlForBlobBody().gsPath(gsPath).requesterPaysProject(requesterPaysProject);
+    log.info("Fetching signed URL from Sam for '{}'", gsPath);
     return samApi.signedUrlForBlob(requestBody).replaceAll("(^\")|(\"$)", "");
   }
 

--- a/service/src/main/java/bio/terra/drshub/services/SignedUrlService.java
+++ b/service/src/main/java/bio/terra/drshub/services/SignedUrlService.java
@@ -55,7 +55,7 @@ public record SignedUrlService(
 
     if (drsProvider.getAccessMethodByType(AccessMethod.TypeEnum.GS).getAuth()
         == AccessUrlAuthEnum.current_request) {
-      return getSignedUrlFromSam(bearerToken, googleProject, bucket, objectName);
+      return getSignedUrlFromSam(bearerToken, bucket, objectName, googleProject);
     } else {
       return getSignedUrlFromDrsProvider(
           bearerToken, drsProvider, googleProject, bucket, objectName, dataObjectUri, ip);
@@ -63,10 +63,10 @@ public record SignedUrlService(
   }
 
   private URL getSignedUrlFromSam(
-      BearerToken bearerToken, String googleProject, String bucketName, String blobName) {
+      BearerToken bearerToken, String bucketName, String blobName, String requesterPaysProject) {
     try {
       return new URL(
-          authService.getSignedUrlForBlob(bearerToken, googleProject, bucketName, blobName));
+          authService.getSignedUrlForBlob(bearerToken, bucketName, blobName, requesterPaysProject));
     } catch (MalformedURLException ex) {
       throw new DrsHubException("Could not parse signed URL from Sam", ex);
     }

--- a/service/src/main/java/bio/terra/drshub/services/SignedUrlService.java
+++ b/service/src/main/java/bio/terra/drshub/services/SignedUrlService.java
@@ -55,7 +55,8 @@ public record SignedUrlService(
 
     if (drsProvider.getAccessMethodByType(AccessMethod.TypeEnum.GS).getAuth()
         == AccessUrlAuthEnum.current_request) {
-      return getSignedUrlFromSam(bearerToken, bucket, objectName, googleProject);
+      return getSignedUrlFromSam(
+          bearerToken, String.format("gs://%s/%s", bucket, objectName), googleProject);
     } else {
       return getSignedUrlFromDrsProvider(
           bearerToken, drsProvider, googleProject, bucket, objectName, dataObjectUri, ip);
@@ -63,10 +64,9 @@ public record SignedUrlService(
   }
 
   private URL getSignedUrlFromSam(
-      BearerToken bearerToken, String bucketName, String blobName, String requesterPaysProject) {
+      BearerToken bearerToken, String gsPath, String requesterPaysProject) {
     try {
-      return new URL(
-          authService.getSignedUrlForBlob(bearerToken, bucketName, blobName, requesterPaysProject));
+      return new URL(authService.getSignedUrlForBlob(bearerToken, gsPath, requesterPaysProject));
     } catch (MalformedURLException ex) {
       throw new DrsHubException("Could not parse signed URL from Sam", ex);
     }

--- a/service/src/main/resources/vendor/sam.yaml
+++ b/service/src/main/resources/vendor/sam.yaml
@@ -20,7 +20,7 @@ servers:
 paths:
   /api/google/v1/user/signedUrlForBlob:
     post:
-      summary: gets a signed url for a blob using the arbitrary pet service account for the user and an optional requester pays google project
+      summary: gets a signed url for a blob using an optional requester pays google project
       tags: [ sam ]
       operationId: signedUrlForBlob
       requestBody:
@@ -30,8 +30,7 @@ paths:
             schema:
               type: object
               required:
-                - bucketName
-                - blobName
+                - gsPath
               properties:
                 gsPath:
                   type: string
@@ -45,7 +44,7 @@ paths:
                   description: Optional Google Project to bill for requester pays objects
       responses:
         200:
-          description: signed URL for the blob, signed by the Pet Service Account key
+          description: signed URL for the blob
           content:
             application/json:
               schema:
@@ -60,8 +59,7 @@ components:
           schema:
             type: object
             required:
-              - bucketName
-              - blobName
+              - gsPath
             properties:
               gsPath:
                 type: string

--- a/service/src/main/resources/vendor/sam.yaml
+++ b/service/src/main/resources/vendor/sam.yaml
@@ -18,19 +18,11 @@ servers:
     description: Development
 
 paths:
-  /api/google/v1/user/petServiceAccount/{project}/signedUrlForBlob:
+  /api/google/v1/user/signedUrlForBlob:
     post:
-      summary: gets a signed url for a blob using the pet service account for the user in the provided project
+      summary: gets a signed url for a blob using the arbitrary pet service account for the user and an optional requester pays google project
       tags: [ sam ]
       operationId: signedUrlForBlob
-      parameters:
-        - name: project
-          in: path
-          required: true
-          description: The Google Project to get the Pet Service Account from for URL signing.
-          schema:
-            type: string
-            example: terra-abcd1234
       requestBody:
         required: true
         content:
@@ -51,10 +43,9 @@ paths:
                   type: number
                   description: Optional validity duration of the link in minutes. Defaults to 1 hour.
                   default: 60
-                requesterPays:
-                  type: boolean
-                  description: Use the pet service account project as the user project in the request.
-                  default: true
+                requesterPaysProject:
+                  type: string
+                  description: Optional Google Project to bill for requester pays objects
       responses:
         200:
           description: signed URL for the blob, signed by the Pet Service Account key
@@ -85,10 +76,9 @@ components:
                 type: number
                 description: Optional validity duration of the link in minutes. Defaults to 1 hour.
                 default: 60
-              requesterPays:
-                type: boolean
-                description: Use the pet service account project as the user project in the request.
-                default: true
+              requesterPaysProject:
+                type: string
+                description: Optional Google Project to bill for requester pays objects
   securitySchemes:
     authorization:
       type: oauth2

--- a/service/src/main/resources/vendor/sam.yaml
+++ b/service/src/main/resources/vendor/sam.yaml
@@ -33,12 +33,9 @@ paths:
                 - bucketName
                 - blobName
               properties:
-                bucketName:
+                gsPath:
                   type: string
-                  description: bucket of the blob
-                blobName:
-                  type: string
-                  description: path to the blob in the bucket
+                  description: GS Path to the blob
                 duration:
                   type: number
                   description: Optional validity duration of the link in minutes. Defaults to 1 hour.
@@ -66,12 +63,9 @@ components:
               - bucketName
               - blobName
             properties:
-              bucketName:
+              gsPath:
                 type: string
-                description: bucket of the blob
-              blobName:
-                type: string
-                description: path to the blob in the bucket
+                description: GS Path to the blob
               duration:
                 type: number
                 description: Optional validity duration of the link in minutes. Defaults to 1 hour.

--- a/service/src/test/java/bio/terra/drshub/services/AuthServiceTest.java
+++ b/service/src/test/java/bio/terra/drshub/services/AuthServiceTest.java
@@ -15,7 +15,7 @@ import bio.terra.drshub.models.DrsApi;
 import bio.terra.drshub.models.DrsHubAuthorization;
 import bio.terra.externalcreds.api.OidcApi;
 import bio.terra.sam.api.SamApi;
-import bio.terra.sam.model.ProjectSignedUrlForBlobBody;
+import bio.terra.sam.model.UserSignedUrlForBlobBody;
 import io.github.ga4gh.drs.model.AccessMethod;
 import io.github.ga4gh.drs.model.Authorizations;
 import java.util.List;
@@ -205,14 +205,14 @@ class AuthServiceTest extends BaseTest {
 
     when(samApiFactory.getApi(eq(bearerToken))).thenReturn(samApi);
     var body =
-        new ProjectSignedUrlForBlobBody()
+        new UserSignedUrlForBlobBody()
             .bucketName(bucketName)
             .blobName(objectName)
-            .requesterPays(false);
-    when(samApi.signedUrlForBlob(eq(body), eq(googleProject))).thenReturn("\"" + url + "\"");
+            .requesterPaysProject(googleProject);
+    when(samApi.signedUrlForBlob(eq(body))).thenReturn("\"" + url + "\"");
 
     var signedUrl =
-        authService.getSignedUrlForBlob(bearerToken, googleProject, bucketName, objectName);
+        authService.getSignedUrlForBlob(bearerToken, bucketName, objectName, googleProject);
     assertEquals(url, signedUrl);
   }
 }

--- a/service/src/test/java/bio/terra/drshub/services/AuthServiceTest.java
+++ b/service/src/test/java/bio/terra/drshub/services/AuthServiceTest.java
@@ -199,20 +199,16 @@ class AuthServiceTest extends BaseTest {
   public void testSamSignsGsUrls() {
     var bucketName = "my-test-bucket";
     var objectName = "my-test-folder/my-test-object.txt";
+    var gsPath = "gs://" + bucketName + "/" + objectName;
     var googleProject = "test-google-project";
     var url = "https://storage.cloud.google.com" + "/" + bucketName + "/" + objectName;
     var bearerToken = new BearerToken("12345");
 
     when(samApiFactory.getApi(eq(bearerToken))).thenReturn(samApi);
-    var body =
-        new UserSignedUrlForBlobBody()
-            .bucketName(bucketName)
-            .blobName(objectName)
-            .requesterPaysProject(googleProject);
+    var body = new UserSignedUrlForBlobBody().gsPath(gsPath).requesterPaysProject(googleProject);
     when(samApi.signedUrlForBlob(eq(body))).thenReturn("\"" + url + "\"");
 
-    var signedUrl =
-        authService.getSignedUrlForBlob(bearerToken, bucketName, objectName, googleProject);
+    var signedUrl = authService.getSignedUrlForBlob(bearerToken, gsPath, googleProject);
     assertEquals(url, signedUrl);
   }
 }

--- a/service/src/test/java/bio/terra/drshub/services/SignedUrlServiceTest.java
+++ b/service/src/test/java/bio/terra/drshub/services/SignedUrlServiceTest.java
@@ -81,7 +81,7 @@ public class SignedUrlServiceTest extends BaseTest {
   void testFailsToParseInvalidURLsFromSam() {
 
     when(authService.getSignedUrlForBlob(
-            any(BearerToken.class), any(String.class), any(String.class), any(String.class)))
+            any(BearerToken.class), any(String.class), any(String.class)))
         .thenReturn("not_a_valid_url");
 
     var drsUri = "drs://drs.anv0:1234/456/2315asd";

--- a/service/src/test/java/bio/terra/drshub/util/SignedUrlTestUtils.java
+++ b/service/src/test/java/bio/terra/drshub/util/SignedUrlTestUtils.java
@@ -72,8 +72,8 @@ public class SignedUrlTestUtils {
       String objectName,
       URL url) {
 
-    when(authService.getSignedUrlForBlob(
-            any(BearerToken.class), eq(bucketName), eq(objectName), eq(googleProject)))
+    var gsPath = String.format("gs://%s/%s", bucketName, objectName);
+    when(authService.getSignedUrlForBlob(any(BearerToken.class), eq(gsPath), eq(googleProject)))
         .thenReturn(url.toString());
   }
 

--- a/service/src/test/java/bio/terra/drshub/util/SignedUrlTestUtils.java
+++ b/service/src/test/java/bio/terra/drshub/util/SignedUrlTestUtils.java
@@ -97,7 +97,7 @@ public class SignedUrlTestUtils {
             any(BearerToken.class),
             eq(forceAccessUrl),
             nullable(String.class),
-            eq(googleProject));
+            nullable(String.class));
   }
 
   public static String generateSaKeyObjectString()

--- a/service/src/test/java/bio/terra/drshub/util/SignedUrlTestUtils.java
+++ b/service/src/test/java/bio/terra/drshub/util/SignedUrlTestUtils.java
@@ -73,7 +73,7 @@ public class SignedUrlTestUtils {
       URL url) {
 
     when(authService.getSignedUrlForBlob(
-            any(BearerToken.class), eq(googleProject), eq(bucketName), eq(objectName)))
+            any(BearerToken.class), eq(bucketName), eq(objectName), eq(googleProject)))
         .thenReturn(url.toString());
   }
 
@@ -95,7 +95,7 @@ public class SignedUrlTestUtils {
             any(BearerToken.class),
             eq(true),
             nullable(String.class),
-            nullable(String.class));
+            eq(googleProject));
   }
 
   public static String generateSaKeyObjectString()


### PR DESCRIPTION
A new Signed URL Endpoint is being created in Sam to correctly handle signed urls for requester-pays buckets. DRSHub should use it.

https://github.com/broadinstitute/sam/pull/1193