### PR TITLE
[DR-3324] Only fetch DRS object via passport if one exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,10 +80,13 @@ Some architecture diagrams can be found in [LucidChart](https://lucid.app/docume
 ### Setup
 Install Java 17 SDK from your preferred provider. A common way to install and manage different JDK versions is to use [sdkman](https://sdkman.io/).
 
-If developing in IntelliJ, you can just configure the Project SDK to use Java 17.
+If developing in IntelliJ, you can configure the Project SDK to use Java 17.
 You'll also need to set the Gradle JVM, located at `Preferences | Build, Execution, Deployment | Build Tools | Gradle`.
 
-You must use [git-secrets](https://github.com/awslabs/git-secrets). You should be doing this anyway for all of your repositories.
+You must use [git-secrets](https://github.com/awslabs/git-secrets) to protect against committing passwords
+or other sensitive information ot this repository.  The linked repository gives instructions for
+installing and setting it up.
+
 DrsHub uses [Minnie Kenny](https://minnie-kenny.readthedocs.io/en/latest/), and is configured to run `minnie_kenny.sh` on `./gradlew test` tasks, ensuring that git-secrets is set up.
 You can also run it manually to make sure `git-secrets` is set up without testing.
 
@@ -93,7 +96,7 @@ DrsHub uses Gradle as a build tool. Some common Gradle commands you may want to 
 ```shell
 ./gradlew generateSwaggerCode # Generate Swagger code for models and Swagger UI
 ./gradlew bootRun # Run DrsHub locally (Swagger UI at localhost:8080)
-./gradlew unitTest # Run the unit tests
+./gradlew test # Run the unit tests
 ./gradlew jib # Build the DrsHub Docker image
 ```
 

--- a/README.md
+++ b/README.md
@@ -136,6 +136,9 @@ DrsHub runs in Kubernetes in GCP. Current deployments for each env can be found 
 - Staging
   - [Kubernetes Deployment](https://console.cloud.google.com/kubernetes/deployment/us-central1-a/terra-staging/terra-staging/drshub-deployment/overview?project=broad-dsde-staging)
   - [Swagger UI](https://drshub.dsde-staging.broadinstitute.org/)
+- Production
+  - [Kubernetes Deployment](https://console.cloud.google.com/kubernetes/deployment/us-central1-a/terra-prod/terra-prod/drshub-deployment/overview?project=broad-dsde-prod)
+  - [Swagger UI](https://drshub.dsde-prod.broadinstitute.org/)
 
 ### DRS Provider Compact ID/URIs per Environment
 

--- a/service/src/main/java/bio/terra/drshub/services/DrsResolutionService.java
+++ b/service/src/main/java/bio/terra/drshub/services/DrsResolutionService.java
@@ -234,15 +234,15 @@ public class DrsResolutionService {
       drsApi.setBearerToken(bearerToken.getToken());
       if (authorizations.stream()
           .anyMatch(a -> a.drsAuthType() == Authorizations.SupportedTypesEnum.PASSPORTAUTH)) {
-        List<String> passports = authService.fetchPassports(bearerToken).orElse(List.of());
-        if (!passports.isEmpty()) {
-          try {
+        try {
+          List<String> passports = authService.fetchPassports(bearerToken).orElse(List.of());
+          if (!passports.isEmpty()) {
             return drsApi.postObject(Map.of("passports", passports), objectId);
-          } catch (Exception ex) {
-            // We are catching a general exception to ensure that we fall back to getting the object
-            // via bearer token in case of any failure
-            log.warn(drsRequestLogMessage + " failed via passport, using bearer token", ex);
           }
+        } catch (Exception ex) {
+          // We are catching a general exception to ensure that we fall back to getting the object
+          // via bearer token in case of any failure
+          log.warn(drsRequestLogMessage + " failed via passport, using bearer token", ex);
         }
       }
     }

--- a/service/src/main/java/bio/terra/drshub/services/DrsResolutionService.java
+++ b/service/src/main/java/bio/terra/drshub/services/DrsResolutionService.java
@@ -13,6 +13,7 @@ import bio.terra.drshub.models.AnnotatedResourceMetadata;
 import bio.terra.drshub.models.DrsHubAuthorization;
 import bio.terra.drshub.models.DrsMetadata;
 import bio.terra.drshub.models.Fields;
+import com.google.common.annotations.VisibleForTesting;
 import io.github.ga4gh.drs.model.AccessMethod;
 import io.github.ga4gh.drs.model.AccessMethod.TypeEnum;
 import io.github.ga4gh.drs.model.AccessURL;
@@ -211,7 +212,8 @@ public class DrsResolutionService {
     }
   }
 
-  private DrsObject fetchObjectInfo(
+  @VisibleForTesting
+  DrsObject fetchObjectInfo(
       DrsProvider drsProvider,
       UriComponents uriComponents,
       String drsUri,

--- a/service/src/test/java/bio/terra/drshub/services/DrsResolutionServiceTest.java
+++ b/service/src/test/java/bio/terra/drshub/services/DrsResolutionServiceTest.java
@@ -1,0 +1,186 @@
+package bio.terra.drshub.services;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import bio.terra.common.iam.BearerToken;
+import bio.terra.drshub.config.DrsProvider;
+import bio.terra.drshub.logging.AuditLogger;
+import bio.terra.drshub.models.DrsApi;
+import bio.terra.drshub.models.DrsHubAuthorization;
+import io.github.ga4gh.drs.model.Authorizations.SupportedTypesEnum;
+import io.github.ga4gh.drs.model.DrsObject;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.Executor;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.util.UriComponents;
+
+@Tag("Unit")
+@ContextConfiguration(classes = {DrsResolutionService.class})
+@SpringBootTest
+class DrsResolutionServiceTest {
+
+  @MockBean private DrsApiFactory drsApiFactory;
+  @MockBean private DrsProviderService drsProviderService;
+  @MockBean private AuthService authService;
+  @MockBean private AuditLogger auditLogger;
+  @MockBean private Executor asyncExecutor;
+  @Autowired DrsResolutionService drsResolutionService;
+
+  @Mock private DrsApi drsApi;
+  @Mock private UriComponents uriComponents;
+
+  private static final String PATH = "path";
+
+  private static final DrsProvider DRS_PROVIDER_UNAUTH =
+      DrsProvider.create().setMetadataAuth(false);
+  private static final DrsProvider DRS_PROVIDER_AUTH = DrsProvider.create().setMetadataAuth(true);
+
+  private static final BearerToken TOKEN = new BearerToken("token");
+  private static final List<String> PASSPORTS = List.of("passport");
+  private static final DrsHubAuthorization PASSPORTAUTH =
+      new DrsHubAuthorization(SupportedTypesEnum.PASSPORTAUTH, null);
+  private static final DrsHubAuthorization BEARERAUTH =
+      new DrsHubAuthorization(SupportedTypesEnum.BEARERAUTH, null);
+  private static final DrsObject DRS_OBJECT = new DrsObject().id("drs.id");
+
+  @BeforeEach
+  void before() {
+    when(uriComponents.getHost()).thenReturn("host.com");
+    when(uriComponents.getPath()).thenReturn(PATH);
+    when(drsApiFactory.getApiFromUriComponents(eq(uriComponents), any(DrsProvider.class)))
+        .thenReturn(drsApi);
+  }
+
+  @Test
+  void fetchObjectInfo_noMetadataAuth() {
+    when(drsApi.getObject(PATH, null)).thenReturn(DRS_OBJECT);
+
+    var actual =
+        drsResolutionService.fetchObjectInfo(
+            DRS_PROVIDER_UNAUTH, uriComponents, "drsUri", TOKEN, List.of(PASSPORTAUTH, BEARERAUTH));
+
+    // When authorization isn't required, we don't pass the bearer token to the API.
+    verify(drsApi, never()).setBearerToken(any());
+    // When authorization isn't required, we don't obtain RAS passports.
+    verifyNoInteractions(authService);
+    verify(drsApi, never()).postObject(any(), any());
+
+    assertThat(
+        "Object fetched via getObject without token when authorization not required",
+        actual,
+        equalTo(DRS_OBJECT));
+  }
+
+  @Test
+  void fetchObjectInfo_passportUnsupported() {
+    when(drsApi.getObject(PATH, null)).thenReturn(DRS_OBJECT);
+
+    var actual =
+        drsResolutionService.fetchObjectInfo(
+            DRS_PROVIDER_AUTH, uriComponents, "drsUri", TOKEN, List.of(BEARERAUTH));
+
+    // When authorization is required, we pass the bearer token to the API.
+    verify(drsApi).setBearerToken(TOKEN.getToken());
+    // When RAS passports are not a supported means of authorization, we don't obtain them.
+    verifyNoInteractions(authService);
+    verify(drsApi, never()).postObject(any(), any());
+
+    assertThat(
+        "Object fetched via getObject with token when passport unsupported",
+        actual,
+        equalTo(DRS_OBJECT));
+  }
+
+  private static Stream<Arguments> fetchObjectInfo_passportUnavailable() {
+    return Stream.of(Arguments.arguments(Optional.empty(), Optional.of(List.of())));
+  }
+
+  @ParameterizedTest
+  @MethodSource
+  void fetchObjectInfo_passportUnavailable(Optional<List<String>> passports) {
+    when(authService.fetchPassports(TOKEN)).thenReturn(passports);
+    when(drsApi.getObject(PATH, null)).thenReturn(DRS_OBJECT);
+
+    var actual =
+        drsResolutionService.fetchObjectInfo(
+            DRS_PROVIDER_AUTH, uriComponents, "drsUri", TOKEN, List.of(BEARERAUTH, PASSPORTAUTH));
+
+    // When authorization is required, we pass the bearer token to the API.
+    verify(drsApi).setBearerToken(TOKEN.getToken());
+    // When RAS passports are a supported means of authorization, we obtain them.
+    verify(authService).fetchPassports(TOKEN);
+    verify(drsApi, never()).postObject(any(), any());
+
+    assertThat(
+        "Object fetched via getObject with token when passport supported but not available",
+        actual,
+        equalTo(DRS_OBJECT));
+  }
+
+  @Test
+  void fetchObjectInfo_passport() {
+    when(authService.fetchPassports(TOKEN)).thenReturn(Optional.of(PASSPORTS));
+    when(drsApi.postObject(Map.of("passports", PASSPORTS), PATH)).thenReturn(DRS_OBJECT);
+
+    var actual =
+        drsResolutionService.fetchObjectInfo(
+            DRS_PROVIDER_AUTH, uriComponents, "drsUri", TOKEN, List.of(BEARERAUTH, PASSPORTAUTH));
+
+    // When authorization is required, we pass the bearer token to the API.
+    verify(drsApi).setBearerToken(TOKEN.getToken());
+    // When RAS passports are a supported means of authorization, we obtain them.
+    verify(authService).fetchPassports(TOKEN);
+    // When fetching the object via POSTed passports succeeds, we don't attempt to fetch it via
+    // bearer token.
+    verify(drsApi, never()).getObject(any(), any());
+
+    assertThat(
+        "Object fetched via POSTed passport when passport supported and available",
+        actual,
+        equalTo(DRS_OBJECT));
+  }
+
+  @Test
+  void fetchObjectInfo_failedPassportFallsBackToBearerToken() {
+    when(authService.fetchPassports(TOKEN)).thenReturn(Optional.of(PASSPORTS));
+    when(drsApi.postObject(Map.of("passports", PASSPORTS), PATH))
+        .thenThrow(RestClientException.class);
+    when(drsApi.getObject(PATH, null)).thenReturn(DRS_OBJECT);
+
+    var actual =
+        drsResolutionService.fetchObjectInfo(
+            DRS_PROVIDER_AUTH, uriComponents, "drsUri", TOKEN, List.of(BEARERAUTH, PASSPORTAUTH));
+
+    // When authorization is required, we pass the bearer token to the API.
+    verify(drsApi).setBearerToken(TOKEN.getToken());
+    // When RAS passports are a supported means of authorization, we obtain them.
+    verify(authService).fetchPassports(TOKEN);
+    verify(drsApi).postObject(Map.of("passports", PASSPORTS), PATH);
+
+    assertThat(
+        "When fetching Object via POSTed passport fails, fal back to getObject with token",
+        actual,
+        equalTo(DRS_OBJECT));
+  }
+}


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DR-3324

`DrsHub` asks TDR Production for the supported authorization mechanisms for a controlled access GTEx file:
```
curl -X 'OPTIONS' \
  'https://data.terra.bio/ga4gh/drs/v1/objects/v2_e559f418-7452-31c2-94fe-ed412157363d' \
  -H 'accept: application/json'

{
  "supported_types": [
    "PassportAuth",
    "BearerAuth"
  ],
  "passport_auth_issuers": [
    "https://stsstg.nih.gov/"
  ],
  "bearer_auth_issuers": null
}
```
Seeing that PassportAuth is a supported type (dictated by the presence of both a PHS ID and consent code on the source snapshot), it tries to obtain a passport to use for fetching the DRS object.

**Previous behavior**

In cases where DRS OPTIONS indicate `PassportAuth` as a supported means of authorization, if a user Passport is not available, then DrsHub passed an empty string as a Passport when attempting object resolution.

But the empty string is not a valid Passport: when DrsHub passed it to TDR, TDR passed it to the ECM client for decoding.  ECM then throws an unhandled error:
```
{
  "message" : "500 Internal Server Error: \"{\"msg\":\"400 Bad Request: \\\"{<EOL>  \\\"message\\\" : \\\"invalid passport jwt\\\",<EOL>  \\\"statusCode\\\" : 400<EOL>}\\\"\",\"status_code\":500}\"",
  "statusCode" : 500
}
```

Furthermore, DrsHub did not fall back to fetching the object via bearer token.

**New behavior**

In cases where DRS OPTIONS indicate `PassportAuth` as a supported means of authorization, DrsHub only attempts to fetch the object via POSTed passport if such a passport exists.

If any part of this fails, DrsHub now falls back to fetching the object via bearer token.

**Tests**

I added targeted unit tests covering DRS object fetching, but there were no previous unit tests for `DrsResolutionService`: I believe this code remains largely uncovered by automated tests, but am also still finding my way around this repo.