### PR TITLE
[DR-3228] Specify which cloud to resolve from

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Request bodies should look like
 ```json
 {
   "url": "string",
+  "cloudPlatform": ["gs", "azure","s3", null],
   "fields": ["string"]
 }
 ```

--- a/README.md
+++ b/README.md
@@ -71,6 +71,9 @@ timeUpdated
 googleServiceAccount
 ```
 
+The `cloudPlatform` field is optional and can be used to specify the preferred cloud platform to use for returning a signed URL.
+If no option is found for the specified cloud platform, an attempt will be made to return a signed URL from a fall-back cloud platform.
+
 ## Architecture
 DrsHub is a Java 17 Spring Boot application running in Kubernetes. As it simply resolves urls and doesn't have any state, it has no database. For developer convenience, a Swagger UI is provided.
 

--- a/common/openapi.yml
+++ b/common/openapi.yml
@@ -188,12 +188,19 @@ components:
       required: [url]
       properties:
         url:
+          description: The DRS URL to resolve
           type: string
         cloudPlatform:
+          description: Which cloud platform to prefer when resolving a DRS URL (options include "gs", "azure", and "s3").
+           If an access url does not exist in that cloud platform, an alternative will be returned if one exists. If
+           this field is not specified, the first access url found will be returned.
           type: string
           nullable: true
           enum: [azure, gs, s3]
         fields:
+          description: Which information to include about the Drs Object. By default the response includes
+           bucket, contentType, fileName, gsUri, hashes, localizationPath, name, size, timeCreated, timeUpdated
+           and googleServiceAccount. The accessUrl and bondProvider will only be included if specified.
           type: array
           items:
             type: string

--- a/common/openapi.yml
+++ b/common/openapi.yml
@@ -192,7 +192,7 @@ components:
         resolveFrom:
           type: string
           nullable: true
-          enum: [aws, azure, gs]
+          enum: [azure, gs, s3]
         fields:
           type: array
           items:

--- a/common/openapi.yml
+++ b/common/openapi.yml
@@ -22,9 +22,9 @@ paths:
           $ref: '#/components/responses/ServerError'
   /api/v4/gcs/getSignedUrl:
     post:
-      summary: Get a signed URL for a GCS Object, signed the caller's fence service account. 
+      summary: Get a signed URL for a GCS Object, signed the caller's fence service account.
         The signed URL is active for 1 hour.
-        The bucket and object in the request body are optional, but providing them allows DRSHub to bypass the 
+        The bucket and object in the request body are optional, but providing them allows DRSHub to bypass the
         DRS object resolution and to just sign the URL using the fence account associated with the DRS Provider
         in the dataObjectUri.
       tags: [ gcs ]
@@ -189,6 +189,10 @@ components:
       properties:
         url:
           type: string
+        resolveFrom:
+          type: string
+          nullable: true
+          enum: [aws, azure, gs]
         fields:
           type: array
           items:

--- a/common/openapi.yml
+++ b/common/openapi.yml
@@ -189,7 +189,7 @@ components:
       properties:
         url:
           type: string
-        resolveFrom:
+        cloudPlatform:
           type: string
           nullable: true
           enum: [azure, gs, s3]

--- a/service/src/main/java/bio/terra/drshub/controllers/DrsHubApiController.java
+++ b/service/src/main/java/bio/terra/drshub/controllers/DrsHubApiController.java
@@ -40,7 +40,7 @@ public record DrsHubApiController(
     return asyncUtils.runAndCatch(
         drsResolutionService.resolveDrsObject(
             body.getUrl(),
-            body.getResolveFrom(),
+            body.getCloudPlatform(),
             body.getFields(),
             bearerToken,
             forceAccessUrl,

--- a/service/src/main/java/bio/terra/drshub/controllers/DrsHubApiController.java
+++ b/service/src/main/java/bio/terra/drshub/controllers/DrsHubApiController.java
@@ -39,7 +39,13 @@ public record DrsHubApiController(
     log.info("Received URL {} from agent {} on IP {}", body.getUrl(), userAgent, ip);
     return asyncUtils.runAndCatch(
         drsResolutionService.resolveDrsObject(
-            body.getUrl(), body.getFields(), bearerToken, forceAccessUrl, ip, googleProject),
+            body.getUrl(),
+            body.getResolveFrom(),
+            body.getFields(),
+            bearerToken,
+            forceAccessUrl,
+            ip,
+            googleProject),
         ResponseEntity::ok);
   }
 

--- a/service/src/main/java/bio/terra/drshub/services/DrsResolutionService.java
+++ b/service/src/main/java/bio/terra/drshub/services/DrsResolutionService.java
@@ -249,7 +249,8 @@ public class DrsResolutionService {
     return drsApi.getObject(objectId, null);
   }
 
-  private AccessURL fetchDrsObjectAccessUrl(
+  @VisibleForTesting
+  AccessURL fetchDrsObjectAccessUrl(
       DrsProvider drsProvider,
       UriComponents uriComponents,
       String accessId,

--- a/service/src/main/java/bio/terra/drshub/services/DrsResolutionService.java
+++ b/service/src/main/java/bio/terra/drshub/services/DrsResolutionService.java
@@ -316,7 +316,7 @@ public class DrsResolutionService {
       }
       // if there is no access method matching the resolveFrom cloud, or
       // if the resolveFrom cloud was not specified, return a different access method
-      if (accessMethod.isEmpty() & !accessMethods.isEmpty()) {
+      if (accessMethod.isEmpty() && !accessMethods.isEmpty()) {
         accessMethod = Optional.of(accessMethods.get(0));
       }
     }

--- a/service/src/main/java/bio/terra/drshub/services/SignedUrlService.java
+++ b/service/src/main/java/bio/terra/drshub/services/SignedUrlService.java
@@ -5,7 +5,7 @@ import bio.terra.common.iam.BearerToken;
 import bio.terra.drshub.DrsHubException;
 import bio.terra.drshub.config.DrsHubConfig;
 import bio.terra.drshub.config.DrsProvider;
-import bio.terra.drshub.generated.model.RequestObject.ResolveFromEnum;
+import bio.terra.drshub.generated.model.RequestObject.CloudPlatformEnum;
 import bio.terra.drshub.logging.AuditLogEvent;
 import bio.terra.drshub.logging.AuditLogEventType;
 import bio.terra.drshub.logging.AuditLogger;
@@ -104,7 +104,7 @@ public record SignedUrlService(
     var objectFuture =
         drsResolutionService.resolveDrsObject(
             dataObjectUri,
-            ResolveFromEnum.GS,
+            CloudPlatformEnum.GS,
             Fields.CORE_FIELDS,
             bearerToken,
             true,

--- a/service/src/main/java/bio/terra/drshub/services/SignedUrlService.java
+++ b/service/src/main/java/bio/terra/drshub/services/SignedUrlService.java
@@ -5,6 +5,7 @@ import bio.terra.common.iam.BearerToken;
 import bio.terra.drshub.DrsHubException;
 import bio.terra.drshub.config.DrsHubConfig;
 import bio.terra.drshub.config.DrsProvider;
+import bio.terra.drshub.generated.model.RequestObject.ResolveFromEnum;
 import bio.terra.drshub.logging.AuditLogEvent;
 import bio.terra.drshub.logging.AuditLogEventType;
 import bio.terra.drshub.logging.AuditLogger;
@@ -102,7 +103,13 @@ public record SignedUrlService(
       String dataObjectUri, BearerToken bearerToken, String ip, String googleProject) {
     var objectFuture =
         drsResolutionService.resolveDrsObject(
-            dataObjectUri, Fields.CORE_FIELDS, bearerToken, true, ip, googleProject);
+            dataObjectUri,
+            ResolveFromEnum.GS,
+            Fields.CORE_FIELDS,
+            bearerToken,
+            true,
+            ip,
+            googleProject);
     return asyncUtils.runAndCatch(objectFuture, result -> BlobId.fromGsUtilUri(result.getGsUri()));
   }
 }

--- a/service/src/main/java/bio/terra/drshub/util/AccessMethodUtils.java
+++ b/service/src/main/java/bio/terra/drshub/util/AccessMethodUtils.java
@@ -26,7 +26,7 @@ public class AccessMethodUtils {
       // if there is no access method matching the cloudPlatform, or
       // if the cloudPlatform was not specified, return the first access method
       if (accessMethod.isEmpty() && !accessMethods.isEmpty()) {
-        accessMethod = Optional.of(accessMethods.get(0));
+        accessMethod = accessMethods.stream().findFirst();
       }
     }
     return accessMethod;

--- a/service/src/main/java/bio/terra/drshub/util/AccessMethodUtils.java
+++ b/service/src/main/java/bio/terra/drshub/util/AccessMethodUtils.java
@@ -1,0 +1,58 @@
+package bio.terra.drshub.util;
+
+import static org.apache.commons.lang3.ObjectUtils.isEmpty;
+
+import bio.terra.drshub.config.DrsProvider;
+import bio.terra.drshub.generated.model.RequestObject.CloudPlatformEnum;
+import io.github.ga4gh.drs.model.AccessMethod;
+import io.github.ga4gh.drs.model.DrsObject;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Predicate;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+public class AccessMethodUtils {
+  public static Optional<AccessMethod> getAccessMethod(
+      DrsObject drsResponse, DrsProvider drsProvider, CloudPlatformEnum cloudPlatform) {
+    Optional<AccessMethod> accessMethod = Optional.empty();
+    if (!isEmpty(drsResponse)) {
+      List<AccessMethod> accessMethods = getAccessMethods(drsResponse, drsProvider);
+      if (cloudPlatform != null) {
+        accessMethod = getAccessMethodForCloud(accessMethods, cloudPlatform);
+      }
+      // if there is no access method matching the cloudPlatform, or
+      // if the cloudPlatform was not specified, return a different access method
+      if (accessMethod.isEmpty() && !accessMethods.isEmpty()) {
+        accessMethod = Optional.of(accessMethods.get(0));
+      }
+    }
+    return accessMethod;
+  }
+
+  public static Optional<AccessMethod> getAccessMethodForCloud(
+      List<AccessMethod> accessMethods, CloudPlatformEnum cloudPlatform) {
+    Predicate<AccessMethod> filter;
+    if (cloudPlatform.equals(CloudPlatformEnum.AZURE)) {
+      filter = m -> m.getAccessId() != null && m.getAccessId().startsWith("az");
+    } else {
+      filter = m -> m.getType().toString().equals(cloudPlatform.toString());
+    }
+    return accessMethods.stream().filter(filter).findFirst();
+  }
+
+  public static List<AccessMethod> getAccessMethods(
+      DrsObject drsResponse, DrsProvider drsProvider) {
+    if (isEmpty(drsResponse)) {
+      return List.of();
+    }
+    return drsProvider.getAccessMethodConfigs().stream()
+        .flatMap(
+            methodConfig ->
+                drsResponse.getAccessMethods().stream()
+                    .filter(m -> methodConfig.getType().getReturnedEquivalent() == m.getType()))
+        .toList();
+  }
+}

--- a/service/src/main/java/bio/terra/drshub/util/AccessMethodUtils.java
+++ b/service/src/main/java/bio/terra/drshub/util/AccessMethodUtils.java
@@ -36,6 +36,7 @@ public class AccessMethodUtils {
       List<AccessMethod> accessMethods, CloudPlatformEnum cloudPlatform) {
     Predicate<AccessMethod> filter;
     if (cloudPlatform.equals(CloudPlatformEnum.AZURE)) {
+      // Note: Only the Terra Data Repo drs provider prefixes Azure access ids with "az"
       filter = m -> m.getAccessId() != null && m.getAccessId().startsWith("az");
     } else {
       filter = m -> m.getType().toString().equals(cloudPlatform.toString());

--- a/service/src/main/java/bio/terra/drshub/util/AccessMethodUtils.java
+++ b/service/src/main/java/bio/terra/drshub/util/AccessMethodUtils.java
@@ -24,7 +24,7 @@ public class AccessMethodUtils {
         accessMethod = getAccessMethodForCloud(accessMethods, cloudPlatform);
       }
       // if there is no access method matching the cloudPlatform, or
-      // if the cloudPlatform was not specified, return a different access method
+      // if the cloudPlatform was not specified, return the first access method
       if (accessMethod.isEmpty() && !accessMethods.isEmpty()) {
         accessMethod = Optional.of(accessMethods.get(0));
       }

--- a/service/src/test/java/bio/terra/drshub/controllers/DrsHubApiControllerTest.java
+++ b/service/src/test/java/bio/terra/drshub/controllers/DrsHubApiControllerTest.java
@@ -692,10 +692,10 @@ public class DrsHubApiControllerTest extends BaseTest {
   private void postDrsHubRequestAccessUrlSuccess(ProviderHosts cidProviderHost, String drsObjectId)
       throws Exception {
     postDrsHubRequest(
-        TEST_ACCESS_TOKEN,
-        cidProviderHost.compactUriPrefix(),
-        drsObjectId,
-        List.of(Fields.ACCESS_URL))
+            TEST_ACCESS_TOKEN,
+            cidProviderHost.compactUriPrefix(),
+            drsObjectId,
+            List.of(Fields.ACCESS_URL))
         .andExpect(status().isOk())
         .andExpect(
             content()

--- a/service/src/test/java/bio/terra/drshub/controllers/GcsApiControllerTest.java
+++ b/service/src/test/java/bio/terra/drshub/controllers/GcsApiControllerTest.java
@@ -7,6 +7,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import bio.terra.common.iam.BearerToken;
 import bio.terra.drshub.BaseTest;
+import bio.terra.drshub.generated.model.RequestObject.ResolveFromEnum;
 import bio.terra.drshub.models.Fields;
 import bio.terra.drshub.services.AuthService;
 import bio.terra.drshub.services.DrsResolutionService;
@@ -69,6 +70,7 @@ public class GcsApiControllerTest extends BaseTest {
     verify(drsResolutionService)
         .resolveDrsObject(
             eq(drsUri),
+            eq(ResolveFromEnum.GS),
             eq(Fields.CORE_FIELDS),
             eq(new BearerToken(TEST_ACCESS_TOKEN)),
             eq(true),

--- a/service/src/test/java/bio/terra/drshub/controllers/GcsApiControllerTest.java
+++ b/service/src/test/java/bio/terra/drshub/controllers/GcsApiControllerTest.java
@@ -7,7 +7,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import bio.terra.common.iam.BearerToken;
 import bio.terra.drshub.BaseTest;
-import bio.terra.drshub.generated.model.RequestObject.ResolveFromEnum;
+import bio.terra.drshub.generated.model.RequestObject.CloudPlatformEnum;
 import bio.terra.drshub.models.Fields;
 import bio.terra.drshub.services.AuthService;
 import bio.terra.drshub.services.DrsResolutionService;
@@ -70,7 +70,7 @@ public class GcsApiControllerTest extends BaseTest {
     verify(drsResolutionService)
         .resolveDrsObject(
             eq(drsUri),
-            eq(ResolveFromEnum.GS),
+            eq(CloudPlatformEnum.GS),
             eq(Fields.CORE_FIELDS),
             eq(new BearerToken(TEST_ACCESS_TOKEN)),
             eq(true),

--- a/service/src/test/java/bio/terra/drshub/services/DrsResolutionServiceTest.java
+++ b/service/src/test/java/bio/terra/drshub/services/DrsResolutionServiceTest.java
@@ -12,11 +12,20 @@ import static org.mockito.Mockito.when;
 
 import bio.terra.common.iam.BearerToken;
 import bio.terra.drshub.config.DrsProvider;
+import bio.terra.drshub.config.ProviderAccessMethodConfig;
+import bio.terra.drshub.logging.AuditLogEvent;
 import bio.terra.drshub.logging.AuditLogger;
+import bio.terra.drshub.models.AccessMethodConfigTypeEnum;
+import bio.terra.drshub.models.AccessUrlAuthEnum;
 import bio.terra.drshub.models.DrsApi;
 import bio.terra.drshub.models.DrsHubAuthorization;
+import bio.terra.drshub.util.SignedUrlTestUtils;
+import io.github.ga4gh.drs.model.AccessMethod.TypeEnum;
+import io.github.ga4gh.drs.model.AccessURL;
 import io.github.ga4gh.drs.model.Authorizations.SupportedTypesEnum;
 import io.github.ga4gh.drs.model.DrsObject;
+import java.net.URL;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -30,11 +39,15 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.util.UriComponents;
 
 @Tag("Unit")
 @ExtendWith(MockitoExtension.class)
+// Adding this since we have a fair amount of common stubbing code
+@MockitoSettings(strictness = Strictness.LENIENT)
 class DrsResolutionServiceTest {
 
   private DrsResolutionService drsResolutionService;
@@ -42,6 +55,7 @@ class DrsResolutionServiceTest {
   @Mock private DrsApi drsApi;
   @Mock private UriComponents uriComponents;
   @Mock private AuthService authService;
+  @Mock private GoogleStorageService googleStorageService;
 
   private static final String PATH = "path";
 
@@ -49,12 +63,14 @@ class DrsResolutionServiceTest {
       DrsProvider.create().setMetadataAuth(false);
   private static final DrsProvider DRS_PROVIDER_AUTH = DrsProvider.create().setMetadataAuth(true);
 
-  private static final BearerToken TOKEN = new BearerToken("token");
+  private static final String TOKEN_VALUE = "token";
+  private static final BearerToken TOKEN = new BearerToken(TOKEN_VALUE);
   private static final List<String> PASSPORTS = List.of("passport");
   private static final DrsHubAuthorization PASSPORTAUTH =
       new DrsHubAuthorization(SupportedTypesEnum.PASSPORTAUTH, null);
   private static final DrsHubAuthorization BEARERAUTH =
-      new DrsHubAuthorization(SupportedTypesEnum.BEARERAUTH, null);
+      new DrsHubAuthorization(
+          SupportedTypesEnum.BEARERAUTH, (var e) -> Optional.of(List.of(TOKEN_VALUE)));
   private static final DrsObject DRS_OBJECT = new DrsObject().id("drs.id");
 
   @BeforeEach
@@ -195,5 +211,38 @@ class DrsResolutionServiceTest {
         "When fetching Object via POSTed passport fails, fall back to getObject with token",
         actual,
         equalTo(DRS_OBJECT));
+  }
+
+  @Test
+  void testSignGoogleUrlWithRequesterPays() throws Exception {
+    var googleProject = "test-google-project";
+    var url = new URL("https://storage.cloud.google.com/my-test-bucket/my/test.txt");
+    var accessId = "foo";
+    SignedUrlTestUtils.setupSignedUrlMocks(authService, googleStorageService, googleProject, url);
+    DrsProvider drsProvider =
+        DrsProvider.create()
+            .setMetadataAuth(true)
+            .setName("test")
+            .setHostRegex(".*")
+            .setAccessMethodConfigs(
+                new ArrayList<>(
+                    List.of(
+                        ProviderAccessMethodConfig.create()
+                            .setType(AccessMethodConfigTypeEnum.gs)
+                            .setAuth(AccessUrlAuthEnum.current_request)
+                            .setFetchAccessUrl(true))));
+    when(drsApi.getAccessURL(PATH, accessId)).thenReturn(new AccessURL().url(url.toString()));
+    var response =
+        drsResolutionService.fetchDrsObjectAccessUrl(
+            drsProvider,
+            uriComponents,
+            accessId,
+            TypeEnum.GS,
+            List.of(BEARERAUTH),
+            new AuditLogEvent.Builder(),
+            googleProject);
+    assertThat(
+        "google signed url is properly returned", response.getUrl(), equalTo(url.toString()));
+    verify(drsApi).setHeader("x-user-project", googleProject);
   }
 }

--- a/service/src/test/java/bio/terra/drshub/tracking/TrackingInterceptorTest.java
+++ b/service/src/test/java/bio/terra/drshub/tracking/TrackingInterceptorTest.java
@@ -14,6 +14,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import bio.terra.common.iam.BearerToken;
 import bio.terra.drshub.DrsHubApplication;
 import bio.terra.drshub.config.DrsHubConfig;
+import bio.terra.drshub.generated.model.RequestObject.CloudPlatformEnum;
 import bio.terra.drshub.services.DrsResolutionService;
 import bio.terra.drshub.services.TrackingService;
 import bio.terra.drshub.util.SignedUrlTestUtils;
@@ -60,20 +61,36 @@ class TrackingInterceptorTest {
     mockBardEmissionsEnabled();
 
     String url = "/api/v4/drs/resolve";
-    postRequest(url, objectMapper.writeValueAsString(Map.of("url", DRS_URI, "fields", List.of())))
+    postRequest(
+            url,
+            objectMapper.writeValueAsString(
+                Map.of("url", DRS_URI, "cloudPlatform", CloudPlatformEnum.GS, "fields", List.of())))
         .andExpect(status().isOk());
 
     verify(trackingService)
         .logEvent(
             TEST_BEARER_TOKEN,
             EVENT_NAME,
-            Map.of("statusCode", 200, "requestUrl", url, "url", DRS_URI, "fields", List.of()));
+            Map.of(
+                "statusCode",
+                200,
+                "requestUrl",
+                url,
+                "url",
+                DRS_URI,
+                "cloudPlatform",
+                CloudPlatformEnum.GS.toString(),
+                "fields",
+                List.of()));
   }
 
   @Test
   void testDoesNotLogWhenBardEmissionsDisabled() throws Exception {
     String url = "/api/v4/drs/resolve";
-    postRequest(url, objectMapper.writeValueAsString(Map.of("url", DRS_URI, "fields", List.of())))
+    postRequest(
+            url,
+            objectMapper.writeValueAsString(
+                Map.of("url", DRS_URI, "cloudPlatform", CloudPlatformEnum.GS, "fields", List.of())))
         .andExpect(status().isOk());
 
     verifyNoInteractions(trackingService);

--- a/service/src/test/java/bio/terra/drshub/util/SignedUrlTestUtils.java
+++ b/service/src/test/java/bio/terra/drshub/util/SignedUrlTestUtils.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.when;
 import bio.terra.bond.model.SaKeyObject;
 import bio.terra.common.iam.BearerToken;
 import bio.terra.drshub.config.DrsProvider;
+import bio.terra.drshub.generated.model.RequestObject.ResolveFromEnum;
 import bio.terra.drshub.models.AnnotatedResourceMetadata;
 import bio.terra.drshub.services.AuthService;
 import bio.terra.drshub.services.DrsResolutionService;
@@ -93,6 +94,7 @@ public class SignedUrlTestUtils {
         .when(drsResolutionService)
         .resolveDrsObject(
             eq(drsUri),
+            eq(ResolveFromEnum.GS),
             any(List.class),
             any(BearerToken.class),
             eq(forceAccessUrl),

--- a/service/src/test/java/bio/terra/drshub/util/SignedUrlTestUtils.java
+++ b/service/src/test/java/bio/terra/drshub/util/SignedUrlTestUtils.java
@@ -10,7 +10,7 @@ import static org.mockito.Mockito.when;
 import bio.terra.bond.model.SaKeyObject;
 import bio.terra.common.iam.BearerToken;
 import bio.terra.drshub.config.DrsProvider;
-import bio.terra.drshub.generated.model.RequestObject.ResolveFromEnum;
+import bio.terra.drshub.generated.model.RequestObject;
 import bio.terra.drshub.models.AnnotatedResourceMetadata;
 import bio.terra.drshub.services.AuthService;
 import bio.terra.drshub.services.DrsResolutionService;
@@ -94,7 +94,7 @@ public class SignedUrlTestUtils {
         .when(drsResolutionService)
         .resolveDrsObject(
             eq(drsUri),
-            eq(ResolveFromEnum.GS),
+            eq(RequestObject.CloudPlatformEnum.GS),
             any(List.class),
             any(BearerToken.class),
             eq(forceAccessUrl),

--- a/service/src/test/java/bio/terra/drshub/util/TestAccessMethodUtils.java
+++ b/service/src/test/java/bio/terra/drshub/util/TestAccessMethodUtils.java
@@ -1,6 +1,7 @@
 package bio.terra.drshub.util;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 
 import bio.terra.drshub.config.DrsProvider;
@@ -10,6 +11,7 @@ import bio.terra.drshub.models.AccessMethodConfigTypeEnum;
 import bio.terra.drshub.models.AccessUrlAuthEnum;
 import io.github.ga4gh.drs.model.AccessMethod;
 import io.github.ga4gh.drs.model.AccessMethod.TypeEnum;
+import io.github.ga4gh.drs.model.AllOfAccessMethodAccessUrl;
 import io.github.ga4gh.drs.model.DrsObject;
 import java.util.ArrayList;
 import java.util.List;
@@ -29,8 +31,15 @@ public class TestAccessMethodUtils {
       new AccessMethod().accessId("az-" + UUID.randomUUID()).type(TypeEnum.HTTPS);
   static AccessMethod s3AccessMethod =
       new AccessMethod().accessId(UUID.randomUUID().toString()).type(TypeEnum.S3);
+  // This case can happen when there is a URL in te accessMethod
+  static AccessMethod accessMethodWithNoAccessId =
+      new AccessMethod()
+          .accessId(null)
+          .type(TypeEnum.GS)
+          .accessUrl(
+              (AllOfAccessMethodAccessUrl) new AllOfAccessMethodAccessUrl().url("https://foo.com"));
   static List<AccessMethod> accessMethods =
-      List.of(gsAccessMethod, azureAccessMethod, s3AccessMethod);
+      List.of(gsAccessMethod, azureAccessMethod, s3AccessMethod, accessMethodWithNoAccessId);
 
   ProviderAccessMethodConfig gsAccessMethodConfig =
       createTestAccessMethodConfig(AccessMethodConfigTypeEnum.gs);
@@ -85,7 +94,7 @@ public class TestAccessMethodUtils {
   void testGetAccessMethods() {
     assertThat(
         AccessMethodUtils.getAccessMethods(drsObject, drsProvider),
-        equalTo(List.of(gsAccessMethod, azureAccessMethod)));
+        containsInAnyOrder(gsAccessMethod, azureAccessMethod, accessMethodWithNoAccessId));
   }
 
   @Test

--- a/service/src/test/java/bio/terra/drshub/util/TestAccessMethodUtils.java
+++ b/service/src/test/java/bio/terra/drshub/util/TestAccessMethodUtils.java
@@ -1,0 +1,103 @@
+package bio.terra.drshub.util;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import bio.terra.drshub.config.DrsProvider;
+import bio.terra.drshub.config.ProviderAccessMethodConfig;
+import bio.terra.drshub.generated.model.RequestObject.CloudPlatformEnum;
+import bio.terra.drshub.models.AccessMethodConfigTypeEnum;
+import bio.terra.drshub.models.AccessUrlAuthEnum;
+import io.github.ga4gh.drs.model.AccessMethod;
+import io.github.ga4gh.drs.model.AccessMethod.TypeEnum;
+import io.github.ga4gh.drs.model.DrsObject;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+@Tag("Unit")
+public class TestAccessMethodUtils {
+  static AccessMethod gsAccessMethod = new AccessMethod().accessId("a").type(TypeEnum.GS);
+  static AccessMethod azureAccessMethod =
+      new AccessMethod().accessId("az-" + UUID.randomUUID()).type(TypeEnum.HTTPS);
+  static AccessMethod s3AccessMethod =
+      new AccessMethod().accessId(UUID.randomUUID().toString()).type(TypeEnum.S3);
+  static List<AccessMethod> accessMethods =
+      List.of(gsAccessMethod, azureAccessMethod, s3AccessMethod);
+
+  ProviderAccessMethodConfig gsAccessMethodConfig =
+      createTestAccessMethodConfig(AccessMethodConfigTypeEnum.gs);
+  ProviderAccessMethodConfig httpsAccessMethodConfig =
+      createTestAccessMethodConfig(AccessMethodConfigTypeEnum.https);
+  ArrayList<ProviderAccessMethodConfig> accessMethodConfigs =
+      new ArrayList<>(List.of(gsAccessMethodConfig, httpsAccessMethodConfig));
+  DrsProvider drsProvider = DrsProvider.create().setAccessMethodConfigs(accessMethodConfigs);
+  DrsObject drsObject = new DrsObject().accessMethods(accessMethods);
+
+  @Test
+  void testGetAccessMethodReturnsPreferredCloud() {
+    Optional<AccessMethod> accessMethod =
+        AccessMethodUtils.getAccessMethod(drsObject, drsProvider, CloudPlatformEnum.AZURE);
+    assertThat(accessMethod.get(), equalTo(azureAccessMethod));
+  }
+
+  @Test
+  void testGetAccessMethodReturnsFallback() {
+    ArrayList<ProviderAccessMethodConfig> accessMethodConfigs =
+        new ArrayList<>(List.of(gsAccessMethodConfig));
+    DrsProvider drsProvider = DrsProvider.create().setAccessMethodConfigs(accessMethodConfigs);
+    Optional<AccessMethod> accessMethod =
+        AccessMethodUtils.getAccessMethod(drsObject, drsProvider, CloudPlatformEnum.AZURE);
+    assertThat(accessMethod.get(), equalTo(gsAccessMethod));
+  }
+
+  @Test
+  void testGetAccessMethodNoCloudPreference() {
+    Optional<AccessMethod> accessMethod =
+        AccessMethodUtils.getAccessMethod(drsObject, drsProvider, null);
+    assertThat(accessMethod.get(), equalTo(gsAccessMethod));
+  }
+
+  private static Stream<Arguments> testGetAccessMethodForCloud() {
+    return Stream.of(
+        Arguments.of(CloudPlatformEnum.GS, gsAccessMethod),
+        Arguments.of(CloudPlatformEnum.AZURE, azureAccessMethod),
+        Arguments.of(CloudPlatformEnum.S3, s3AccessMethod));
+  }
+
+  @ParameterizedTest
+  @MethodSource
+  void testGetAccessMethodForCloud(
+      CloudPlatformEnum cloudPlatform, AccessMethod expectedAccessMethod) {
+    Optional<AccessMethod> accessMethod =
+        AccessMethodUtils.getAccessMethodForCloud(accessMethods, cloudPlatform);
+    assertThat(accessMethod.get(), equalTo(expectedAccessMethod));
+  }
+
+  @Test
+  void testGetAccessMethods() {
+    assertThat(
+        AccessMethodUtils.getAccessMethods(drsObject, drsProvider),
+        equalTo(List.of(gsAccessMethod, azureAccessMethod)));
+  }
+
+  @Test
+  void testGetAccessMethodsNoDrsResponse() {
+    DrsProvider drsProvider = DrsProvider.create();
+    assertThat(AccessMethodUtils.getAccessMethods(null, drsProvider), equalTo(List.of()));
+  }
+
+  private ProviderAccessMethodConfig createTestAccessMethodConfig(AccessMethodConfigTypeEnum type) {
+    return ProviderAccessMethodConfig.create()
+        .setType(type)
+        .setAuth(AccessUrlAuthEnum.fence_token)
+        .setFetchAccessUrl(true);
+  }
+}


### PR DESCRIPTION
When a user requests an `access_url` for a DRS URI, DRSHub goes through the access methods defined in the provider configuration and returns the first match. For example, in the [configuration for TDR](https://github.com/DataBiosphere/terra-drs-hub/blob/efd40df660bc36d36f615a8aad7d033bb8cce90f/service/src/main/resources/application.yml#L53) the first access method that's listed is "gs", so if a DRS URI has an access url for both "gs" and "https" (azure) it will always return the access url for "gs".

This updates the behavior so that if a user specifies the `resolveFrom` parameter (either `azure`, `gs` or `s3`), DRSHub will return the `access_url` for that cloud if it exists, otherwise it will return the first one that it finds. So if a user specifies "gs" as the `resolveFrom` field but there is only an azure `access_url`, the azure one will get returned. If the field is not specified, the behavior of the endpoint stays the same.