### PR TITLE
[DR-3354] Fix retrieving an access url when a user has no passport

### DIFF
--- a/service/src/main/java/bio/terra/drshub/services/DrsResolutionService.java
+++ b/service/src/main/java/bio/terra/drshub/services/DrsResolutionService.java
@@ -285,8 +285,11 @@ public class DrsResolutionService {
             }
             case PASSPORTAUTH -> {
               try {
-                yield drsApi.postAccessURL(
-                    Map.of("passports", auth.orElse(List.of(""))), objectId, accessId);
+                if (auth.isPresent()) {
+                  yield drsApi.postAccessURL(Map.of("passports", auth.get()), objectId, accessId);
+                } else {
+                  yield null;
+                }
               } catch (RestClientException e) {
                 log.error(
                     "Passport authorized request failed for {} with error {}",

--- a/service/src/main/java/bio/terra/drshub/services/DrsResolutionService.java
+++ b/service/src/main/java/bio/terra/drshub/services/DrsResolutionService.java
@@ -285,11 +285,9 @@ public class DrsResolutionService {
             }
             case PASSPORTAUTH -> {
               try {
-                if (auth.isPresent()) {
-                  yield drsApi.postAccessURL(Map.of("passports", auth.get()), objectId, accessId);
-                } else {
-                  yield null;
-                }
+                yield auth.map(
+                        a -> drsApi.postAccessURL(Map.of("passports", a), objectId, accessId))
+                    .orElse(null);
               } catch (RestClientException e) {
                 log.error(
                     "Passport authorized request failed for {} with error {}",

--- a/service/src/test/java/bio/terra/drshub/controllers/DrsHubApiControllerTest.java
+++ b/service/src/test/java/bio/terra/drshub/controllers/DrsHubApiControllerTest.java
@@ -128,7 +128,7 @@ public class DrsHubApiControllerTest extends BaseTest {
     mockExternalcredsApi("ras", TEST_ACCESS_TOKEN, Optional.empty());
 
     mockBondLinkAccessTokenApi(
-        cidProviderHost.drsProvider().getBondProvider().get(),
+        cidProviderHost.drsProvider().getBondProvider().orElseThrow(),
         TEST_ACCESS_TOKEN,
         TEST_BOND_SA_TOKEN);
 
@@ -167,7 +167,7 @@ public class DrsHubApiControllerTest extends BaseTest {
     mockExternalcredsApi("ras", TEST_ACCESS_TOKEN, Optional.of(TEST_PASSPORT));
 
     mockBondLinkAccessTokenApi(
-        cidProviderHost.drsProvider().getBondProvider().get(),
+        cidProviderHost.drsProvider().getBondProvider().orElseThrow(),
         TEST_ACCESS_TOKEN,
         TEST_BOND_SA_TOKEN);
 

--- a/service/src/test/java/bio/terra/drshub/controllers/DrsHubApiControllerTest.java
+++ b/service/src/test/java/bio/terra/drshub/controllers/DrsHubApiControllerTest.java
@@ -3,6 +3,7 @@ package bio.terra.drshub.controllers;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -117,11 +118,13 @@ public class DrsHubApiControllerTest extends BaseTest {
   @Test
   void testCallsCorrectEndpointsWhenOnlyAccessUrlRequestedWithPassportsUsingFallback()
       throws Exception {
+    var accessId = "gs";
     var cidProviderHost = getProviderHosts("passport");
     var drsObject = drsObjectWithRandomId("gs");
 
     var drsApi =
-        mockDrsApiAccessUrlWithToken(cidProviderHost.dnsHost(), drsObject, "gs", TEST_ACCESS_URL);
+        mockDrsApiAccessUrlWithToken(
+            cidProviderHost.dnsHost(), drsObject, accessId, TEST_ACCESS_URL);
 
     mockExternalcredsApi("ras", TEST_ACCESS_TOKEN, Optional.empty());
 
@@ -144,6 +147,8 @@ public class DrsHubApiControllerTest extends BaseTest {
 
     // need an extra verify because nothing in the mock cares that bearer token is set or not
     verify(drsApi).setBearerToken(TEST_BOND_SA_TOKEN);
+    verify(drsApi, never())
+        .postAccessURL(Map.of("passports", List.of("")), drsObject.getId(), accessId);
   }
 
   @Test

--- a/service/src/test/java/bio/terra/drshub/controllers/DrsHubApiControllerTest.java
+++ b/service/src/test/java/bio/terra/drshub/controllers/DrsHubApiControllerTest.java
@@ -102,17 +102,7 @@ public class DrsHubApiControllerTest extends BaseTest {
 
     mockExternalcredsApi("ras", TEST_ACCESS_TOKEN, Optional.of(TEST_PASSPORT));
 
-    postDrsHubRequest(
-            TEST_ACCESS_TOKEN,
-            cidProviderHost.compactUriPrefix(),
-            drsObject.getId(),
-            List.of(Fields.ACCESS_URL))
-        .andExpect(status().isOk())
-        .andExpect(
-            content()
-                .json(
-                    objectMapper.writeValueAsString(Map.of(Fields.ACCESS_URL, TEST_ACCESS_URL)),
-                    true));
+    postDrsHubRequestAccessUrlSuccess(cidProviderHost, drsObject.getId());
   }
 
   @Test
@@ -132,17 +122,7 @@ public class DrsHubApiControllerTest extends BaseTest {
         TEST_ACCESS_TOKEN,
         TEST_BOND_SA_TOKEN);
 
-    postDrsHubRequest(
-            TEST_ACCESS_TOKEN,
-            cidProviderHost.compactUriPrefix(),
-            drsObject.getId(),
-            List.of(Fields.ACCESS_URL))
-        .andExpect(status().isOk())
-        .andExpect(
-            content()
-                .json(
-                    objectMapper.writeValueAsString(Map.of(Fields.ACCESS_URL, TEST_ACCESS_URL)),
-                    true));
+    postDrsHubRequestAccessUrlSuccess(cidProviderHost, drsObject.getId());
 
     // need an extra verify because nothing in the mock cares that bearer token is set or not
     verify(drsApi).setBearerToken(TEST_BOND_SA_TOKEN);
@@ -171,17 +151,7 @@ public class DrsHubApiControllerTest extends BaseTest {
         TEST_ACCESS_TOKEN,
         TEST_BOND_SA_TOKEN);
 
-    postDrsHubRequest(
-            TEST_ACCESS_TOKEN,
-            cidProviderHost.compactUriPrefix(),
-            drsObject.getId(),
-            List.of(Fields.ACCESS_URL))
-        .andExpect(status().isOk())
-        .andExpect(
-            content()
-                .json(
-                    objectMapper.writeValueAsString(Map.of(Fields.ACCESS_URL, TEST_ACCESS_URL)),
-                    true));
+    postDrsHubRequestAccessUrlSuccess(cidProviderHost, drsObject.getId());
 
     // verify that the passport postAccessURL method was called for the passport
     verify(drsApi)
@@ -301,17 +271,7 @@ public class DrsHubApiControllerTest extends BaseTest {
         TEST_ACCESS_TOKEN,
         TEST_BOND_SA_TOKEN);
 
-    postDrsHubRequest(
-            TEST_ACCESS_TOKEN,
-            cidProviderHost.compactUriPrefix(),
-            drsObject.getId(),
-            List.of(Fields.ACCESS_URL))
-        .andExpect(status().isOk())
-        .andExpect(
-            content()
-                .json(
-                    objectMapper.writeValueAsString(Map.of(Fields.ACCESS_URL, TEST_ACCESS_URL)),
-                    true));
+    postDrsHubRequestAccessUrlSuccess(cidProviderHost, drsObject.getId());
 
     // need an extra verify because nothing in the mock cares that bearer token is set or not
     verify(drsApi).setBearerToken(TEST_BOND_SA_TOKEN);
@@ -727,6 +687,21 @@ public class DrsHubApiControllerTest extends BaseTest {
     }
 
     return responseMap;
+  }
+
+  private void postDrsHubRequestAccessUrlSuccess(ProviderHosts cidProviderHost, String drsObjectId)
+      throws Exception {
+    postDrsHubRequest(
+        TEST_ACCESS_TOKEN,
+        cidProviderHost.compactUriPrefix(),
+        drsObjectId,
+        List.of(Fields.ACCESS_URL))
+        .andExpect(status().isOk())
+        .andExpect(
+            content()
+                .json(
+                    objectMapper.writeValueAsString(Map.of(Fields.ACCESS_URL, TEST_ACCESS_URL)),
+                    true));
   }
 
   private ResultActions postDrsHubRequest(


### PR DESCRIPTION
**Ticket:** https://broadworkbench.atlassian.net/browse/DR-3354

If a DRS object can be accessed with a passport but the user does not have one, DRSHub will still attempt to get an access url for that object but [pass in an empty string](https://github.com/DataBiosphere/terra-drs-hub/blob/dev/service/src/main/java/bio/terra/drshub/services/DrsResolutionService.java#L289) as the passport. DRSHub catches the exception, logs an error message, and (in the case of TDR) falls back to use authentication with a bearer token. It's not necessary to call this endpoint if the user does not have a passport, so this PR adds in a check to make sure it exists.