### PR TITLE
[DR-3361] Only log events to Bard when enabled

### DIFF
--- a/service/src/main/java/bio/terra/drshub/config/DrsHubConfigInterface.java
+++ b/service/src/main/java/bio/terra/drshub/config/DrsHubConfigInterface.java
@@ -36,4 +36,8 @@ public interface DrsHubConfigInterface {
   // If this is true, then we will track calls to the Bard API in MixPanel in addition to the
   // BigQuery Data warehouse.
   Boolean trackInMixPanel();
+
+  // Only log events to Bard when enabled: this is exposed to help debug performance regressions
+  // following the introduction of Bard logging.
+  Boolean bardEventLoggingEnabled();
 }

--- a/service/src/main/java/bio/terra/drshub/tracking/TrackingInterceptor.java
+++ b/service/src/main/java/bio/terra/drshub/tracking/TrackingInterceptor.java
@@ -2,6 +2,7 @@ package bio.terra.drshub.tracking;
 
 import bio.terra.bard.model.EventProperties;
 import bio.terra.common.iam.BearerTokenFactory;
+import bio.terra.drshub.config.DrsHubConfig;
 import bio.terra.drshub.services.TrackingService;
 import bio.terra.drshub.util.AsyncUtils;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -30,7 +31,8 @@ public record TrackingInterceptor(
     TrackingService trackingService,
     AsyncUtils asyncUtils,
     BearerTokenFactory bearerTokenFactory,
-    ObjectMapper objectMapper)
+    ObjectMapper objectMapper,
+    DrsHubConfig config)
     implements HandlerInterceptor {
 
   public static final String EVENT_NAME = "drshub:api";
@@ -45,7 +47,8 @@ public record TrackingInterceptor(
     var responseStatus = HttpStatus.valueOf(response.getStatus());
     // Note: invalid responses will not be logged since there are no sessions to associate users
     // with
-    if (handler instanceof HandlerMethod handlerMethod
+    if (config.bardEventLoggingEnabled()
+        && handler instanceof HandlerMethod handlerMethod
         && handlerMethod.getMethod().getAnnotation(TrackCall.class) != null
         && responseStatus.is2xxSuccessful()) {
       var bearerToken = bearerTokenFactory.from(request);

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -59,6 +59,7 @@ drshub:
           fetchAccessUrl: true # Used for Azure
   pencilsDownSeconds: 58
   asyncThreads: ${TOMCAT_MAX_THREADS:200}
+  bardEventLoggingEnabled: ${BARD_EVENT_LOGGING_ENABLED:true}
   trackInMixpanel: false
 
 server:


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DR-3361

Possible contributor to degraded DrsHub performance following initial 8/15/23 load tests: we now log successful DRS resolutions in Bard.

To help verify the extent of Bard event logging’s impact on performance, we want to selectively disable it in DrsHub dev for additional scale tests.

Logging events to Bard is now controlled by new property `drshub.bardEventLoggingEnabled` which defaults to true, and can be overridden via environment variable `BARD_EVENT_LOGGING_ENABLED`.