### PR TITLE
[DR-3366] Enable Micrometer metrics collection through Spring Boot Actuator

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -70,6 +70,10 @@ dependencies {
 		}
 	}
 
+	// For Micrometer metrics gathering
+	implementation 'org.springframework.boot:spring-boot-starter-actuator:2.7.17'
+	implementation 'io.micrometer:micrometer-registry-prometheus'
+
 	testImplementation('org.springframework.boot:spring-boot-starter-test') {
 		// Fixes warning about multiple occurrences of JSONObject on the classpath
 		exclude group: 'com.vaadin.external.google', module: 'android-json'

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -62,6 +62,17 @@ drshub:
   bardEventLoggingEnabled: ${BARD_EVENT_LOGGING_ENABLED:true}
   trackInMixpanel: false
 
+management:
+  # For Micrometer metrics gathering
+  endpoints:
+    web:
+      exposure:
+        # Expose all management endpoints in Spring Boot
+        include: "*"
+  server:
+    # Expose metrics on a different port than our app so that they aren't exposed with other endpoints
+    port: 9098
+
 server:
   compression:
     enabled: true


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DR-3366

**Background**

In response to DrsHub performance degradation during manual scale tests, we have already picked the following low-hanging fruit in DrsHub dev:
1. [Increasing the number of Tomcat threads](https://github.com/broadinstitute/terra-helmfile/pull/4773)
2. [Disabling Bard event logging](https://broadworkbench.atlassian.net/browse/DR-3361), as this logging was added after our last successful scale test in August

Neither change has resulted in noticeable change in the performance of our scale tests, but our ability to gauge impact is hampered by a lack of visibility into Tomcat thread usage and `asyncExecutor` state / capacity, among other things.

**Objective**

In order to better target our performance tuning, this PR enables [Micrometer](https://spring.io/blog/2018/03/16/micrometer-spring-boot-2-s-new-application-metrics-collector) metrics collection on port 9098 via endpoint `/actuator/prometheus`.  Out of the box, we get many JVM metrics for free that may help us tune performance mindfully.

I leaned heavily on the [example set by BPM](https://broadworkbench.atlassian.net/browse/WOR-547) when they added this support in December '22 -- thank you @cahrens for documenting your process so thoroughly on Jira and in Slack conversations!

**Verification**
With a local DrsHub running:
```
okotsopo@wm111-e35 terra-drs-hub % ./gradlew bootRun
```

I can see the expected metrics emitted on port 9098:
```
okotsopo@wm111-e35 terra-drs-hub % curl http://localhost:9098/actuator/prometheus
…
# HELP executor_queue_remaining_tasks The number of additional elements that this queue can ideally accept without blocking
# TYPE executor_queue_remaining_tasks gauge
executor_queue_remaining_tasks{name="asyncExecutor",} 400.0
# HELP executor_pool_max_threads The maximum allowed number of threads in the pool
# TYPE executor_pool_max_threads gauge
executor_pool_max_threads{name="asyncExecutor",} 2.147483647E9
…
# HELP executor_queued_tasks The approximate number of tasks that are queued for execution
# TYPE executor_queued_tasks gauge
executor_queued_tasks{name="asyncExecutor",} 0.0
…
# HELP tomcat_sessions_active_current_sessions  
# TYPE tomcat_sessions_active_current_sessions gauge
tomcat_sessions_active_current_sessions 0.0
# HELP tomcat_sessions_rejected_sessions_total  
# TYPE tomcat_sessions_rejected_sessions_total counter
tomcat_sessions_rejected_sessions_total 0.0
…
# HELP executor_active_threads The approximate number of threads that are actively executing tasks
# TYPE executor_active_threads gauge
executor_active_threads{name="asyncExecutor",} 0.0
# HELP executor_pool_size_threads The current number of threads in the pool
# TYPE executor_pool_size_threads gauge
executor_pool_size_threads{name="asyncExecutor",} 0.0
…
# HELP executor_pool_core_threads The core number of threads for the pool
# TYPE executor_pool_core_threads gauge
executor_pool_core_threads{name="asyncExecutor",} 400.0
# HELP tomcat_sessions_active_max_sessions  
# TYPE tomcat_sessions_active_max_sessions gauge
tomcat_sessions_active_max_sessions 0.0
…
# HELP executor_completed_tasks_total The approximate total number of tasks that have completed execution
# TYPE executor_completed_tasks_total counter
executor_completed_tasks_total{name="asyncExecutor",} 0.0
…
```


**Next Up…**

Working with DevOps to pull these metrics into Grafana for monitoring, and ensure that Grafana will also pick up any custom metrics we add in the future.

Related, adding custom metrics once we have a better sense of what will be valuable to monitor.