### PR TITLE
[DR-3367] object resolution should only spawn one async thread

### DIFF
--- a/service/src/test/java/bio/terra/drshub/services/DrsResolutionServiceTest.java
+++ b/service/src/test/java/bio/terra/drshub/services/DrsResolutionServiceTest.java
@@ -20,7 +20,6 @@ import io.github.ga4gh.drs.model.DrsObject;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.Executor;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
@@ -64,11 +63,7 @@ class DrsResolutionServiceTest {
 
     drsResolutionService =
         new DrsResolutionService(
-            drsApiFactory,
-            mock(DrsProviderService.class),
-            authService,
-            mock(AuditLogger.class),
-            mock(Executor.class));
+            drsApiFactory, mock(DrsProviderService.class), authService, mock(AuditLogger.class));
 
     when(uriComponents.getHost()).thenReturn("host.com");
     when(uriComponents.getPath()).thenReturn(PATH);


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DR-3367

The [object resolution API](https://github.com/DataBiosphere/terra-drs-hub/blob/ef798881fff6e74013e1250b9a54f0d181365276/service/src/main/java/bio/terra/drshub/controllers/DrsHubApiController.java#L40-L43) calls DrsResolutionService.resolveDrsObject.  It is annotated with @Async, meaning that Spring takes care of handling its invocation in a new thread from asyncExecutor:

```
  @Async("asyncExecutor")
  public CompletableFuture<AnnotatedResourceMetadata> resolveDrsObject(
  …
```

But within this method, we took a second thread from asyncExecutor by wrapping the return value in `CompletableFuture.completeAsync`:

```
    return new CompletableFuture<AnnotatedResourceMetadata>()
        .completeAsync(
            () -> {
              var metadata = fetchObject(…);
              return buildResponseObject(requestedFields, metadata, provider);
            },
            asyncExecutor);
```

Both together are unnecessary and could lead to unexpected behavior, plus the extra threads make it hard to trace the completion of the request via the first spawned thread’s name.

**New Behavior**

Note that we can now track the single async thread spawned to service this object resolution request to completion:
```
{"requestId":"aw9vLKyp","timestampSeconds":1700669291,"timestampNanos":107000000,"severity":"INFO","thread":"http-nio-8080-exec-1","logger":"bio.terra.drshub.controllers.DrsHubApiController","message":"Received URL drs://jade.datarepo-dev.broadinstitute.org/v1_1a45eebc-ba3b-4336-8fb5-95c848f23893_57bbf476-b5ba-4ac0-8a79-fc1fc5e30b05 from agent Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36 on IP null","context":"default"}
{"timestampSeconds":1700669291,"timestampNanos":118000000,"severity":"INFO","thread":"drshub-async-thread-1","logger":"bio.terra.drshub.services.DrsProviderService","message":"Matched a hostname ID and stripped path: v1_1a45eebc-ba3b-4336-8fb5-95c848f23893_57bbf476-b5ba-4ac0-8a79-fc1fc5e30b05","context":"default"}
{"timestampSeconds":1700669291,"timestampNanos":122000000,"severity":"INFO","thread":"drshub-async-thread-1","logger":"bio.terra.drshub.services.DrsProviderService","message":"built URI: drs://jade.datarepo-dev.broadinstitute.org/v1_1a45eebc-ba3b-4336-8fb5-95c848f23893_57bbf476-b5ba-4ac0-8a79-fc1fc5e30b05","context":"default"}
{"timestampSeconds":1700669291,"timestampNanos":123000000,"severity":"INFO","thread":"drshub-async-thread-1","logger":"bio.terra.drshub.services.DrsResolutionService","message":"Drs URI drs://jade.datarepo-dev.broadinstitute.org/v1_1a45eebc-ba3b-4336-8fb5-95c848f23893_57bbf476-b5ba-4ac0-8a79-fc1fc5e30b05 will use provider Terra Data Repo (TDR), requested fields bucket, contentType, fileName, gsUri, hashes, localizationPath, name, size, timeCreated, timeUpdated, googleServiceAccount","context":"default"}
{"timestampSeconds":1700669291,"timestampNanos":123000000,"severity":"INFO","thread":"drshub-async-thread-1","logger":"bio.terra.drshub.services.DrsApiFactory","message":"Creating new DrsApi client for host \u0027jade.datarepo-dev.broadinstitute.org\u0027, for DRS Provider \u0027Terra Data Repo (TDR)\u0027","context":"default"}
{"timestampSeconds":1700669291,"timestampNanos":867000000,"severity":"INFO","thread":"drshub-async-thread-1","logger":"bio.terra.drshub.services.DrsResolutionService","message":"Requesting DRS metadata for drs://jade.datarepo-dev.broadinstitute.org/v1_1a45eebc-ba3b-4336-8fb5-95c848f23893_57bbf476-b5ba-4ac0-8a79-fc1fc5e30b05 with auth required true from host jade.datarepo-dev.broadinstitute.org","context":"default"}
{"timestampSeconds":1700669291,"timestampNanos":867000000,"severity":"INFO","thread":"drshub-async-thread-1","logger":"bio.terra.drshub.services.DrsApiFactory","message":"Creating new DrsApi client for host \u0027jade.datarepo-dev.broadinstitute.org\u0027, for DRS Provider \u0027Terra Data Repo (TDR)\u0027","context":"default"}
{"timestampSeconds":1700669291,"timestampNanos":870000000,"severity":"INFO","thread":"drshub-async-thread-1","logger":"bio.terra.drshub.services.AuthService","message":"Cache miss. Fetching passports from ECM","context":"default"}
{"timestampSeconds":1700669292,"timestampNanos":693000000,"severity":"INFO","thread":"drshub-async-thread-1","logger":"bio.terra.drshub.services.AuthService","message":"User does not have a passport.","context":"default"}
{"timestampSeconds":1700669294,"timestampNanos":95000000,"severity":"INFO","thread":"drshub-async-thread-1","logger":"bio.terra.drshub.logging.AuditLogger","message":"DrsResolutionSucceeded","context":"default"}
{"requestId":"aw9vLKyp","timestampSeconds":1700669294,"timestampNanos":113000000,"severity":"INFO","thread":"http-nio-8080-exec-1","logger":"bio.terra.drshub.logging.LoggerInterceptor","message":"POST /api/v4/drs/resolve 200","context":"default"}
```