### PR TITLE
[DR-3369] ApiClients share RestTemplates

### DIFF
--- a/.github/workflows/publish-branch-image.yml
+++ b/.github/workflows/publish-branch-image.yml
@@ -7,18 +7,18 @@ env:
 
 jobs:
   publish-branch-image-job:
+    outputs:
+      tag: ${{ steps.tag.outputs.tag }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-      - name: Parse tag
-        id: tag
-        run: echo tag=$(git branch --show-current) >> $GITHUB_OUTPUT
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
           java-version: '17'
           distribution: 'temurin'
+
       - name: Cache Gradle packages
         uses: actions/cache@v3
         with:
@@ -27,24 +27,52 @@ jobs:
             ~/.gradle/wrapper
           key: v1-${{ runner.os }}-gradle-${{ hashfiles('**/gradle-wrapper.properties') }}-${{ hashFiles('**/*.gradle') }}
           restore-keys: v1-${{ runner.os }}-gradle-${{ hashfiles('**/gradle-wrapper.properties') }}
+
+      - name: Parse tag
+        id: tag
+        run: echo tag=$(git branch --show-current) >> $GITHUB_OUTPUT
+
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
+
       #    - name: "Publish to Artifactory"
       #      run: ./gradlew :client:artifactoryPublish
       #      env:
       #        ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
       #        ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
       #        ARTIFACTORY_REPO_KEY: "libs-snapshot-local"
+
       - name: Auth to GCR
         uses: google-github-actions/auth@v1
         with:
           credentials_json: ${{ secrets.GCR_PUBLISH_KEY_B64 }}
+
       - name: Explicitly auth Docker for GCR
-        run: gcloud auth configure-docker --quiet
+        run: gcloud auth configure-docker --quiet  
+
       - name: Construct docker image name and tag
         id: image-name
         run: echo name=gcr.io/${GOOGLE_PROJECT}/${SERVICE_NAME}:${{ steps.tag.outputs.tag }} >> $GITHUB_OUTPUT
+
+      - name: Add Google Cloud Profiler to Docker Image
+        run: docker build ./service -t drshub:local
+
       - name: Build image locally with jib
-        run: './gradlew :service:jibDockerBuild --image=${{ steps.image-name.outputs.name }} -Djib.console=plain'
+        run: |
+          ./gradlew --build-cache :service:jibDockerBuild \
+          --image=${{ steps.image-name.outputs.name }} \
+          -Djib.from.image=docker://drshub:local \
+          -Djib.console=plain
       - name: Push GCR image
         run: 'docker push ${{ steps.image-name.outputs.name }}'
+
+  report-to-sherlock:
+    # Report new drshub version to Broad DevOps
+    uses: broadinstitute/sherlock/.github/workflows/client-report-app-version.yaml@main
+    needs: [ publish-branch-image-job ]
+    with:
+      new-version: ${{ needs.publish-branch-image-job.outputs.tag }}
+      chart-name: 'drshub'
+    permissions:
+      contents: 'read'
+      id-token: 'write'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,6 +9,8 @@ jobs:
   publish-job:
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.tag.outputs.tag }}
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK 17
@@ -73,6 +75,34 @@ jobs:
           event-type: update-service
           client-payload: '{"service": "drshub", "version": "${{ steps.tag.outputs.tag }}", "dev_only": false}'
 
+  report-to-sherlock:
+    # Report new drshub version to Broad DevOps
+    uses: broadinstitute/sherlock/.github/workflows/client-report-app-version.yaml@main
+    needs: publish-job
+    with:
+      new-version: ${{ needs.publish-job.outputs.tag }}
+      chart-name: 'drshub'
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+
+  set-version-in-dev:
+    # Put new drshub version in Broad dev environment
+    uses: broadinstitute/sherlock/.github/workflows/client-set-environment-app-version.yaml@main
+    needs: [publish-job, report-to-sherlock]
+    with:
+      new-version: ${{ needs.publish-job.outputs.tag }}
+      chart-name: 'drshub'
+      environment-name: 'dev'
+    secrets:
+      sync-git-token: ${{ secrets.BROADBOT_TOKEN }}
+    permissions:
+      id-token: 'write'
+
+  notify-slack-failures:
+    needs: [publish-job, report-to-sherlock, set-version-in-dev]
+    runs-on: ubuntu-latest
+    steps:
       - name: Notify slack on failure
         uses: 8398a7/action-slack@v3
         if: failure()

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,6 +42,7 @@ jobs:
         uses: google-github-actions/auth@v1
         with:
           credentials_json: ${{ secrets.GCR_PUBLISH_KEY_B64 }}
+
       - name: Explicitly auth Docker for GCR
         run: gcloud auth configure-docker --quiet
 
@@ -66,14 +67,6 @@ jobs:
 
       - name: Push GCR image
         run: docker push ${{ steps.image-name.outputs.name }}
-
-      - name: Deploy to Terra Dev environment
-        uses: broadinstitute/repository-dispatch@master
-        with:
-          token: ${{ secrets.BROADBOT_TOKEN }}
-          repository: broadinstitute/terra-helmfile
-          event-type: update-service
-          client-payload: '{"service": "drshub", "version": "${{ steps.tag.outputs.tag }}", "dev_only": false}'
 
   report-to-sherlock:
     # Report new drshub version to Broad DevOps

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ repositories { mavenCentral() }
 
 subprojects {
 	group = 'bio.terra'
-	version = '0.70.0-SNAPSHOT'
+	version = '0.71.0-SNAPSHOT'
 
 	ext {
 		artifactGroup = "${group}.${rootProject.name}"

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ repositories { mavenCentral() }
 
 subprojects {
 	group = 'bio.terra'
-	version = '0.71.0-SNAPSHOT'
+	version = '0.72.0-SNAPSHOT'
 
 	ext {
 		artifactGroup = "${group}.${rootProject.name}"

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ repositories { mavenCentral() }
 
 subprojects {
 	group = 'bio.terra'
-	version = '0.69.0-SNAPSHOT'
+	version = '0.70.0-SNAPSHOT'
 
 	ext {
 		artifactGroup = "${group}.${rootProject.name}"

--- a/service/src/main/java/bio/terra/drshub/services/DrsApiFactory.java
+++ b/service/src/main/java/bio/terra/drshub/services/DrsApiFactory.java
@@ -3,18 +3,11 @@ package bio.terra.drshub.services;
 import bio.terra.drshub.config.DrsProvider;
 import bio.terra.drshub.models.DrsApi;
 import io.github.ga4gh.drs.client.ApiClient;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import lombok.extern.slf4j.Slf4j;
-import nl.altindag.ssl.SSLFactory;
-import nl.altindag.ssl.util.Apache4SslUtils;
-import nl.altindag.ssl.util.PemUtils;
-import org.apache.http.config.Registry;
-import org.apache.http.config.RegistryBuilder;
-import org.apache.http.conn.socket.ConnectionSocketFactory;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClients;
-import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
-import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponents;
@@ -23,19 +16,25 @@ import org.springframework.web.util.UriComponents;
 @Slf4j
 public class DrsApiFactory {
 
-  private static final Integer CONNECTION_POOL_SIZE = 500;
+  private final RestTemplateFactory restTemplateFactory;
+
+  /**
+   * We create a new ApiClient for each call so that headers and tokens are not shared between
+   * calls, but each DRS provider can safely share one RestTemplate among its ApiClients.
+   */
+  private final Map<String, RestTemplate> restTemplateCache =
+      Collections.synchronizedMap(new HashMap<>());
+
+  public DrsApiFactory(RestTemplateFactory restTemplateFactory) {
+    this.restTemplateFactory = restTemplateFactory;
+  }
 
   public DrsApi getApiFromUriComponents(UriComponents uriComponents, DrsProvider drsProvider) {
-    log.info(
+    log.debug(
         "Creating new DrsApi client for host '{}', for DRS Provider '{}'",
         uriComponents.getHost(),
         drsProvider.getName());
-    var mTlsConfig = drsProvider.getMTlsConfig();
-    var drsClient =
-        mTlsConfig == null
-            ? new ApiClient(makeRestTemplateWithPooling())
-            : new ApiClient(
-                makeMTlsRestTemplateWithPooling(mTlsConfig.getCertPath(), mTlsConfig.getKeyPath()));
+    var drsClient = new ApiClient(getOrCreateRestTemplate(drsProvider));
 
     drsClient.setBasePath(
         drsClient
@@ -45,36 +44,20 @@ public class DrsApiFactory {
     return new DrsApi(drsClient);
   }
 
-  RestTemplate makeRestTemplateWithPooling() {
-    PoolingHttpClientConnectionManager poolingConnManager =
-        new PoolingHttpClientConnectionManager();
-    poolingConnManager.setMaxTotal(CONNECTION_POOL_SIZE);
-    poolingConnManager.setDefaultMaxPerRoute(CONNECTION_POOL_SIZE);
-    CloseableHttpClient httpClient =
-        HttpClients.custom().setConnectionManager(poolingConnManager).build();
-    HttpComponentsClientHttpRequestFactory factory =
-        new HttpComponentsClientHttpRequestFactory(httpClient);
-    return new RestTemplate(factory);
-  }
-
-  public RestTemplate makeMTlsRestTemplateWithPooling(String certPath, String keyPath) {
-    var keyManager = PemUtils.loadIdentityMaterial(certPath, keyPath);
-    var sslFactory = SSLFactory.builder().withIdentityMaterial(keyManager).build();
-    var socketFactory = Apache4SslUtils.toSocketFactory(sslFactory);
-    Registry<ConnectionSocketFactory> socketFactoryRegistry =
-        RegistryBuilder.<ConnectionSocketFactory>create().register("https", socketFactory).build();
-
-    PoolingHttpClientConnectionManager poolingConnManager =
-        new PoolingHttpClientConnectionManager(socketFactoryRegistry);
-    poolingConnManager.setMaxTotal(CONNECTION_POOL_SIZE);
-    poolingConnManager.setDefaultMaxPerRoute(CONNECTION_POOL_SIZE);
-    CloseableHttpClient httpClient =
-        HttpClients.custom()
-            .setSSLSocketFactory(socketFactory)
-            .setConnectionManager(poolingConnManager)
-            .build();
-    HttpComponentsClientHttpRequestFactory factory =
-        new HttpComponentsClientHttpRequestFactory(httpClient);
-    return new RestTemplate(factory);
+  private RestTemplate getOrCreateRestTemplate(DrsProvider drsProvider) {
+    var name = drsProvider.getName();
+    if (restTemplateCache.containsKey(name)) {
+      log.debug("Cache hit. Reusing RestTemplate for DRS Provider '{}'", name);
+    }
+    return restTemplateCache.computeIfAbsent(
+        name,
+        n -> {
+          log.info("Cache miss. Creating RestTemplate for DRS Provider '{}'", name);
+          var mTlsConfig = drsProvider.getMTlsConfig();
+          if (mTlsConfig == null) {
+            return restTemplateFactory.makeRestTemplateWithPooling();
+          }
+          return restTemplateFactory.makeMTlsRestTemplateWithPooling(mTlsConfig);
+        });
   }
 }

--- a/service/src/main/java/bio/terra/drshub/services/RestTemplateFactory.java
+++ b/service/src/main/java/bio/terra/drshub/services/RestTemplateFactory.java
@@ -1,0 +1,62 @@
+package bio.terra.drshub.services;
+
+import bio.terra.drshub.config.MTlsConfig;
+import lombok.extern.slf4j.Slf4j;
+import nl.altindag.ssl.SSLFactory;
+import nl.altindag.ssl.util.Apache4SslUtils;
+import nl.altindag.ssl.util.PemUtils;
+import org.apache.http.config.Registry;
+import org.apache.http.config.RegistryBuilder;
+import org.apache.http.conn.socket.ConnectionSocketFactory;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+@Service
+@Slf4j
+public class RestTemplateFactory {
+
+  private static final Integer CONNECTION_POOL_SIZE = 500;
+
+  /** @return a new RestTemplate backed by a pooling connection manager */
+  public RestTemplate makeRestTemplateWithPooling() {
+    PoolingHttpClientConnectionManager poolingConnManager =
+        new PoolingHttpClientConnectionManager();
+    poolingConnManager.setMaxTotal(CONNECTION_POOL_SIZE);
+    poolingConnManager.setDefaultMaxPerRoute(CONNECTION_POOL_SIZE);
+    CloseableHttpClient httpClient =
+        HttpClients.custom().setConnectionManager(poolingConnManager).build();
+    HttpComponentsClientHttpRequestFactory factory =
+        new HttpComponentsClientHttpRequestFactory(httpClient);
+    return new RestTemplate(factory);
+  }
+
+  /**
+   * @return a new RestTemplate backed by a pooling connection manager using mutual TLS (the client
+   *     must also be authenticated)
+   */
+  public RestTemplate makeMTlsRestTemplateWithPooling(MTlsConfig mTlsConfig) {
+    var keyManager =
+        PemUtils.loadIdentityMaterial(mTlsConfig.getCertPath(), mTlsConfig.getKeyPath());
+    var sslFactory = SSLFactory.builder().withIdentityMaterial(keyManager).build();
+    var socketFactory = Apache4SslUtils.toSocketFactory(sslFactory);
+    Registry<ConnectionSocketFactory> socketFactoryRegistry =
+        RegistryBuilder.<ConnectionSocketFactory>create().register("https", socketFactory).build();
+
+    PoolingHttpClientConnectionManager poolingConnManager =
+        new PoolingHttpClientConnectionManager(socketFactoryRegistry);
+    poolingConnManager.setMaxTotal(CONNECTION_POOL_SIZE);
+    poolingConnManager.setDefaultMaxPerRoute(CONNECTION_POOL_SIZE);
+    CloseableHttpClient httpClient =
+        HttpClients.custom()
+            .setSSLSocketFactory(socketFactory)
+            .setConnectionManager(poolingConnManager)
+            .build();
+    HttpComponentsClientHttpRequestFactory factory =
+        new HttpComponentsClientHttpRequestFactory(httpClient);
+    return new RestTemplate(factory);
+  }
+}

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -69,6 +69,14 @@ management:
       exposure:
         # Expose all management endpoints in Spring Boot
         include: "*"
+  metrics:
+    distribution:
+      # Used to publish a histogram suitable for computing aggregable (across dimensions) percentile
+      # latency approximations in Prometheus (by using histogram_quantile)
+      # For more information: https://micrometer.io/docs/concepts#_histograms_and_percentiles
+      minimum-expected-value[http.server.requests]: 200ms
+      maximum-expected-value[http.server.requests]: 60s
+      percentiles-histogram[http.server.requests]: true
   server:
     # Expose metrics on a different port than our app so that they aren't exposed with other endpoints
     port: 9098

--- a/service/src/test/java/bio/terra/drshub/services/DrsApiFactoryTest.java
+++ b/service/src/test/java/bio/terra/drshub/services/DrsApiFactoryTest.java
@@ -1,57 +1,84 @@
 package bio.terra.drshub.services;
 
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 
-import bio.terra.drshub.BaseTest;
 import bio.terra.drshub.config.DrsProvider;
 import bio.terra.drshub.config.MTlsConfig;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponents;
 import org.springframework.web.util.UriComponentsBuilder;
 
 @Tag("Unit")
-public class DrsApiFactoryTest extends BaseTest {
+@ExtendWith(MockitoExtension.class)
+public class DrsApiFactoryTest {
 
-  @Autowired DrsApiFactory drsApiFactory;
+  @Spy private RestTemplateFactory restTemplateFactory;
+  private DrsApiFactory drsApiFactory;
+  private static final UriComponents URI_COMPONENTS =
+      UriComponentsBuilder.newInstance().host("test").build();
+
+  @BeforeEach
+  void setup() {
+    drsApiFactory = new DrsApiFactory(restTemplateFactory);
+  }
+
+  private DrsProvider createDrsProvider() {
+    return DrsProvider.create().setName("testDrsProvider");
+  }
 
   @Test
   void testMTlsConfigured() {
     var mTlsConfig = MTlsConfig.create().setCertPath("fake.crt").setKeyPath("fake.key");
-    var drsProvider = DrsProvider.create().setMTlsConfig(mTlsConfig).setName("testMtlsDrsProvider");
-    var spy = spy(drsApiFactory);
+    when(restTemplateFactory.makeMTlsRestTemplateWithPooling(mTlsConfig))
+        .thenReturn(new RestTemplate());
 
-    spy.getApiFromUriComponents(
-        UriComponentsBuilder.newInstance().host("test").build(), drsProvider);
+    drsApiFactory.getApiFromUriComponents(
+        URI_COMPONENTS, createDrsProvider().setMTlsConfig(mTlsConfig));
 
-    verify(spy).makeMTlsRestTemplateWithPooling(mTlsConfig.getCertPath(), mTlsConfig.getKeyPath());
+    verify(restTemplateFactory, never()).makeRestTemplateWithPooling();
   }
 
   @Test
   void testMTlsNotConfigured() {
-    var drsProvider = DrsProvider.create().setName("testDrsProvider");
-    var spy = spy(drsApiFactory);
+    when(restTemplateFactory.makeRestTemplateWithPooling()).thenReturn(new RestTemplate());
 
-    spy.getApiFromUriComponents(
-        UriComponentsBuilder.newInstance().host("test").build(), drsProvider);
+    drsApiFactory.getApiFromUriComponents(URI_COMPONENTS, createDrsProvider());
 
-    verify(spy, never()).makeMTlsRestTemplateWithPooling(anyString(), anyString());
+    verify(restTemplateFactory, never()).makeMTlsRestTemplateWithPooling(any(MTlsConfig.class));
   }
 
   @Test
   void testIndependentApiClients() {
-    var drsProvider = DrsProvider.create().setName("testDrsProvider");
-    var client1 =
-        drsApiFactory.getApiFromUriComponents(
-            UriComponentsBuilder.newInstance().host("test").build(), drsProvider);
+    var drsProvider = createDrsProvider();
+    when(restTemplateFactory.makeRestTemplateWithPooling()).thenReturn(new RestTemplate());
+
+    // The first ApiClient created for a DrsProvider will populate the RestTemplate cache
+    var client1 = drsApiFactory.getApiFromUriComponents(URI_COMPONENTS, drsProvider);
+    verify(restTemplateFactory).makeRestTemplateWithPooling();
+
+    // Subsequent ApiClients created for the same DrsProvider will reuse the cached RestTemplate
     var separateApiClient =
-        spy(
-            drsApiFactory
-                .getApiFromUriComponents(
-                    UriComponentsBuilder.newInstance().host("test").build(), drsProvider)
-                .getApiClient());
+        spy(drsApiFactory.getApiFromUriComponents(URI_COMPONENTS, drsProvider).getApiClient());
+    verifyNoMoreInteractions(restTemplateFactory);
+
+    // Setting the token or headers on an ApiClient will have no effect on ApiClients created for
+    // the same DrsProvider
+    client1.setBearerToken("bearer-token");
+    verifyNoInteractions(separateApiClient);
+
     client1.setHeader("test-header", "test-value");
-    verify(separateApiClient, never()).addDefaultHeader(anyString(), anyString());
+    verifyNoInteractions(separateApiClient);
   }
 }


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DR-3369

Each `DrsProvider` will still have new `ApiClients` made on request, but now they will all share the same backing `RestTemplate`. This brings behavior in line with the caching present at our last successful scale test in August '23, without sharing headers between requests (the impetus for the rollback).