### PR TITLE
[DR-3374] Micrometer: publish percentile histograms for per-endpoint latencies

### DIFF
--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -69,6 +69,12 @@ management:
       exposure:
         # Expose all management endpoints in Spring Boot
         include: "*"
+  metrics:
+    distribution:
+      # Used to publish a histogram suitable for computing aggregable (across dimensions) percentile
+      # latency approximations in Prometheus (by using histogram_quantile)
+      # For more information: https://micrometer.io/docs/concepts#_histograms_and_percentiles
+      percentiles-histogram[http.server.requests]: true
   server:
     # Expose metrics on a different port than our app so that they aren't exposed with other endpoints
     port: 9098

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -74,6 +74,8 @@ management:
       # Used to publish a histogram suitable for computing aggregable (across dimensions) percentile
       # latency approximations in Prometheus (by using histogram_quantile)
       # For more information: https://micrometer.io/docs/concepts#_histograms_and_percentiles
+      minimum-expected-value[http.server.requests]: 200ms
+      maximum-expected-value[http.server.requests]: 60s
       percentiles-histogram[http.server.requests]: true
   server:
     # Expose metrics on a different port than our app so that they aren't exposed with other endpoints


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DR-3374

We are currently equipped to calculate average per-endpoint latencies in DrsHub, but it would be preferable to be able to calculate rolling percentiles of these per-endpoint latencies, and expose them in [Grafana](https://grafana.dsp-devops.broadinstitute.org/d/DCzG49SSk/drshub?orgId=1).  This will help us develop meaningful SLOs and quickly assess whether we are meeting them.

Off a local DrsHub, I interacted with the `/api/v4/drs/resolve` endpoint 10 times, then noted that the following metrics were present.

```
(base) okotsopo@wm111-e35 terra-drs-hub % curl localhost:9098/actuator/prometheus | grep http_server_requests_seconds_bucket | grep /api/v4/drs/resolve
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 34710  100 34710    0     0  6063k      0 --:--:-- --:--:-- --:--:-- 6779k
http_server_requests_seconds_bucket{exception="None",method="POST",outcome="SUCCESS",status="200",uri="/api/v4/drs/resolve",le="0.2",} 0.0
http_server_requests_seconds_bucket{exception="None",method="POST",outcome="SUCCESS",status="200",uri="/api/v4/drs/resolve",le="0.20132659",} 0.0
http_server_requests_seconds_bucket{exception="None",method="POST",outcome="SUCCESS",status="200",uri="/api/v4/drs/resolve",le="0.223696211",} 0.0
http_server_requests_seconds_bucket{exception="None",method="POST",outcome="SUCCESS",status="200",uri="/api/v4/drs/resolve",le="0.246065832",} 0.0
http_server_requests_seconds_bucket{exception="None",method="POST",outcome="SUCCESS",status="200",uri="/api/v4/drs/resolve",le="0.268435456",} 0.0
http_server_requests_seconds_bucket{exception="None",method="POST",outcome="SUCCESS",status="200",uri="/api/v4/drs/resolve",le="0.357913941",} 0.0
http_server_requests_seconds_bucket{exception="None",method="POST",outcome="SUCCESS",status="200",uri="/api/v4/drs/resolve",le="0.447392426",} 0.0
http_server_requests_seconds_bucket{exception="None",method="POST",outcome="SUCCESS",status="200",uri="/api/v4/drs/resolve",le="0.536870911",} 0.0
http_server_requests_seconds_bucket{exception="None",method="POST",outcome="SUCCESS",status="200",uri="/api/v4/drs/resolve",le="0.626349396",} 4.0
http_server_requests_seconds_bucket{exception="None",method="POST",outcome="SUCCESS",status="200",uri="/api/v4/drs/resolve",le="0.715827881",} 6.0
http_server_requests_seconds_bucket{exception="None",method="POST",outcome="SUCCESS",status="200",uri="/api/v4/drs/resolve",le="0.805306366",} 9.0
http_server_requests_seconds_bucket{exception="None",method="POST",outcome="SUCCESS",status="200",uri="/api/v4/drs/resolve",le="0.894784851",} 9.0
http_server_requests_seconds_bucket{exception="None",method="POST",outcome="SUCCESS",status="200",uri="/api/v4/drs/resolve",le="0.984263336",} 9.0
http_server_requests_seconds_bucket{exception="None",method="POST",outcome="SUCCESS",status="200",uri="/api/v4/drs/resolve",le="1.073741824",} 9.0
http_server_requests_seconds_bucket{exception="None",method="POST",outcome="SUCCESS",status="200",uri="/api/v4/drs/resolve",le="1.431655765",} 9.0
http_server_requests_seconds_bucket{exception="None",method="POST",outcome="SUCCESS",status="200",uri="/api/v4/drs/resolve",le="1.789569706",} 9.0
http_server_requests_seconds_bucket{exception="None",method="POST",outcome="SUCCESS",status="200",uri="/api/v4/drs/resolve",le="2.147483647",} 9.0
http_server_requests_seconds_bucket{exception="None",method="POST",outcome="SUCCESS",status="200",uri="/api/v4/drs/resolve",le="2.505397588",} 9.0
http_server_requests_seconds_bucket{exception="None",method="POST",outcome="SUCCESS",status="200",uri="/api/v4/drs/resolve",le="2.863311529",} 10.0
http_server_requests_seconds_bucket{exception="None",method="POST",outcome="SUCCESS",status="200",uri="/api/v4/drs/resolve",le="3.22122547",} 10.0
http_server_requests_seconds_bucket{exception="None",method="POST",outcome="SUCCESS",status="200",uri="/api/v4/drs/resolve",le="3.579139411",} 10.0
http_server_requests_seconds_bucket{exception="None",method="POST",outcome="SUCCESS",status="200",uri="/api/v4/drs/resolve",le="3.937053352",} 10.0
http_server_requests_seconds_bucket{exception="None",method="POST",outcome="SUCCESS",status="200",uri="/api/v4/drs/resolve",le="4.294967296",} 10.0
http_server_requests_seconds_bucket{exception="None",method="POST",outcome="SUCCESS",status="200",uri="/api/v4/drs/resolve",le="5.726623061",} 10.0
http_server_requests_seconds_bucket{exception="None",method="POST",outcome="SUCCESS",status="200",uri="/api/v4/drs/resolve",le="7.158278826",} 10.0
http_server_requests_seconds_bucket{exception="None",method="POST",outcome="SUCCESS",status="200",uri="/api/v4/drs/resolve",le="8.589934591",} 10.0
http_server_requests_seconds_bucket{exception="None",method="POST",outcome="SUCCESS",status="200",uri="/api/v4/drs/resolve",le="10.021590356",} 10.0
http_server_requests_seconds_bucket{exception="None",method="POST",outcome="SUCCESS",status="200",uri="/api/v4/drs/resolve",le="11.453246121",} 10.0
http_server_requests_seconds_bucket{exception="None",method="POST",outcome="SUCCESS",status="200",uri="/api/v4/drs/resolve",le="12.884901886",} 10.0
http_server_requests_seconds_bucket{exception="None",method="POST",outcome="SUCCESS",status="200",uri="/api/v4/drs/resolve",le="14.316557651",} 10.0
http_server_requests_seconds_bucket{exception="None",method="POST",outcome="SUCCESS",status="200",uri="/api/v4/drs/resolve",le="15.748213416",} 10.0
http_server_requests_seconds_bucket{exception="None",method="POST",outcome="SUCCESS",status="200",uri="/api/v4/drs/resolve",le="17.179869184",} 10.0
http_server_requests_seconds_bucket{exception="None",method="POST",outcome="SUCCESS",status="200",uri="/api/v4/drs/resolve",le="22.906492245",} 10.0
http_server_requests_seconds_bucket{exception="None",method="POST",outcome="SUCCESS",status="200",uri="/api/v4/drs/resolve",le="28.633115306",} 10.0
http_server_requests_seconds_bucket{exception="None",method="POST",outcome="SUCCESS",status="200",uri="/api/v4/drs/resolve",le="34.359738367",} 10.0
http_server_requests_seconds_bucket{exception="None",method="POST",outcome="SUCCESS",status="200",uri="/api/v4/drs/resolve",le="40.086361428",} 10.0
http_server_requests_seconds_bucket{exception="None",method="POST",outcome="SUCCESS",status="200",uri="/api/v4/drs/resolve",le="45.812984489",} 10.0
http_server_requests_seconds_bucket{exception="None",method="POST",outcome="SUCCESS",status="200",uri="/api/v4/drs/resolve",le="51.53960755",} 10.0
http_server_requests_seconds_bucket{exception="None",method="POST",outcome="SUCCESS",status="200",uri="/api/v4/drs/resolve",le="57.266230611",} 10.0
http_server_requests_seconds_bucket{exception="None",method="POST",outcome="SUCCESS",status="200",uri="/api/v4/drs/resolve",le="60.0",} 10.0
http_server_requests_seconds_bucket{exception="None",method="POST",outcome="SUCCESS",status="200",uri="/api/v4/drs/resolve",le="+Inf",} 10.0
```

Here's a translation of what a subset of those bucket metrics mean:
```
http_server_requests_seconds_bucket{exception="None",method="POST",outcome="SUCCESS",status="200",uri="/api/v4/drs/resolve",le="0.536870911",} 0.0
http_server_requests_seconds_bucket{exception="None",method="POST",outcome="SUCCESS",status="200",uri="/api/v4/drs/resolve",le="0.626349396",} 4.0
…
http_server_requests_seconds_bucket{exception="None",method="POST",outcome="SUCCESS",status="200",uri="/api/v4/drs/resolve",le="3.579139411",} 10.0
```
For as long as we have been collecting these metrics…
- 0 successful DRS resolutions completed within 0.54 seconds
- 4 successful DRS resolutions completed within 0.63 seconds
- 10 successful DRS resolutions completed within 3.58 seconds

Note that these buckets "stack" on top of each other: so the 4 successful DRS resolutions in that second metric are also included in the third metric.

The way these metrics are generated allows Prometheus to aggregate them across different dimensions, which is super valuable to us.  For example, our DrsHub deployment actually runs 12 servers together, and each generates their own set of metrics like this: when thinking of how our endpoints are performing, we are interested in learning more about the latency across all of those servers.  Or we might want to view latency for the successful DRS resolutions versus the unsuccessful ones.

Once merged, I will update the DrsHub Grafana dashboard to calculate latency percentiles from these figures.

Relevant documentation:
- https://micrometer.io/docs/concepts#_histograms_and_percentiles
- [histogram_quantile query function | Prometheus]
-(https://prometheus.io/docs/prometheus/latest/querying/functions/#histogram_quantile)