### PR TITLE
[DR-3369] ApiClients share RestTemplates

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,12 +100,20 @@ DrsHub uses Gradle as a build tool. Some common Gradle commands you may want to 
 ./gradlew jib # Build the DrsHub Docker image
 ```
 
-### Run Integration Tests
-DrsHub uses [TestRunner](https://github.com/DataBiosphere/terra-test-runner) to run its integration tests.
+### Run Integration or Performance Tests
+DrsHub uses [TestRunner](https://github.com/DataBiosphere/terra-test-runner) to run its integration
+and performance tests.
+
 To run the integration test suite, run
 ```shell
 ./gradlew runTest --args="suites/FullIntegration.json /tmp/test-results"
 ```
+
+To run the performance test suite, run
+```shell
+./gradlew runTest --args="suites/FullPerf.json /tmp/test-results"
+```
+
 Adding `--stacktrace` can give you more debugging information, if needed.
 
 ### Run Pact Tests
@@ -133,9 +141,6 @@ DrsHub runs in Kubernetes in GCP. Current deployments for each env can be found 
 - Alpha
   - [Kubernetes Deployment](https://console.cloud.google.com/kubernetes/deployment/us-central1-a/terra-alpha/terra-alpha/drshub-deployment/overview?project=broad-dsde-alpha)
   - [Swagger UI](https://drshub.dsde-alpha.broadinstitute.org/)
-- Perf
-  - [Kubernetes Deployment](https://console.cloud.google.com/kubernetes/deployment/us-central1-a/terra-perf/terra-perf/drshub-deployment/overview?project=broad-dsde-perf)
-  - [Swagger UI](https://drshub.dsde-perf.broadinstitute.org/)
 - Staging
   - [Kubernetes Deployment](https://console.cloud.google.com/kubernetes/deployment/us-central1-a/terra-staging/terra-staging/drshub-deployment/overview?project=broad-dsde-staging)
   - [Swagger UI](https://drshub.dsde-staging.broadinstitute.org/)

--- a/integration/src/main/resources/configs/perf/GetStatus.json
+++ b/integration/src/main/resources/configs/perf/GetStatus.json
@@ -1,6 +1,6 @@
 {
   "name": "GetStatus",
-  "description": "Check the service status once. No authentication required.",
+  "description": "Check the service status 10 times. No authentication required.",
   "serverSpecificationFile": "drshub-local.json",
   "kubernetes": {},
   "application": {},

--- a/integration/src/main/resources/configs/perf/GetVersion.json
+++ b/integration/src/main/resources/configs/perf/GetVersion.json
@@ -1,6 +1,6 @@
 {
   "name": "GetVersion",
-  "description": "Check the version endpoint once. No authentication required.",
+  "description": "Check the version endpoint 10 times. No authentication required.",
   "serverSpecificationFile": "drshub-local.json",
   "kubernetes": {},
   "application": {},

--- a/integration/src/main/resources/configs/perf/ResolveTdrDrs100.json
+++ b/integration/src/main/resources/configs/perf/ResolveTdrDrs100.json
@@ -7,8 +7,8 @@
   "testScripts": [
     {
       "name": "ResolveTdrDrs",
-      "numberOfUserJourneyThreadsToRun": 110,
-      "userJourneyThreadPoolSize": 100,
+      "numberOfUserJourneyThreadsToRun": 100,
+      "userJourneyThreadPoolSize": 110,
       "expectedTimeForEach": 10,
       "expectedTimeForEachUnit": "SECONDS"
     }

--- a/integration/src/main/resources/configs/perf/ResolveTdrDrs100.json
+++ b/integration/src/main/resources/configs/perf/ResolveTdrDrs100.json
@@ -1,0 +1,17 @@
+{
+  "name": "ResolveTdrDrs100",
+  "description": "100 concurrent attempts to resolve DRS URIs from TDR.",
+  "serverSpecificationFile": "drshub-local.json",
+  "kubernetes": {},
+  "application": {},
+  "testScripts": [
+    {
+      "name": "ResolveTdrDrs",
+      "numberOfUserJourneyThreadsToRun": 110,
+      "userJourneyThreadPoolSize": 100,
+      "expectedTimeForEach": 10,
+      "expectedTimeForEachUnit": "SECONDS"
+    }
+  ],
+  "testUserFiles": ["scarlett.json"]
+}

--- a/integration/src/main/resources/configs/perf/ResolveTdrDrs50.json
+++ b/integration/src/main/resources/configs/perf/ResolveTdrDrs50.json
@@ -1,0 +1,17 @@
+{
+  "name": "ResolveTdrDrs50",
+  "description": "50 concurrent attempts to resolve DRS URIs from TDR.",
+  "serverSpecificationFile": "drshub-local.json",
+  "kubernetes": {},
+  "application": {},
+  "testScripts": [
+    {
+      "name": "ResolveTdrDrs",
+      "numberOfUserJourneyThreadsToRun": 60,
+      "userJourneyThreadPoolSize": 50,
+      "expectedTimeForEach": 10,
+      "expectedTimeForEachUnit": "SECONDS"
+    }
+  ],
+  "testUserFiles": ["scarlett.json"]
+}

--- a/integration/src/main/resources/suites/FullPerf.json
+++ b/integration/src/main/resources/suites/FullPerf.json
@@ -1,9 +1,11 @@
 {
   "name": "FullPerf",
-  "description": "All perf tests",
-  "serverSpecificationFile": "drshub-perf.json",
+  "description": "All perf tests locally in the absence of a live perf environment (see: DR-3380)",
+  "serverSpecificationFile": "drshub-local.json",
   "testConfigurationFiles": [
     "perf/GetStatus.json",
-    "perf/GetVersion.json"
+    "perf/GetVersion.json",
+    "perf/ResolveTdrDrs50.json",
+    "perf/ResolveTdrDrs100.json"
   ]
 }

--- a/service/src/main/java/bio/terra/drshub/config/DrsHubConfigInterface.java
+++ b/service/src/main/java/bio/terra/drshub/config/DrsHubConfigInterface.java
@@ -33,6 +33,8 @@ public interface DrsHubConfigInterface {
 
   Integer asyncThreads();
 
+  int restTemplateConnectionPoolSize();
+
   // If this is true, then we will track calls to the Bard API in MixPanel in addition to the
   // BigQuery Data warehouse.
   Boolean trackInMixPanel();

--- a/service/src/main/java/bio/terra/drshub/services/DrsApiClientFactory.java
+++ b/service/src/main/java/bio/terra/drshub/services/DrsApiClientFactory.java
@@ -1,0 +1,13 @@
+package bio.terra.drshub.services;
+
+import io.github.ga4gh.drs.client.ApiClient;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+@Component
+public class DrsApiClientFactory {
+
+  ApiClient createClient(RestTemplate restTemplate) {
+    return new ApiClient(restTemplate);
+  }
+}

--- a/service/src/main/java/bio/terra/drshub/services/DrsApiFactory.java
+++ b/service/src/main/java/bio/terra/drshub/services/DrsApiFactory.java
@@ -3,18 +3,11 @@ package bio.terra.drshub.services;
 import bio.terra.drshub.config.DrsProvider;
 import bio.terra.drshub.models.DrsApi;
 import io.github.ga4gh.drs.client.ApiClient;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import lombok.extern.slf4j.Slf4j;
-import nl.altindag.ssl.SSLFactory;
-import nl.altindag.ssl.util.Apache4SslUtils;
-import nl.altindag.ssl.util.PemUtils;
-import org.apache.http.config.Registry;
-import org.apache.http.config.RegistryBuilder;
-import org.apache.http.conn.socket.ConnectionSocketFactory;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClients;
-import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
-import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponents;
@@ -23,19 +16,25 @@ import org.springframework.web.util.UriComponents;
 @Slf4j
 public class DrsApiFactory {
 
-  private static final Integer CONNECTION_POOL_SIZE = 500;
+  private final RestTemplateFactory restTemplateFactory;
+
+  /**
+   * We create a new ApiClient for each call so that headers and tokens are not shared between
+   * calls, but each DRS provider can safely share one RestTemplate among its ApiClients.
+   */
+  private final Map<String, RestTemplate> restTemplateCache =
+      Collections.synchronizedMap(new HashMap<>());
+
+  public DrsApiFactory(RestTemplateFactory restTemplateFactory) {
+    this.restTemplateFactory = restTemplateFactory;
+  }
 
   public DrsApi getApiFromUriComponents(UriComponents uriComponents, DrsProvider drsProvider) {
-    log.info(
+    log.debug(
         "Creating new DrsApi client for host '{}', for DRS Provider '{}'",
         uriComponents.getHost(),
         drsProvider.getName());
-    var mTlsConfig = drsProvider.getMTlsConfig();
-    var drsClient =
-        mTlsConfig == null
-            ? new ApiClient(makeRestTemplateWithPooling())
-            : new ApiClient(
-                makeMTlsRestTemplateWithPooling(mTlsConfig.getCertPath(), mTlsConfig.getKeyPath()));
+    var drsClient = new ApiClient(getOrCreateRestTemplate(drsProvider));
 
     drsClient.setBasePath(
         drsClient
@@ -45,36 +44,20 @@ public class DrsApiFactory {
     return new DrsApi(drsClient);
   }
 
-  RestTemplate makeRestTemplateWithPooling() {
-    PoolingHttpClientConnectionManager poolingConnManager =
-        new PoolingHttpClientConnectionManager();
-    poolingConnManager.setMaxTotal(CONNECTION_POOL_SIZE);
-    poolingConnManager.setDefaultMaxPerRoute(CONNECTION_POOL_SIZE);
-    CloseableHttpClient httpClient =
-        HttpClients.custom().setConnectionManager(poolingConnManager).build();
-    HttpComponentsClientHttpRequestFactory factory =
-        new HttpComponentsClientHttpRequestFactory(httpClient);
-    return new RestTemplate(factory);
-  }
-
-  public RestTemplate makeMTlsRestTemplateWithPooling(String certPath, String keyPath) {
-    var keyManager = PemUtils.loadIdentityMaterial(certPath, keyPath);
-    var sslFactory = SSLFactory.builder().withIdentityMaterial(keyManager).build();
-    var socketFactory = Apache4SslUtils.toSocketFactory(sslFactory);
-    Registry<ConnectionSocketFactory> socketFactoryRegistry =
-        RegistryBuilder.<ConnectionSocketFactory>create().register("https", socketFactory).build();
-
-    PoolingHttpClientConnectionManager poolingConnManager =
-        new PoolingHttpClientConnectionManager(socketFactoryRegistry);
-    poolingConnManager.setMaxTotal(CONNECTION_POOL_SIZE);
-    poolingConnManager.setDefaultMaxPerRoute(CONNECTION_POOL_SIZE);
-    CloseableHttpClient httpClient =
-        HttpClients.custom()
-            .setSSLSocketFactory(socketFactory)
-            .setConnectionManager(poolingConnManager)
-            .build();
-    HttpComponentsClientHttpRequestFactory factory =
-        new HttpComponentsClientHttpRequestFactory(httpClient);
-    return new RestTemplate(factory);
+  private RestTemplate getOrCreateRestTemplate(DrsProvider drsProvider) {
+    var name = drsProvider.getName();
+    if (restTemplateCache.containsKey(name)) {
+      log.debug("Cache hit. Reusing RestTemplate for DRS Provider '{}'", name);
+    }
+    return restTemplateCache.computeIfAbsent(
+        name,
+        n -> {
+          log.info("Cache miss. Creating RestTemplate for DRS Provider '{}'", name);
+          var mTlsConfig = drsProvider.getMTlsConfig();
+          if (mTlsConfig == null) {
+            return restTemplateFactory.makeRestTemplateWithPooling();
+          }
+          return restTemplateFactory.makeMTlsRestTemplateWithPooling(mTlsConfig);
+        });
   }
 }

--- a/service/src/main/java/bio/terra/drshub/services/DrsApiFactory.java
+++ b/service/src/main/java/bio/terra/drshub/services/DrsApiFactory.java
@@ -2,7 +2,6 @@ package bio.terra.drshub.services;
 
 import bio.terra.drshub.config.DrsProvider;
 import bio.terra.drshub.models.DrsApi;
-import io.github.ga4gh.drs.client.ApiClient;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -17,6 +16,7 @@ import org.springframework.web.util.UriComponents;
 public class DrsApiFactory {
 
   private final RestTemplateFactory restTemplateFactory;
+  private final DrsApiClientFactory drsApiClientFactory;
 
   /**
    * We create a new ApiClient for each call so that headers and tokens are not shared between
@@ -25,8 +25,10 @@ public class DrsApiFactory {
   private final Map<String, RestTemplate> restTemplateCache =
       Collections.synchronizedMap(new HashMap<>());
 
-  public DrsApiFactory(RestTemplateFactory restTemplateFactory) {
+  public DrsApiFactory(
+      RestTemplateFactory restTemplateFactory, DrsApiClientFactory drsApiClientFactory) {
     this.restTemplateFactory = restTemplateFactory;
+    this.drsApiClientFactory = drsApiClientFactory;
   }
 
   public DrsApi getApiFromUriComponents(UriComponents uriComponents, DrsProvider drsProvider) {
@@ -34,7 +36,7 @@ public class DrsApiFactory {
         "Creating new DrsApi client for host '{}', for DRS Provider '{}'",
         uriComponents.getHost(),
         drsProvider.getName());
-    var drsClient = new ApiClient(getOrCreateRestTemplate(drsProvider));
+    var drsClient = drsApiClientFactory.createClient(getOrCreateRestTemplate(drsProvider));
 
     drsClient.setBasePath(
         drsClient

--- a/service/src/main/java/bio/terra/drshub/services/DrsApiFactory.java
+++ b/service/src/main/java/bio/terra/drshub/services/DrsApiFactory.java
@@ -22,7 +22,7 @@ public class DrsApiFactory {
    * We create a new ApiClient for each call so that headers and tokens are not shared between
    * calls, but each DRS provider can safely share one RestTemplate among its ApiClients.
    */
-  private static final Map<String, RestTemplate> REST_TEMPLATE_CACHE =
+  private final Map<String, RestTemplate> restTemplateCache =
       Collections.synchronizedMap(new HashMap<>());
 
   public DrsApiFactory(
@@ -51,12 +51,12 @@ public class DrsApiFactory {
     if (log.isDebugEnabled()) {
       // Normally checking for the presence of a key in a map is a lightweight operation, but we
       // don't want to obtain an unnecessary mutex lock on the backing synchronized map.
-      if (REST_TEMPLATE_CACHE.containsKey(name)) {
+      if (restTemplateCache.containsKey(name)) {
         log.debug("Cache hit. Reusing RestTemplate for DRS Provider '{}'", name);
       }
     }
 
-    return REST_TEMPLATE_CACHE.computeIfAbsent(
+    return restTemplateCache.computeIfAbsent(
         name,
         n -> {
           log.info("Cache miss. Creating RestTemplate for DRS Provider '{}'", name);

--- a/service/src/main/java/bio/terra/drshub/services/RestTemplateFactory.java
+++ b/service/src/main/java/bio/terra/drshub/services/RestTemplateFactory.java
@@ -1,7 +1,7 @@
 package bio.terra.drshub.services;
 
+import bio.terra.drshub.config.DrsHubConfig;
 import bio.terra.drshub.config.MTlsConfig;
-import lombok.extern.slf4j.Slf4j;
 import nl.altindag.ssl.SSLFactory;
 import nl.altindag.ssl.util.Apache4SslUtils;
 import nl.altindag.ssl.util.PemUtils;
@@ -16,17 +16,20 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
 @Service
-@Slf4j
 public class RestTemplateFactory {
 
-  private static final Integer CONNECTION_POOL_SIZE = 500;
+  private final int connectionPoolSize;
+
+  public RestTemplateFactory(DrsHubConfig drsHubConfig) {
+    connectionPoolSize = drsHubConfig.restTemplateConnectionPoolSize();
+  }
 
   /** @return a new RestTemplate backed by a pooling connection manager */
   public RestTemplate makeRestTemplateWithPooling() {
     PoolingHttpClientConnectionManager poolingConnManager =
         new PoolingHttpClientConnectionManager();
-    poolingConnManager.setMaxTotal(CONNECTION_POOL_SIZE);
-    poolingConnManager.setDefaultMaxPerRoute(CONNECTION_POOL_SIZE);
+    poolingConnManager.setMaxTotal(connectionPoolSize);
+    poolingConnManager.setDefaultMaxPerRoute(connectionPoolSize);
     CloseableHttpClient httpClient =
         HttpClients.custom().setConnectionManager(poolingConnManager).build();
     HttpComponentsClientHttpRequestFactory factory =
@@ -48,8 +51,8 @@ public class RestTemplateFactory {
 
     PoolingHttpClientConnectionManager poolingConnManager =
         new PoolingHttpClientConnectionManager(socketFactoryRegistry);
-    poolingConnManager.setMaxTotal(CONNECTION_POOL_SIZE);
-    poolingConnManager.setDefaultMaxPerRoute(CONNECTION_POOL_SIZE);
+    poolingConnManager.setMaxTotal(connectionPoolSize);
+    poolingConnManager.setDefaultMaxPerRoute(connectionPoolSize);
     CloseableHttpClient httpClient =
         HttpClients.custom()
             .setSSLSocketFactory(socketFactory)

--- a/service/src/main/java/bio/terra/drshub/services/RestTemplateFactory.java
+++ b/service/src/main/java/bio/terra/drshub/services/RestTemplateFactory.java
@@ -1,0 +1,62 @@
+package bio.terra.drshub.services;
+
+import bio.terra.drshub.config.MTlsConfig;
+import lombok.extern.slf4j.Slf4j;
+import nl.altindag.ssl.SSLFactory;
+import nl.altindag.ssl.util.Apache4SslUtils;
+import nl.altindag.ssl.util.PemUtils;
+import org.apache.http.config.Registry;
+import org.apache.http.config.RegistryBuilder;
+import org.apache.http.conn.socket.ConnectionSocketFactory;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+@Service
+@Slf4j
+public class RestTemplateFactory {
+
+  private static final Integer CONNECTION_POOL_SIZE = 500;
+
+  /** @return a new RestTemplate backed by a pooling connection manager */
+  public RestTemplate makeRestTemplateWithPooling() {
+    PoolingHttpClientConnectionManager poolingConnManager =
+        new PoolingHttpClientConnectionManager();
+    poolingConnManager.setMaxTotal(CONNECTION_POOL_SIZE);
+    poolingConnManager.setDefaultMaxPerRoute(CONNECTION_POOL_SIZE);
+    CloseableHttpClient httpClient =
+        HttpClients.custom().setConnectionManager(poolingConnManager).build();
+    HttpComponentsClientHttpRequestFactory factory =
+        new HttpComponentsClientHttpRequestFactory(httpClient);
+    return new RestTemplate(factory);
+  }
+
+  /**
+   * @return a new RestTemplate backed by a pooling connection manager using mutual TLS (the client
+   *     must also be authenticated)
+   */
+  public RestTemplate makeMTlsRestTemplateWithPooling(MTlsConfig mTlsConfig) {
+    var keyManager =
+        PemUtils.loadIdentityMaterial(mTlsConfig.getCertPath(), mTlsConfig.getKeyPath());
+    var sslFactory = SSLFactory.builder().withIdentityMaterial(keyManager).build();
+    var socketFactory = Apache4SslUtils.toSocketFactory(sslFactory);
+    Registry<ConnectionSocketFactory> socketFactoryRegistry =
+        RegistryBuilder.<ConnectionSocketFactory>create().register("https", socketFactory).build();
+
+    PoolingHttpClientConnectionManager poolingConnManager =
+        new PoolingHttpClientConnectionManager(socketFactoryRegistry);
+    poolingConnManager.setMaxTotal(CONNECTION_POOL_SIZE);
+    poolingConnManager.setDefaultMaxPerRoute(CONNECTION_POOL_SIZE);
+    CloseableHttpClient httpClient =
+        HttpClients.custom()
+            .setSSLSocketFactory(socketFactory)
+            .setConnectionManager(poolingConnManager)
+            .build();
+    HttpComponentsClientHttpRequestFactory factory =
+        new HttpComponentsClientHttpRequestFactory(httpClient);
+    return new RestTemplate(factory);
+  }
+}

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -59,6 +59,7 @@ drshub:
           fetchAccessUrl: true # Used for Azure
   pencilsDownSeconds: 58
   asyncThreads: ${TOMCAT_MAX_THREADS:200}
+  restTemplateConnectionPoolSize: ${REST_TEMPLATE_CONNECTION_POOL_SIZE:500}
   bardEventLoggingEnabled: ${BARD_EVENT_LOGGING_ENABLED:true}
   trackInMixpanel: false
 

--- a/service/src/test/java/bio/terra/drshub/models/DrsApiTest.java
+++ b/service/src/test/java/bio/terra/drshub/models/DrsApiTest.java
@@ -1,0 +1,49 @@
+package bio.terra.drshub.models;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.github.ga4gh.drs.client.ApiClient;
+import io.github.ga4gh.drs.client.auth.OAuth;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@Tag("Unit")
+@ExtendWith(MockitoExtension.class)
+class DrsApiTest {
+
+  @Mock private ApiClient apiClient;
+
+  private DrsApi drsApi;
+
+  @BeforeEach
+  void setup() {
+    drsApi = new DrsApi(apiClient);
+  }
+
+  @Test
+  void testSetBearerToken() {
+    var accessToken = "bearerToken";
+    var oAuth = mock(OAuth.class);
+    when(apiClient.getAuthentication("BearerAuth")).thenReturn(oAuth);
+
+    drsApi.setBearerToken(accessToken);
+
+    verify(oAuth).setAccessToken(accessToken);
+  }
+
+  @Test
+  void testSetHeader() {
+    var name = "name";
+    var value = "value";
+
+    drsApi.setHeader(name, value);
+
+    verify(apiClient).addDefaultHeader(name, value);
+  }
+}

--- a/service/src/test/java/bio/terra/drshub/services/DrsApiClientFactoryTest.java
+++ b/service/src/test/java/bio/terra/drshub/services/DrsApiClientFactoryTest.java
@@ -1,0 +1,41 @@
+package bio.terra.drshub.services;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsNot.not;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.client.RestTemplate;
+
+@Tag("Unit")
+class DrsApiClientFactoryTest {
+
+  private DrsApiClientFactory drsApiClientFactory;
+
+  @BeforeEach
+  void setup() {
+    drsApiClientFactory = new DrsApiClientFactory();
+  }
+
+  @Test
+  void testCreateClientWithCommonRestTemplate() {
+    var restTemplate = new RestTemplate();
+    var apiClient1 = drsApiClientFactory.createClient(restTemplate);
+    var apiClient2 = drsApiClientFactory.createClient(restTemplate);
+
+    assertThat("Factory creates new ApiClients", apiClient1, not(apiClient2));
+  }
+
+  @Test
+  void testCreateClientsWithDistinctRestTemplates() {
+    var restTemplate1 = new RestTemplate();
+    var restTemplate2 = new RestTemplate();
+
+    var apiClient1 = drsApiClientFactory.createClient(restTemplate1);
+    var apiClient2 = drsApiClientFactory.createClient(restTemplate2);
+
+    assertThat("RestTemplates are distinct", restTemplate1, not(restTemplate2));
+    assertThat("Factory creates new ApiClients", apiClient1, not(apiClient2));
+  }
+}

--- a/service/src/test/java/bio/terra/drshub/services/DrsApiFactoryTest.java
+++ b/service/src/test/java/bio/terra/drshub/services/DrsApiFactoryTest.java
@@ -80,7 +80,8 @@ class DrsApiFactoryTest {
     // If there was a cache miss, this would fail as the API would be called twice.
     verify(restTemplateFactory).makeRestTemplateWithPooling();
 
-    // Force a cache miss by using a different provider name. Now we should see two calls to the rest template factory.
+    // Force a cache miss by using a different provider name. Now we should see two calls to the
+    // rest template factory.
     drsProvider.setName("another name");
     drsApiFactory.getApiFromUriComponents(URI_COMPONENTS, drsProvider);
     verify(restTemplateFactory, times(2)).makeRestTemplateWithPooling();

--- a/service/src/test/java/bio/terra/drshub/services/DrsApiFactoryTest.java
+++ b/service/src/test/java/bio/terra/drshub/services/DrsApiFactoryTest.java
@@ -20,7 +20,7 @@ import org.springframework.web.util.UriComponentsBuilder;
 
 @Tag("Unit")
 @ExtendWith(MockitoExtension.class)
-public class DrsApiFactoryTest {
+class DrsApiFactoryTest {
 
   @Spy private RestTemplateFactory restTemplateFactory;
   private DrsApiFactory drsApiFactory;

--- a/service/src/test/java/bio/terra/drshub/services/DrsApiFactoryTest.java
+++ b/service/src/test/java/bio/terra/drshub/services/DrsApiFactoryTest.java
@@ -1,20 +1,21 @@
 package bio.terra.drshub.services;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.spy;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 
 import bio.terra.drshub.config.DrsProvider;
 import bio.terra.drshub.config.MTlsConfig;
+import io.github.ga4gh.drs.client.ApiClient;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Spy;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponents;
 import org.springframework.web.util.UriComponentsBuilder;
 
@@ -22,14 +23,20 @@ import org.springframework.web.util.UriComponentsBuilder;
 @ExtendWith(MockitoExtension.class)
 class DrsApiFactoryTest {
 
-  @Spy private RestTemplateFactory restTemplateFactory;
+  @Mock private RestTemplateFactory restTemplateFactory;
+  @Mock private DrsApiClientFactory drsApiClientFactory;
+  @Mock private ApiClient apiClient;
+  @Mock private RestTemplate restTemplate;
   private DrsApiFactory drsApiFactory;
   private static final UriComponents URI_COMPONENTS =
       UriComponentsBuilder.newInstance().host("test").build();
 
   @BeforeEach
   void setup() {
-    drsApiFactory = new DrsApiFactory(restTemplateFactory);
+    drsApiFactory = new DrsApiFactory(restTemplateFactory, drsApiClientFactory);
+
+    when(drsApiClientFactory.createClient(restTemplate)).thenReturn(apiClient);
+    when(apiClient.getBasePath()).thenReturn("");
   }
 
   private DrsProvider createDrsProvider() {
@@ -38,21 +45,25 @@ class DrsApiFactoryTest {
 
   @Test
   void testMTlsConfigured() {
-    var mTlsConfig = MTlsConfig.create().setCertPath("fake.crt").setKeyPath("fake.key");
+    var mTlsConfig = MTlsConfig.create();
+    when(restTemplateFactory.makeMTlsRestTemplateWithPooling(mTlsConfig)).thenReturn(restTemplate);
 
-    drsApiFactory.getApiFromUriComponents(
-        URI_COMPONENTS, createDrsProvider().setMTlsConfig(mTlsConfig));
+    var drsApi =
+        drsApiFactory.getApiFromUriComponents(
+            URI_COMPONENTS, createDrsProvider().setMTlsConfig(mTlsConfig));
+    assertThat(drsApi.getApiClient(), is(apiClient));
 
-    verify(restTemplateFactory).makeMTlsRestTemplateWithPooling(any(MTlsConfig.class));
-    verify(restTemplateFactory, never()).makeRestTemplateWithPooling();
+    verify(drsApiClientFactory).createClient(restTemplate);
   }
 
   @Test
   void testMTlsNotConfigured() {
-    drsApiFactory.getApiFromUriComponents(URI_COMPONENTS, createDrsProvider());
+    when(restTemplateFactory.makeRestTemplateWithPooling()).thenReturn(restTemplate);
 
-    verify(restTemplateFactory).makeRestTemplateWithPooling();
-    verify(restTemplateFactory, never()).makeMTlsRestTemplateWithPooling(any(MTlsConfig.class));
+    var drsApi = drsApiFactory.getApiFromUriComponents(URI_COMPONENTS, createDrsProvider());
+    assertThat(drsApi.getApiClient(), is(apiClient));
+
+    verify(drsApiClientFactory).createClient(restTemplate);
   }
 
   @Test
@@ -60,21 +71,18 @@ class DrsApiFactoryTest {
     var drsProvider = createDrsProvider();
 
     // The first ApiClient created for a DrsProvider will populate the RestTemplate cache
-    var client1 = drsApiFactory.getApiFromUriComponents(URI_COMPONENTS, drsProvider);
+    when(restTemplateFactory.makeRestTemplateWithPooling()).thenReturn(restTemplate);
+    drsApiFactory.getApiFromUriComponents(URI_COMPONENTS, drsProvider);
     verify(restTemplateFactory).makeRestTemplateWithPooling();
-    verify(restTemplateFactory, never()).makeMTlsRestTemplateWithPooling(any(MTlsConfig.class));
 
     // Subsequent ApiClients created for the same DrsProvider will reuse the cached RestTemplate
-    var separateApiClient =
-        spy(drsApiFactory.getApiFromUriComponents(URI_COMPONENTS, drsProvider).getApiClient());
-    verifyNoMoreInteractions(restTemplateFactory);
+    drsApiFactory.getApiFromUriComponents(URI_COMPONENTS, drsProvider);
+    // If there was a cache miss, this would fail as the API would be called twice.
+    verify(restTemplateFactory).makeRestTemplateWithPooling();
 
-    // Setting the token or headers on an ApiClient will have no effect on ApiClients created for
-    // the same DrsProvider
-    client1.setBearerToken("bearer-token");
-    verifyNoInteractions(separateApiClient);
-
-    client1.setHeader("test-header", "test-value");
-    verifyNoInteractions(separateApiClient);
+    // Force a cache miss by using a different provider name. Now we should see two calls to the rest template factory.
+    drsProvider.setName("another name");
+    drsApiFactory.getApiFromUriComponents(URI_COMPONENTS, drsProvider);
+    verify(restTemplateFactory, times(2)).makeRestTemplateWithPooling();
   }
 }

--- a/service/src/test/java/bio/terra/drshub/services/DrsApiFactoryTest.java
+++ b/service/src/test/java/bio/terra/drshub/services/DrsApiFactoryTest.java
@@ -6,7 +6,6 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.when;
 
 import bio.terra.drshub.config.DrsProvider;
 import bio.terra.drshub.config.MTlsConfig;
@@ -14,9 +13,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponents;
 import org.springframework.web.util.UriComponentsBuilder;
 
@@ -24,7 +22,7 @@ import org.springframework.web.util.UriComponentsBuilder;
 @ExtendWith(MockitoExtension.class)
 public class DrsApiFactoryTest {
 
-  @Mock private RestTemplateFactory restTemplateFactory;
+  @Spy private RestTemplateFactory restTemplateFactory;
   private DrsApiFactory drsApiFactory;
   private static final UriComponents URI_COMPONENTS =
       UriComponentsBuilder.newInstance().host("test").build();
@@ -41,32 +39,30 @@ public class DrsApiFactoryTest {
   @Test
   void testMTlsConfigured() {
     var mTlsConfig = MTlsConfig.create().setCertPath("fake.crt").setKeyPath("fake.key");
-    when(restTemplateFactory.makeMTlsRestTemplateWithPooling(mTlsConfig))
-        .thenReturn(new RestTemplate());
 
     drsApiFactory.getApiFromUriComponents(
         URI_COMPONENTS, createDrsProvider().setMTlsConfig(mTlsConfig));
 
+    verify(restTemplateFactory).makeMTlsRestTemplateWithPooling(any(MTlsConfig.class));
     verify(restTemplateFactory, never()).makeRestTemplateWithPooling();
   }
 
   @Test
   void testMTlsNotConfigured() {
-    when(restTemplateFactory.makeRestTemplateWithPooling()).thenReturn(new RestTemplate());
-
     drsApiFactory.getApiFromUriComponents(URI_COMPONENTS, createDrsProvider());
 
+    verify(restTemplateFactory).makeRestTemplateWithPooling();
     verify(restTemplateFactory, never()).makeMTlsRestTemplateWithPooling(any(MTlsConfig.class));
   }
 
   @Test
   void testIndependentApiClients() {
     var drsProvider = createDrsProvider();
-    when(restTemplateFactory.makeRestTemplateWithPooling()).thenReturn(new RestTemplate());
 
     // The first ApiClient created for a DrsProvider will populate the RestTemplate cache
     var client1 = drsApiFactory.getApiFromUriComponents(URI_COMPONENTS, drsProvider);
     verify(restTemplateFactory).makeRestTemplateWithPooling();
+    verify(restTemplateFactory, never()).makeMTlsRestTemplateWithPooling(any(MTlsConfig.class));
 
     // Subsequent ApiClients created for the same DrsProvider will reuse the cached RestTemplate
     var separateApiClient =

--- a/service/src/test/java/bio/terra/drshub/services/DrsApiFactoryTest.java
+++ b/service/src/test/java/bio/terra/drshub/services/DrsApiFactoryTest.java
@@ -1,57 +1,84 @@
 package bio.terra.drshub.services;
 
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 
-import bio.terra.drshub.BaseTest;
 import bio.terra.drshub.config.DrsProvider;
 import bio.terra.drshub.config.MTlsConfig;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponents;
 import org.springframework.web.util.UriComponentsBuilder;
 
 @Tag("Unit")
-public class DrsApiFactoryTest extends BaseTest {
+@ExtendWith(MockitoExtension.class)
+public class DrsApiFactoryTest {
 
-  @Autowired DrsApiFactory drsApiFactory;
+  @Spy private RestTemplateFactory restTemplateFactory;
+  private DrsApiFactory drsApiFactory;
+  private static final UriComponents URI_COMPONENTS =
+      UriComponentsBuilder.newInstance().host("test").build();
+
+  @BeforeEach
+  void setup() {
+    drsApiFactory = new DrsApiFactory(restTemplateFactory);
+  }
+
+  private DrsProvider createDrsProvider() {
+    return DrsProvider.create().setName("testDrsProvider");
+  }
 
   @Test
   void testMTlsConfigured() {
     var mTlsConfig = MTlsConfig.create().setCertPath("fake.crt").setKeyPath("fake.key");
-    var drsProvider = DrsProvider.create().setMTlsConfig(mTlsConfig).setName("testMtlsDrsProvider");
-    var spy = spy(drsApiFactory);
+    when(restTemplateFactory.makeMTlsRestTemplateWithPooling(mTlsConfig))
+        .thenReturn(new RestTemplate());
 
-    spy.getApiFromUriComponents(
-        UriComponentsBuilder.newInstance().host("test").build(), drsProvider);
+    drsApiFactory.getApiFromUriComponents(
+        URI_COMPONENTS, createDrsProvider().setMTlsConfig(mTlsConfig));
 
-    verify(spy).makeMTlsRestTemplateWithPooling(mTlsConfig.getCertPath(), mTlsConfig.getKeyPath());
+    verify(restTemplateFactory, never()).makeRestTemplateWithPooling();
   }
 
   @Test
   void testMTlsNotConfigured() {
-    var drsProvider = DrsProvider.create().setName("testDrsProvider");
-    var spy = spy(drsApiFactory);
+    when(restTemplateFactory.makeRestTemplateWithPooling()).thenReturn(new RestTemplate());
 
-    spy.getApiFromUriComponents(
-        UriComponentsBuilder.newInstance().host("test").build(), drsProvider);
+    drsApiFactory.getApiFromUriComponents(URI_COMPONENTS, createDrsProvider());
 
-    verify(spy, never()).makeMTlsRestTemplateWithPooling(anyString(), anyString());
+    verify(restTemplateFactory, never()).makeMTlsRestTemplateWithPooling(any(MTlsConfig.class));
   }
 
   @Test
   void testIndependentApiClients() {
-    var drsProvider = DrsProvider.create().setName("testDrsProvider");
-    var client1 =
-        drsApiFactory.getApiFromUriComponents(
-            UriComponentsBuilder.newInstance().host("test").build(), drsProvider);
+    var drsProvider = createDrsProvider();
+    when(restTemplateFactory.makeRestTemplateWithPooling()).thenReturn(new RestTemplate());
+
+    // The first ApiClient created for a DrsProvider will populate the RestTemplate cache
+    var client1 = drsApiFactory.getApiFromUriComponents(URI_COMPONENTS, drsProvider);
+    verify(restTemplateFactory).makeRestTemplateWithPooling();
+
+    // Subsequent ApiClients created for the same DrsProvider will reuse the cached RestTemplate
     var separateApiClient =
-        spy(
-            drsApiFactory
-                .getApiFromUriComponents(
-                    UriComponentsBuilder.newInstance().host("test").build(), drsProvider)
-                .getApiClient());
+        spy(drsApiFactory.getApiFromUriComponents(URI_COMPONENTS, drsProvider).getApiClient());
+    verifyNoMoreInteractions(restTemplateFactory);
+
+    // Setting the token or headers on an ApiClient will have no effect on ApiClients created for
+    // the same DrsProvider
+    client1.setBearerToken("bearer-token");
+    verifyNoInteractions(separateApiClient);
+
     client1.setHeader("test-header", "test-value");
-    verify(separateApiClient, never()).addDefaultHeader(anyString(), anyString());
+    verifyNoInteractions(separateApiClient);
   }
 }

--- a/service/src/test/java/bio/terra/drshub/services/DrsApiFactoryTest.java
+++ b/service/src/test/java/bio/terra/drshub/services/DrsApiFactoryTest.java
@@ -67,7 +67,7 @@ class DrsApiFactoryTest {
   }
 
   @Test
-  void testIndependentApiClients() {
+  void testRestTemplateCache() {
     var drsProvider = createDrsProvider();
 
     // The first ApiClient created for a DrsProvider will populate the RestTemplate cache

--- a/service/src/test/java/bio/terra/drshub/services/DrsApiFactoryTest.java
+++ b/service/src/test/java/bio/terra/drshub/services/DrsApiFactoryTest.java
@@ -14,7 +14,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Spy;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponents;
@@ -24,7 +24,7 @@ import org.springframework.web.util.UriComponentsBuilder;
 @ExtendWith(MockitoExtension.class)
 public class DrsApiFactoryTest {
 
-  @Spy private RestTemplateFactory restTemplateFactory;
+  @Mock private RestTemplateFactory restTemplateFactory;
   private DrsApiFactory drsApiFactory;
   private static final UriComponents URI_COMPONENTS =
       UriComponentsBuilder.newInstance().host("test").build();


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DR-3369

Each DrsProvider will still have new ApiClients made on request, but now they will all share the same backing RestTemplate. This brings behavior in line with the caching present at our last successful scale test in August '23, without sharing headers between requests (the impetus for the rollback).

**Performance Testing**

Note: our most recent 20k DRS URI dev-tier scale test in [Grafana](https://grafana.dsp-devops.broadinstitute.org/goto/EiPs66HIk?orgId=1) shows a peak request rate of 54 requests / second.

I added in two new performance test configurations for testing 50 and 100 concurrent TDR DRS URI resolution user journeys, respectively.  Each user journey resolves 4 DRS URIs sequentially, so these tests perform a total of 200 and 400 DRS URI resolutions, respectively.

These performance tests can be run off of a local DrsHub (I filed https://broadworkbench.atlassian.net/browse/DR-3380 in response to the discovery that DrsHub perf deployment no longer exists).

I saw modest improvements to latency when running these tests off of this feature branch versus running them off of dev, assessed via running `curl http://localhost:9098/actuator/prometheus | grep /api/v4/drs/resolve` after completion.  This is enough to feel comfortable moving forward with merging this PR but as the infrastructure and test are different enough from the workflow scale test, I am not positive what the outcome of that test will be after merge.