### PR TITLE
add scaffold layer to avoid spy

### DIFF
--- a/service/src/main/java/bio/terra/drshub/services/DrsApiClientFactory.java
+++ b/service/src/main/java/bio/terra/drshub/services/DrsApiClientFactory.java
@@ -1,0 +1,13 @@
+package bio.terra.drshub.services;
+
+import io.github.ga4gh.drs.client.ApiClient;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+@Component
+public class DrsApiClientFactory {
+
+  ApiClient createClient(RestTemplate restTemplate) {
+    return new ApiClient(restTemplate);
+  }
+}

--- a/service/src/main/java/bio/terra/drshub/services/DrsApiFactory.java
+++ b/service/src/main/java/bio/terra/drshub/services/DrsApiFactory.java
@@ -2,7 +2,6 @@ package bio.terra.drshub.services;
 
 import bio.terra.drshub.config.DrsProvider;
 import bio.terra.drshub.models.DrsApi;
-import io.github.ga4gh.drs.client.ApiClient;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -17,6 +16,7 @@ import org.springframework.web.util.UriComponents;
 public class DrsApiFactory {
 
   private final RestTemplateFactory restTemplateFactory;
+  private final DrsApiClientFactory drsApiClientFactory;
 
   /**
    * We create a new ApiClient for each call so that headers and tokens are not shared between
@@ -25,8 +25,10 @@ public class DrsApiFactory {
   private final Map<String, RestTemplate> restTemplateCache =
       Collections.synchronizedMap(new HashMap<>());
 
-  public DrsApiFactory(RestTemplateFactory restTemplateFactory) {
+  public DrsApiFactory(
+      RestTemplateFactory restTemplateFactory, DrsApiClientFactory drsApiClientFactory) {
     this.restTemplateFactory = restTemplateFactory;
+    this.drsApiClientFactory = drsApiClientFactory;
   }
 
   public DrsApi getApiFromUriComponents(UriComponents uriComponents, DrsProvider drsProvider) {
@@ -34,7 +36,7 @@ public class DrsApiFactory {
         "Creating new DrsApi client for host '{}', for DRS Provider '{}'",
         uriComponents.getHost(),
         drsProvider.getName());
-    var drsClient = new ApiClient(getOrCreateRestTemplate(drsProvider));
+    var drsClient = drsApiClientFactory.createClient(getOrCreateRestTemplate(drsProvider));
 
     drsClient.setBasePath(
         drsClient

--- a/service/src/test/java/bio/terra/drshub/services/DrsApiFactoryTest.java
+++ b/service/src/test/java/bio/terra/drshub/services/DrsApiFactoryTest.java
@@ -1,20 +1,21 @@
 package bio.terra.drshub.services;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.spy;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 
 import bio.terra.drshub.config.DrsProvider;
 import bio.terra.drshub.config.MTlsConfig;
+import io.github.ga4gh.drs.client.ApiClient;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Spy;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponents;
 import org.springframework.web.util.UriComponentsBuilder;
 
@@ -22,14 +23,20 @@ import org.springframework.web.util.UriComponentsBuilder;
 @ExtendWith(MockitoExtension.class)
 class DrsApiFactoryTest {
 
-  @Spy private RestTemplateFactory restTemplateFactory;
+  @Mock private RestTemplateFactory restTemplateFactory;
+  @Mock private DrsApiClientFactory drsApiClientFactory;
+  @Mock private ApiClient apiClient;
+  @Mock private RestTemplate restTemplate;
   private DrsApiFactory drsApiFactory;
   private static final UriComponents URI_COMPONENTS =
       UriComponentsBuilder.newInstance().host("test").build();
 
   @BeforeEach
   void setup() {
-    drsApiFactory = new DrsApiFactory(restTemplateFactory);
+    drsApiFactory = new DrsApiFactory(restTemplateFactory, drsApiClientFactory);
+
+    when(drsApiClientFactory.createClient(restTemplate)).thenReturn(apiClient);
+    when(apiClient.getBasePath()).thenReturn("");
   }
 
   private DrsProvider createDrsProvider() {
@@ -38,21 +45,25 @@ class DrsApiFactoryTest {
 
   @Test
   void testMTlsConfigured() {
-    var mTlsConfig = MTlsConfig.create().setCertPath("fake.crt").setKeyPath("fake.key");
+    var mTlsConfig = MTlsConfig.create();
+    when(restTemplateFactory.makeMTlsRestTemplateWithPooling(mTlsConfig)).thenReturn(restTemplate);
 
-    drsApiFactory.getApiFromUriComponents(
-        URI_COMPONENTS, createDrsProvider().setMTlsConfig(mTlsConfig));
+    var drsApi =
+        drsApiFactory.getApiFromUriComponents(
+            URI_COMPONENTS, createDrsProvider().setMTlsConfig(mTlsConfig));
+    assertThat(drsApi.getApiClient(), is(apiClient));
 
-    verify(restTemplateFactory).makeMTlsRestTemplateWithPooling(any(MTlsConfig.class));
-    verify(restTemplateFactory, never()).makeRestTemplateWithPooling();
+    verify(drsApiClientFactory).createClient(restTemplate);
   }
 
   @Test
   void testMTlsNotConfigured() {
-    drsApiFactory.getApiFromUriComponents(URI_COMPONENTS, createDrsProvider());
+    when(restTemplateFactory.makeRestTemplateWithPooling()).thenReturn(restTemplate);
 
-    verify(restTemplateFactory).makeRestTemplateWithPooling();
-    verify(restTemplateFactory, never()).makeMTlsRestTemplateWithPooling(any(MTlsConfig.class));
+    var drsApi = drsApiFactory.getApiFromUriComponents(URI_COMPONENTS, createDrsProvider());
+    assertThat(drsApi.getApiClient(), is(apiClient));
+
+    verify(drsApiClientFactory).createClient(restTemplate);
   }
 
   @Test
@@ -60,21 +71,18 @@ class DrsApiFactoryTest {
     var drsProvider = createDrsProvider();
 
     // The first ApiClient created for a DrsProvider will populate the RestTemplate cache
-    var client1 = drsApiFactory.getApiFromUriComponents(URI_COMPONENTS, drsProvider);
+    when(restTemplateFactory.makeRestTemplateWithPooling()).thenReturn(restTemplate);
+    drsApiFactory.getApiFromUriComponents(URI_COMPONENTS, drsProvider);
     verify(restTemplateFactory).makeRestTemplateWithPooling();
-    verify(restTemplateFactory, never()).makeMTlsRestTemplateWithPooling(any(MTlsConfig.class));
 
     // Subsequent ApiClients created for the same DrsProvider will reuse the cached RestTemplate
-    var separateApiClient =
-        spy(drsApiFactory.getApiFromUriComponents(URI_COMPONENTS, drsProvider).getApiClient());
-    verifyNoMoreInteractions(restTemplateFactory);
+    drsApiFactory.getApiFromUriComponents(URI_COMPONENTS, drsProvider);
+    // If there was a cache miss, this would fail as the API would be called twice.
+    verify(restTemplateFactory).makeRestTemplateWithPooling();
 
-    // Setting the token or headers on an ApiClient will have no effect on ApiClients created for
-    // the same DrsProvider
-    client1.setBearerToken("bearer-token");
-    verifyNoInteractions(separateApiClient);
-
-    client1.setHeader("test-header", "test-value");
-    verifyNoInteractions(separateApiClient);
+    // Force a cache miss by using a different provider name. Now we should see two calls to the rest template factory.
+    drsProvider.setName("another name");
+    drsApiFactory.getApiFromUriComponents(URI_COMPONENTS, drsProvider);
+    verify(restTemplateFactory, times(2)).makeRestTemplateWithPooling();
   }
 }


### PR DESCRIPTION
To avoid `spy()` and to provide better test support, add a layer between ApiClient and its arguments to we can see when it's called and with what arguments.