### PR TITLE
[DR-3386] CVE-2023-46589 Upgrade tomcat-embed-core to 9.0.83

### DIFF
--- a/service/spring.gradle
+++ b/service/spring.gradle
@@ -15,10 +15,10 @@ dependencies {
 	// allows mocking final classes
 	testImplementation 'org.mockito:mockito-inline:5.2.0'
 
-	// ID-645 Fixes a vulnerability
+	// See https://nvd.nist.gov/vuln/detail/CVE-2023-46589
 	implementation('org.apache.tomcat.embed:tomcat-embed-core') {
 		version{
-			strictly('9.0.76')
+			strictly('9.0.83')
 		}
 	}
 

--- a/service/spring.gradle
+++ b/service/spring.gradle
@@ -16,8 +16,9 @@ dependencies {
 	testImplementation 'org.mockito:mockito-inline:5.2.0'
 
 	// See https://nvd.nist.gov/vuln/detail/CVE-2023-46589
+	// TODO DR-3393: remove this pin when upgrading Spring Boot, TCL
 	implementation('org.apache.tomcat.embed:tomcat-embed-core') {
-		version{
+		version {
 			strictly('9.0.83')
 		}
 	}


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DR-3386

Upgrade `tomcat-embed-core` to address https://nvd.nist.gov/vuln/detail/CVE-2023-46589 -- it was previously pinned to address a different vulnerability.

Note: we will be able to remove this pin when upgrading Spring Boot 2->3 and Terra Common Lib in https://broadworkbench.atlassian.net/browse/DR-3393