### PR TITLE
[DR-3411] Upgrade Spring Boot 3.1.6 -> 3.1.7

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
 	id 'idea'
 
 	id 'io.spring.dependency-management' version '1.1.4' apply false
-	id 'org.springframework.boot' version '3.1.6' apply false
+	id 'org.springframework.boot' version '3.1.7' apply false
 	id 'com.diffplug.spotless' version '6.3.0' apply false
 	// ^^ for some reason, can't use spotless in multiple subprojects without this ^^
 	id 'com.google.cloud.tools.jib' version '3.1.4' apply false

--- a/service/spring.gradle
+++ b/service/spring.gradle
@@ -15,13 +15,6 @@ dependencies {
 
 	// allows mocking final classes
 	testImplementation 'org.mockito:mockito-inline:5.2.0'
-
-	// See https://nvd.nist.gov/vuln/detail/cve-2023-6378
-	// TODO: when latest versions of Spring are released on 2023-12-21, see if upgrading also brings
-	// its logback versions >= 1.4.14, which would allow us to stop explicitly pulling them in.
-	var logbackVersion = '1.4.14'
-	implementation "ch.qos.logback:logback-classic:$logbackVersion"
-	implementation "ch.qos.logback:logback-core:$logbackVersion"
 }
 
 


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DR-3411

Because this release includes a logback upgrade to 1.4.14, we can also remove our pin of this version which addressed a security vulnerability.

Dependency insights verify that the pin is no longer necessary:
```
(base) okotsopo@wm111-e35 terra-drs-hub % ./gradlew service:dependencyInsight --dependency logback-classic                         

> Task :service:dependencyInsight
ch.qos.logback:logback-classic:1.4.14 (selected by rule)
  Variant compile:
    | Attribute Name                 | Provided | Requested    |
    |--------------------------------|----------|--------------|
    | org.gradle.status              | release  |              |
    | org.gradle.category            | library  | library      |
    | org.gradle.libraryelements     | jar      | classes      |
    | org.gradle.usage               | java-api | java-api     |
    | org.gradle.dependency.bundling |          | external     |
    | org.gradle.jvm.environment     |          | standard-jvm |
    | org.gradle.jvm.version         |          | 17           |

ch.qos.logback:logback-classic:1.4.14
\--- org.springframework.boot:spring-boot-starter-logging:3.1.7
     \--- org.springframework.boot:spring-boot-starter:3.1.7
          +--- org.springframework.boot:spring-boot-starter-actuator:3.1.7
          |    \--- compileClasspath (requested org.springframework.boot:spring-boot-starter-actuator)
          +--- org.springframework.boot:spring-boot-starter-web:3.1.7
          |    \--- compileClasspath (requested org.springframework.boot:spring-boot-starter-web)
          +--- org.springframework.boot:spring-boot-starter-thymeleaf:3.1.7
          |    \--- compileClasspath (requested org.springframework.boot:spring-boot-starter-thymeleaf)
          +--- com.google.cloud:spring-cloud-gcp-starter:4.9.0 (requested org.springframework.boot:spring-boot-starter:3.1.5)
          |    \--- com.google.cloud:spring-cloud-gcp-starter-logging:4.9.0
          |         \--- compileClasspath
          \--- org.springframework.boot:spring-boot-starter-json:3.1.7
               +--- org.springframework.boot:spring-boot-starter-web:3.1.7 (*)
               \--- bio.terra:externalcreds-client-resttemplate:1.0.0-SNAPSHOT:20231214.221852-1 (requested org.springframework.boot:spring-boot-starter-json:3.1.6)
                    \--- compileClasspath

ch.qos.logback:logback-classic:1.1.3 -> 1.4.14
\--- ch.qos.logback.contrib:logback-json-classic:0.1.5
     \--- com.google.cloud:spring-cloud-gcp-logging:4.9.0
          \--- com.google.cloud:spring-cloud-gcp-starter-logging:4.9.0
               \--- compileClasspath

ch.qos.logback:logback-classic:1.2.11 -> 1.4.14
\--- com.google.cloud:google-cloud-logging-logback:0.130.28-alpha
     +--- com.google.cloud:libraries-bom:26.28.0
     |    \--- compileClasspath
     \--- com.google.cloud:spring-cloud-gcp-logging:4.9.0
          \--- com.google.cloud:spring-cloud-gcp-starter-logging:4.9.0
               \--- compileClasspath

(*) - dependencies omitted (listed previously)

(base) okotsopo@wm111-e35 terra-drs-hub % ./gradlew service:dependencyInsight --dependency logback-core   

> Task :service:dependencyInsight
ch.qos.logback:logback-core:1.4.14 (selected by rule)
  Variant compile:
    | Attribute Name                 | Provided | Requested    |
    |--------------------------------|----------|--------------|
    | org.gradle.status              | release  |              |
    | org.gradle.category            | library  | library      |
    | org.gradle.libraryelements     | jar      | classes      |
    | org.gradle.usage               | java-api | java-api     |
    | org.gradle.dependency.bundling |          | external     |
    | org.gradle.jvm.environment     |          | standard-jvm |
    | org.gradle.jvm.version         |          | 17           |

ch.qos.logback:logback-core:1.4.14
\--- ch.qos.logback:logback-classic:1.4.14
     +--- com.google.cloud:google-cloud-logging-logback:0.130.28-alpha (requested ch.qos.logback:logback-classic:1.2.11)
     |    +--- com.google.cloud:libraries-bom:26.28.0
     |    |    \--- compileClasspath
     |    \--- com.google.cloud:spring-cloud-gcp-logging:4.9.0
     |         \--- com.google.cloud:spring-cloud-gcp-starter-logging:4.9.0
     |              \--- compileClasspath
     +--- org.springframework.boot:spring-boot-starter-logging:3.1.7
     |    \--- org.springframework.boot:spring-boot-starter:3.1.7
     |         +--- org.springframework.boot:spring-boot-starter-actuator:3.1.7
     |         |    \--- compileClasspath (requested org.springframework.boot:spring-boot-starter-actuator)
     |         +--- org.springframework.boot:spring-boot-starter-web:3.1.7
     |         |    \--- compileClasspath (requested org.springframework.boot:spring-boot-starter-web)
     |         +--- org.springframework.boot:spring-boot-starter-thymeleaf:3.1.7
     |         |    \--- compileClasspath (requested org.springframework.boot:spring-boot-starter-thymeleaf)
     |         +--- com.google.cloud:spring-cloud-gcp-starter:4.9.0 (requested org.springframework.boot:spring-boot-starter:3.1.5)
     |         |    \--- com.google.cloud:spring-cloud-gcp-starter-logging:4.9.0 (*)
     |         \--- org.springframework.boot:spring-boot-starter-json:3.1.7
     |              +--- org.springframework.boot:spring-boot-starter-web:3.1.7 (*)
     |              \--- bio.terra:externalcreds-client-resttemplate:1.0.0-SNAPSHOT:20231214.221852-1 (requested org.springframework.boot:spring-boot-starter-json:3.1.6)
     |                   \--- compileClasspath
     \--- ch.qos.logback.contrib:logback-json-classic:0.1.5 (requested ch.qos.logback:logback-classic:1.1.3)
          \--- com.google.cloud:spring-cloud-gcp-logging:4.9.0 (*)

ch.qos.logback:logback-core:1.1.3 -> 1.4.14
\--- ch.qos.logback.contrib:logback-json-core:0.1.5
     \--- ch.qos.logback.contrib:logback-json-classic:0.1.5
          \--- com.google.cloud:spring-cloud-gcp-logging:4.9.0
               \--- com.google.cloud:spring-cloud-gcp-starter-logging:4.9.0
                    \--- compileClasspath

ch.qos.logback:logback-core:1.2.11 -> 1.4.14
\--- com.google.cloud:google-cloud-logging-logback:0.130.28-alpha
     +--- com.google.cloud:libraries-bom:26.28.0
     |    \--- compileClasspath
     \--- com.google.cloud:spring-cloud-gcp-logging:4.9.0
          \--- com.google.cloud:spring-cloud-gcp-starter-logging:4.9.0
               \--- compileClasspath

(*) - dependencies omitted (listed previously)
```