### PR TITLE
DR-3365: Switch to send slack alerts to #Jade-alerts; Use slack app integration

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -8,216 +8,211 @@ on:
     branches: [ '**' ]
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up JDK 17
-        uses: actions/setup-java@v2
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-
-      - name: Gradle cache
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: v1-${{ runner.os }}-gradle-${{ github.ref }}-${{ github.sha }}
-          restore-keys: v1-${{ runner.os }}-gradle-${{ github.ref }}
-
-      - name: Cache SonarCloud packages
-        uses: actions/cache@v1
-        with:
-          path: ~/.sonar/cache
-          key: ${{ runner.os }}-sonar
-          restore-keys: ${{ runner.os }}-sonar
-
-      - name: Gradle build service
-        run: ./gradlew --build-cache :service:build -x test
-
-      - name: SonarQube scan service
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: ./gradlew --build-cache :service:sonarqube
-
-      - name: Upload spotbugs results
-        uses: github/codeql-action/upload-sarif@main
-        with:
-          sarif_file: service/build/reports/spotbugs/main.sarif
-
-  jib:
-    needs: [ build ]
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up JDK 17
-        uses: actions/setup-java@v2
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-
-      - name: Gradle cache
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: v1-${{ runner.os }}-gradle-${{ github.ref }}-${{ github.sha }}
-
-      - name: Add Google Cloud Profiler to Docker Image
-        run: docker build ./service -t drshub:local
-
-      - name: Build image locally with jib
-        # build the docker image to make sure it does not error
-        run: |
-          ./gradlew --build-cache :service:jibDockerBuild \
-          -Djib.from.image=docker://drshub:local \
-          -Djib.console=plain
-
-  unit-tests:
-    needs: [ build ]
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up JDK 17
-        uses: actions/setup-java@v2
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-
-      - name: Git secrets setup
-        run: |
-          git clone https://github.com/awslabs/git-secrets.git ~/git-secrets
-          cd ~/git-secrets
-          git checkout b9e96b3212fa06aea65964ff0d5cda84ce935f38
-          sudo make install
-
-      - name: Secrets check
-        run: |
-          sudo ln -s "$(which echo)" /usr/local/bin/say
-          ./minnie-kenny.sh --force
-          git secrets --scan-history
-
-      - name: Gradle cache
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: v1-${{ runner.os }}-gradle-${{ github.ref }}-${{ github.sha }}
-
-      - name: Test with coverage
-        run: ./gradlew --build-cache jacocoTestReport --scan
-
-      - name: Codecov
-        uses: codecov/codecov-action@v3
-        with:
-          files: ./service/build/reports/jacoco/test/jacocoTestReport.xml
-
-  integration-tests:
-    needs: [ build ]
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up JDK 17
-        uses: actions/setup-java@v2
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-
-      - name: Gradle cache
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: v1-${{ runner.os }}-gradle-${{ github.ref }}-${{ github.sha }}
-
-      - name: Render GitHub Secrets
-        env:
-          DEV_FIRECLOUD_ACCOUNT_B64: ${{ secrets.DEV_FIRECLOUD_ACCOUNT_B64 }}
-        run: echo "$DEV_FIRECLOUD_ACCOUNT_B64" | base64 -d >"./integration/src/main/resources/rendered/user-delegated-sa.json"
-
-      - name: Launch the background process for integration tests
-        run: ./gradlew --build-cache :service:bootRunDev | tee application.log &
-
-      - name: Prep the integration project
-        run: ./gradlew --build-cache :integration:classes
-
-      - name: Wait for boot run to be ready
-        run: |
-          timeout 60 bash -c 'until echo > /dev/tcp/localhost/8080; do sleep 1; done'
-          resultStatus=$(echo > /dev/tcp/localhost/8080; echo $?)
-          if [[ $resultStatus == 0 ]]; then
-            echo "Server started successfully"
-          else
-            echo "Server did not start successfully."
-            exit 1
-          fi
-
-      - name: Run the integration test suite
-        run: ./gradlew --build-cache :integration:runTest --args="suites/FullIntegration.json /tmp/foo"
-
-      - name: Archive logs
-        id: archive_logs
-        if: always()
-        uses: actions/upload-artifact@v2
-        with:
-          name: application-logs
-          path: |
-            application.log
-
   notify-slack:
-    needs: [ build, jib, unit-tests, integration-tests ]
+    # needs: [ build, jib, unit-tests, integration-tests ]
     runs-on: ubuntu-latest
 
-    if: failure() && github.ref == 'refs/heads/dev'
+    # if: failure() && github.ref == 'refs/heads/dev'
 
     steps:
       - name: Notify slack on failure
-        uses: 8398a7/action-slack@v3
+        id: slack
+        uses: slackapi/slack-github-action@v1.24.0
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.POLICY_INT_WEBHOOK_URL }}
-        with:
-          status: failure
-          author_name: Build on dev (drs-hub)
-          fields: workflow,message
-          text: 'Build failed :sadpanda:'
+          SLACK_WEBHOOK_URL: ${{ secrets.TEST_JADE_ALERTS_SLACK_WEBHOOK }}
+  # build:
+  #   runs-on: ubuntu-latest
 
-  dispatch-tag:
-    needs: [ build, jib, unit-tests, integration-tests ]
-    runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Set up JDK 17
+  #       uses: actions/setup-java@v2
+  #       with:
+  #         java-version: '17'
+  #         distribution: 'temurin'
 
-    if: success() && github.ref == 'refs/heads/dev'
+  #     - name: Gradle cache
+  #       uses: actions/cache@v2
+  #       with:
+  #         path: |
+  #           ~/.gradle/caches
+  #           ~/.gradle/wrapper
+  #         key: v1-${{ runner.os }}-gradle-${{ github.ref }}-${{ github.sha }}
+  #         restore-keys: v1-${{ runner.os }}-gradle-${{ github.ref }}
 
-    steps:
-      - name: Fire off tag action
-        uses: benc-uk/workflow-dispatch@v1
-        with:
-          workflow: Tag
-          token: ${{ secrets.BROADBOT_TOKEN }}
+  #     - name: Cache SonarCloud packages
+  #       uses: actions/cache@v1
+  #       with:
+  #         path: ~/.sonar/cache
+  #         key: ${{ runner.os }}-sonar
+  #         restore-keys: ${{ runner.os }}-sonar
 
-  source-clear:
-    needs: [ build ]
-    runs-on: ubuntu-latest
+  #     - name: Gradle build service
+  #       run: ./gradlew --build-cache :service:build -x test
 
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up JDK
-        uses: actions/setup-java@v2
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-          cache: 'gradle'
+  #     - name: SonarQube scan service
+  #       env:
+  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
+  #         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+  #       run: ./gradlew --build-cache :service:sonarqube
 
-      - name: SourceClear scan
-        env:
-          SRCCLR_API_TOKEN: ${{ secrets.SRCCLR_API_TOKEN }}
-        run: ./gradlew --build-cache srcclr
+  #     - name: Upload spotbugs results
+  #       uses: github/codeql-action/upload-sarif@main
+  #       with:
+  #         sarif_file: service/build/reports/spotbugs/main.sarif
+
+  # jib:
+  #   needs: [ build ]
+  #   runs-on: ubuntu-latest
+
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Set up JDK 17
+  #       uses: actions/setup-java@v2
+  #       with:
+  #         java-version: '17'
+  #         distribution: 'temurin'
+
+  #     - name: Gradle cache
+  #       uses: actions/cache@v2
+  #       with:
+  #         path: |
+  #           ~/.gradle/caches
+  #           ~/.gradle/wrapper
+  #         key: v1-${{ runner.os }}-gradle-${{ github.ref }}-${{ github.sha }}
+
+  #     - name: Add Google Cloud Profiler to Docker Image
+  #       run: docker build ./service -t drshub:local
+
+  #     - name: Build image locally with jib
+  #       # build the docker image to make sure it does not error
+  #       run: |
+  #         ./gradlew --build-cache :service:jibDockerBuild \
+  #         -Djib.from.image=docker://drshub:local \
+  #         -Djib.console=plain
+
+  # unit-tests:
+  #   needs: [ build ]
+  #   runs-on: ubuntu-latest
+
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Set up JDK 17
+  #       uses: actions/setup-java@v2
+  #       with:
+  #         java-version: '17'
+  #         distribution: 'temurin'
+
+  #     - name: Git secrets setup
+  #       run: |
+  #         git clone https://github.com/awslabs/git-secrets.git ~/git-secrets
+  #         cd ~/git-secrets
+  #         git checkout b9e96b3212fa06aea65964ff0d5cda84ce935f38
+  #         sudo make install
+
+  #     - name: Secrets check
+  #       run: |
+  #         sudo ln -s "$(which echo)" /usr/local/bin/say
+  #         ./minnie-kenny.sh --force
+  #         git secrets --scan-history
+
+  #     - name: Gradle cache
+  #       uses: actions/cache@v2
+  #       with:
+  #         path: |
+  #           ~/.gradle/caches
+  #           ~/.gradle/wrapper
+  #         key: v1-${{ runner.os }}-gradle-${{ github.ref }}-${{ github.sha }}
+
+  #     - name: Test with coverage
+  #       run: ./gradlew --build-cache jacocoTestReport --scan
+
+  #     - name: Codecov
+  #       uses: codecov/codecov-action@v3
+  #       with:
+  #         files: ./service/build/reports/jacoco/test/jacocoTestReport.xml
+
+  # integration-tests:
+  #   needs: [ build ]
+  #   runs-on: ubuntu-latest
+
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Set up JDK 17
+  #       uses: actions/setup-java@v2
+  #       with:
+  #         java-version: '17'
+  #         distribution: 'temurin'
+
+  #     - name: Gradle cache
+  #       uses: actions/cache@v2
+  #       with:
+  #         path: |
+  #           ~/.gradle/caches
+  #           ~/.gradle/wrapper
+  #         key: v1-${{ runner.os }}-gradle-${{ github.ref }}-${{ github.sha }}
+
+  #     - name: Render GitHub Secrets
+  #       env:
+  #         DEV_FIRECLOUD_ACCOUNT_B64: ${{ secrets.DEV_FIRECLOUD_ACCOUNT_B64 }}
+  #       run: echo "$DEV_FIRECLOUD_ACCOUNT_B64" | base64 -d >"./integration/src/main/resources/rendered/user-delegated-sa.json"
+
+  #     - name: Launch the background process for integration tests
+  #       run: ./gradlew --build-cache :service:bootRunDev | tee application.log &
+
+  #     - name: Prep the integration project
+  #       run: ./gradlew --build-cache :integration:classes
+
+  #     - name: Wait for boot run to be ready
+  #       run: |
+  #         timeout 60 bash -c 'until echo > /dev/tcp/localhost/8080; do sleep 1; done'
+  #         resultStatus=$(echo > /dev/tcp/localhost/8080; echo $?)
+  #         if [[ $resultStatus == 0 ]]; then
+  #           echo "Server started successfully"
+  #         else
+  #           echo "Server did not start successfully."
+  #           exit 1
+  #         fi
+
+  #     - name: Run the integration test suite
+  #       run: ./gradlew --build-cache :integration:runTest --args="suites/FullIntegration.json /tmp/foo"
+
+  #     - name: Archive logs
+  #       id: archive_logs
+  #       if: always()
+  #       uses: actions/upload-artifact@v2
+  #       with:
+  #         name: application-logs
+  #         path: |
+  #           application.log
+
+  # dispatch-tag:
+  #   needs: [ build, jib, unit-tests, integration-tests ]
+  #   runs-on: ubuntu-latest
+
+  #   if: success() && github.ref == 'refs/heads/dev'
+
+  #   steps:
+  #     - name: Fire off tag action
+  #       uses: benc-uk/workflow-dispatch@v1
+  #       with:
+  #         workflow: Tag
+  #         token: ${{ secrets.BROADBOT_TOKEN }}
+
+  # source-clear:
+  #   needs: [ build ]
+  #   runs-on: ubuntu-latest
+
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Set up JDK
+  #       uses: actions/setup-java@v2
+  #       with:
+  #         java-version: '17'
+  #         distribution: 'temurin'
+  #         cache: 'gradle'
+
+  #     - name: SourceClear scan
+  #       env:
+  #         SRCCLR_API_TOKEN: ${{ secrets.SRCCLR_API_TOKEN }}
+  #       run: ./gradlew --build-cache srcclr

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -177,23 +177,12 @@ jobs:
 
   notify-slack:
     needs: [ build, jib, unit-tests, integration-tests ]
-    runs-on: ubuntu-latest
-
-    if: failure() && github.ref == 'refs/heads/dev'
-
-    steps:
-      - name: Notify slack on failure
-        id: slack
-        uses: slackapi/slack-github-action@v1.24.0
-        with:
-          payload: |
-            {
-              "workflow_url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
-              "workflow_name": "Build and Test",
-              "branch" : "${{ github.ref }}"
-            }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.TEST_JADE_ALERTS_SLACK_WEBHOOK }}
+    #TODO - uncomment before merging
+    #if: failure() && github.ref == 'refs/heads/dev'
+    uses: ./.github/workflows/slack-notify.yml
+    secrets: inherit
+    with:
+      workflow_name: DRShub Build and Test
 
   dispatch-tag:
     needs: [ build, jib, unit-tests, integration-tests ]

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -9,276 +9,219 @@ on:
   workflow_dispatch: {}
 
 jobs:
-  notify-slack:
+  build:
     runs-on: ubuntu-latest
+
     steps:
-      - name: Notify on kicking off job
+      - uses: actions/checkout@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v2
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Gradle cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: v1-${{ runner.os }}-gradle-${{ github.ref }}-${{ github.sha }}
+          restore-keys: v1-${{ runner.os }}-gradle-${{ github.ref }}
+
+      - name: Cache SonarCloud packages
+        uses: actions/cache@v1
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+
+      - name: Gradle build service
+        run: ./gradlew --build-cache :service:build -x test
+
+      - name: SonarQube scan service
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: ./gradlew --build-cache :service:sonarqube
+
+      - name: Upload spotbugs results
+        uses: github/codeql-action/upload-sarif@main
+        with:
+          sarif_file: service/build/reports/spotbugs/main.sarif
+
+  jib:
+    needs: [ build ]
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v2
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Gradle cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: v1-${{ runner.os }}-gradle-${{ github.ref }}-${{ github.sha }}
+
+      - name: Add Google Cloud Profiler to Docker Image
+        run: docker build ./service -t drshub:local
+
+      - name: Build image locally with jib
+        # build the docker image to make sure it does not error
+        run: |
+          ./gradlew --build-cache :service:jibDockerBuild \
+          -Djib.from.image=docker://drshub:local \
+          -Djib.console=plain
+
+  unit-tests:
+    needs: [ build ]
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v2
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Git secrets setup
+        run: |
+          git clone https://github.com/awslabs/git-secrets.git ~/git-secrets
+          cd ~/git-secrets
+          git checkout b9e96b3212fa06aea65964ff0d5cda84ce935f38
+          sudo make install
+
+      - name: Secrets check
+        run: |
+          sudo ln -s "$(which echo)" /usr/local/bin/say
+          ./minnie-kenny.sh --force
+          git secrets --scan-history
+
+      - name: Gradle cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: v1-${{ runner.os }}-gradle-${{ github.ref }}-${{ github.sha }}
+
+      - name: Test with coverage
+        run: ./gradlew --build-cache jacocoTestReport --scan
+
+      - name: Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          files: ./service/build/reports/jacoco/test/jacocoTestReport.xml
+
+  integration-tests:
+    needs: [ build ]
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v2
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Gradle cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: v1-${{ runner.os }}-gradle-${{ github.ref }}-${{ github.sha }}
+
+      - name: Render GitHub Secrets
+        env:
+          DEV_FIRECLOUD_ACCOUNT_B64: ${{ secrets.DEV_FIRECLOUD_ACCOUNT_B64 }}
+        run: echo "$DEV_FIRECLOUD_ACCOUNT_B64" | base64 -d >"./integration/src/main/resources/rendered/user-delegated-sa.json"
+
+      - name: Launch the background process for integration tests
+        run: ./gradlew --build-cache :service:bootRunDev | tee application.log &
+
+      - name: Prep the integration project
+        run: ./gradlew --build-cache :integration:classes
+
+      - name: Wait for boot run to be ready
+        run: |
+          timeout 60 bash -c 'until echo > /dev/tcp/localhost/8080; do sleep 1; done'
+          resultStatus=$(echo > /dev/tcp/localhost/8080; echo $?)
+          if [[ $resultStatus == 0 ]]; then
+            echo "Server started successfully"
+          else
+            echo "Server did not start successfully."
+            exit 1
+          fi
+
+      - name: Run the integration test suite
+        run: ./gradlew --build-cache :integration:runTest --args="suites/FullIntegration.json /tmp/foo"
+
+      - name: Archive logs
+        id: archive_logs
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: application-logs
+          path: |
+            application.log
+
+  notify-slack:
+    needs: [ build, jib, unit-tests, integration-tests ]
+    runs-on: ubuntu-latest
+
+    if: failure() && github.ref == 'refs/heads/dev'
+
+    steps:
+      - name: Notify slack on failure
         id: slack
         uses: slackapi/slack-github-action@v1.24.0
         with:
-          # The following message update step does not accept a channel name.
-          # Setting a channel ID here for consistency is highly recommended.
-          channel-id: "CMYTGJVFY"
           payload: |
             {
-              "text": "DRSHub Build and Test Action (Running)",
-              "attachments": [
-                {
-                  "pretext": "Job Started",
-                  "color": "DBAB09",
-                  "fields": [
-                    {
-                      "title": "Status",
-                      "short": true,
-                      "value": "In progress"
-                    }
-                  ]
-                }
-              ]
+              "workflow_url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+              "workflow_name": "Build and Test",
+              "branch" : "${{ github.ref }}"
             }
         env:
-          SLACK_BOT_TOKEN: ${{ secrets.TEST_SLACK_BOT_TOKEN}}
-      - name: Sleep for 1 minute
-        run: sleep 60s
-        shell: bash
-      - name: Notify on completing job
-        uses: slackapi/slack-github-action@v1.24.0
+          SLACK_WEBHOOK_URL: ${{ secrets.TEST_JADE_ALERTS_SLACK_WEBHOOK }}
+
+  dispatch-tag:
+    needs: [ build, jib, unit-tests, integration-tests ]
+    runs-on: ubuntu-latest
+
+    if: success() && github.ref == 'refs/heads/dev'
+
+    steps:
+      - name: Fire off tag action
+        uses: benc-uk/workflow-dispatch@v1
         with:
-            # Unlike the step posting a new message, this step does not accept a channel name.
-            # Please use a channel ID, not a name here.
-            channel-id: "CMYTGJVFY"
-            update-ts: ${{ steps.slack.outputs.ts }}
-            payload: |
-              {
-                "text": "DRSHub Build and Test Action (Completed)",
-                "attachments": [
-                  {
-                    "pretext": "Job Completed",
-                    "color": "28a745",
-                    "fields": [
-                      {
-                        "title": "Status",
-                        "short": true,
-                        "value": "Completed"
-                      }
-                    ]
-                  }
-                ]
-              }
+          workflow: Tag
+          token: ${{ secrets.BROADBOT_TOKEN }}
+
+  source-clear:
+    needs: [ build ]
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK
+        uses: actions/setup-java@v2
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: 'gradle'
+
+      - name: SourceClear scan
         env:
-          SLACK_BOT_TOKEN: ${{ secrets.TEST_SLACK_BOT_TOKEN }}
-  # notify-slack:
-  #   needs: [ build, jib, unit-tests, integration-tests ]
-  #   runs-on: ubuntu-latest
-
-  #   if: failure() && github.ref == 'refs/heads/dev'
-
-  #   steps:
-  #     - name: Notify slack on failure
-  #       id: slack
-  #       uses: slackapi/slack-github-action@v1.24.0
-  #       with:
-  #         payload: |
-  #           {
-  #             "workflow_url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
-  #             "workflow_name": "Build and Test",
-  #             "branch" : "${{ github.ref }}"
-  #           }
-  #       env:
-  #         SLACK_WEBHOOK_URL: ${{ secrets.TEST_JADE_ALERTS_SLACK_WEBHOOK }}
-  # build:
-  #   runs-on: ubuntu-latest
-
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - name: Set up JDK 17
-  #       uses: actions/setup-java@v2
-  #       with:
-  #         java-version: '17'
-  #         distribution: 'temurin'
-
-  #     - name: Gradle cache
-  #       uses: actions/cache@v2
-  #       with:
-  #         path: |
-  #           ~/.gradle/caches
-  #           ~/.gradle/wrapper
-  #         key: v1-${{ runner.os }}-gradle-${{ github.ref }}-${{ github.sha }}
-  #         restore-keys: v1-${{ runner.os }}-gradle-${{ github.ref }}
-
-  #     - name: Cache SonarCloud packages
-  #       uses: actions/cache@v1
-  #       with:
-  #         path: ~/.sonar/cache
-  #         key: ${{ runner.os }}-sonar
-  #         restore-keys: ${{ runner.os }}-sonar
-
-  #     - name: Gradle build service
-  #       run: ./gradlew --build-cache :service:build -x test
-
-  #     - name: SonarQube scan service
-  #       env:
-  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
-  #         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-  #       run: ./gradlew --build-cache :service:sonarqube
-
-  #     - name: Upload spotbugs results
-  #       uses: github/codeql-action/upload-sarif@main
-  #       with:
-  #         sarif_file: service/build/reports/spotbugs/main.sarif
-
-  # jib:
-  #   needs: [ build ]
-  #   runs-on: ubuntu-latest
-
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - name: Set up JDK 17
-  #       uses: actions/setup-java@v2
-  #       with:
-  #         java-version: '17'
-  #         distribution: 'temurin'
-
-  #     - name: Gradle cache
-  #       uses: actions/cache@v2
-  #       with:
-  #         path: |
-  #           ~/.gradle/caches
-  #           ~/.gradle/wrapper
-  #         key: v1-${{ runner.os }}-gradle-${{ github.ref }}-${{ github.sha }}
-
-  #     - name: Add Google Cloud Profiler to Docker Image
-  #       run: docker build ./service -t drshub:local
-
-  #     - name: Build image locally with jib
-  #       # build the docker image to make sure it does not error
-  #       run: |
-  #         ./gradlew --build-cache :service:jibDockerBuild \
-  #         -Djib.from.image=docker://drshub:local \
-  #         -Djib.console=plain
-
-  # unit-tests:
-  #   needs: [ build ]
-  #   runs-on: ubuntu-latest
-
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - name: Set up JDK 17
-  #       uses: actions/setup-java@v2
-  #       with:
-  #         java-version: '17'
-  #         distribution: 'temurin'
-
-  #     - name: Git secrets setup
-  #       run: |
-  #         git clone https://github.com/awslabs/git-secrets.git ~/git-secrets
-  #         cd ~/git-secrets
-  #         git checkout b9e96b3212fa06aea65964ff0d5cda84ce935f38
-  #         sudo make install
-
-  #     - name: Secrets check
-  #       run: |
-  #         sudo ln -s "$(which echo)" /usr/local/bin/say
-  #         ./minnie-kenny.sh --force
-  #         git secrets --scan-history
-
-  #     - name: Gradle cache
-  #       uses: actions/cache@v2
-  #       with:
-  #         path: |
-  #           ~/.gradle/caches
-  #           ~/.gradle/wrapper
-  #         key: v1-${{ runner.os }}-gradle-${{ github.ref }}-${{ github.sha }}
-
-  #     - name: Test with coverage
-  #       run: ./gradlew --build-cache jacocoTestReport --scan
-
-  #     - name: Codecov
-  #       uses: codecov/codecov-action@v3
-  #       with:
-  #         files: ./service/build/reports/jacoco/test/jacocoTestReport.xml
-
-  # integration-tests:
-  #   needs: [ build ]
-  #   runs-on: ubuntu-latest
-
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - name: Set up JDK 17
-  #       uses: actions/setup-java@v2
-  #       with:
-  #         java-version: '17'
-  #         distribution: 'temurin'
-
-  #     - name: Gradle cache
-  #       uses: actions/cache@v2
-  #       with:
-  #         path: |
-  #           ~/.gradle/caches
-  #           ~/.gradle/wrapper
-  #         key: v1-${{ runner.os }}-gradle-${{ github.ref }}-${{ github.sha }}
-
-  #     - name: Render GitHub Secrets
-  #       env:
-  #         DEV_FIRECLOUD_ACCOUNT_B64: ${{ secrets.DEV_FIRECLOUD_ACCOUNT_B64 }}
-  #       run: echo "$DEV_FIRECLOUD_ACCOUNT_B64" | base64 -d >"./integration/src/main/resources/rendered/user-delegated-sa.json"
-
-  #     - name: Launch the background process for integration tests
-  #       run: ./gradlew --build-cache :service:bootRunDev | tee application.log &
-
-  #     - name: Prep the integration project
-  #       run: ./gradlew --build-cache :integration:classes
-
-  #     - name: Wait for boot run to be ready
-  #       run: |
-  #         timeout 60 bash -c 'until echo > /dev/tcp/localhost/8080; do sleep 1; done'
-  #         resultStatus=$(echo > /dev/tcp/localhost/8080; echo $?)
-  #         if [[ $resultStatus == 0 ]]; then
-  #           echo "Server started successfully"
-  #         else
-  #           echo "Server did not start successfully."
-  #           exit 1
-  #         fi
-
-  #     - name: Run the integration test suite
-  #       run: ./gradlew --build-cache :integration:runTest --args="suites/FullIntegration.json /tmp/foo"
-
-  #     - name: Archive logs
-  #       id: archive_logs
-  #       if: always()
-  #       uses: actions/upload-artifact@v2
-  #       with:
-  #         name: application-logs
-  #         path: |
-  #           application.log
-
-  # dispatch-tag:
-  #   needs: [ build, jib, unit-tests, integration-tests ]
-  #   runs-on: ubuntu-latest
-
-  #   if: success() && github.ref == 'refs/heads/dev'
-
-  #   steps:
-  #     - name: Fire off tag action
-  #       uses: benc-uk/workflow-dispatch@v1
-  #       with:
-  #         workflow: Tag
-  #         token: ${{ secrets.BROADBOT_TOKEN }}
-
-  # source-clear:
-  #   needs: [ build ]
-  #   runs-on: ubuntu-latest
-
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - name: Set up JDK
-  #       uses: actions/setup-java@v2
-  #       with:
-  #         java-version: '17'
-  #         distribution: 'temurin'
-  #         cache: 'gradle'
-
-  #     - name: SourceClear scan
-  #       env:
-  #         SRCCLR_API_TOKEN: ${{ secrets.SRCCLR_API_TOKEN }}
-  #       run: ./gradlew --build-cache srcclr
+          SRCCLR_API_TOKEN: ${{ secrets.SRCCLR_API_TOKEN }}
+        run: ./gradlew --build-cache srcclr

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -182,7 +182,7 @@ jobs:
     uses: ./.github/workflows/slack-notify.yml
     secrets: inherit
     with:
-      workflow_name: DRShub Build and Test
+      workflow_name: Build and Test
 
   dispatch-tag:
     needs: [ build, jib, unit-tests, integration-tests ]

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -177,8 +177,7 @@ jobs:
 
   notify-slack-on-failure:
     needs: [ build, jib, unit-tests, integration-tests ]
-    # TODO - uncomment before merging
-    # if:  github.ref == 'refs/heads/dev'
+    if:  github.ref == 'refs/heads/dev'
     uses: ./.github/workflows/slack-notify-on-failure.yml
     secrets: inherit
     with:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -177,7 +177,6 @@ jobs:
 
   notify-slack-on-failure:
     needs: [ build, jib, unit-tests, integration-tests ]
-    if:  github.ref == 'refs/heads/dev'
     uses: ./.github/workflows/slack-notify-on-failure.yml
     secrets: inherit
     with:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -175,11 +175,11 @@ jobs:
           path: |
             application.log
 
-  notify-slack:
+  notify-slack-on-failure:
     needs: [ build, jib, unit-tests, integration-tests ]
-    #TODO - uncomment before merging
-    #if: failure() && github.ref == 'refs/heads/dev'
-    uses: ./.github/workflows/slack-notify.yml
+    # TODO - uncomment before merging
+    # if:  github.ref == 'refs/heads/dev'
+    uses: ./.github/workflows/slack-notify-on-failure.yml
     secrets: inherit
     with:
       workflow_name: Build and Test

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -6,6 +6,7 @@ on:
     paths-ignore: [ '*.md' ]
   pull_request:
     branches: [ '**' ]
+  workflow_dispatch: {}
 
 jobs:
   notify-slack:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -9,219 +9,276 @@ on:
   workflow_dispatch: {}
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up JDK 17
-        uses: actions/setup-java@v2
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-
-      - name: Gradle cache
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: v1-${{ runner.os }}-gradle-${{ github.ref }}-${{ github.sha }}
-          restore-keys: v1-${{ runner.os }}-gradle-${{ github.ref }}
-
-      - name: Cache SonarCloud packages
-        uses: actions/cache@v1
-        with:
-          path: ~/.sonar/cache
-          key: ${{ runner.os }}-sonar
-          restore-keys: ${{ runner.os }}-sonar
-
-      - name: Gradle build service
-        run: ./gradlew --build-cache :service:build -x test
-
-      - name: SonarQube scan service
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: ./gradlew --build-cache :service:sonarqube
-
-      - name: Upload spotbugs results
-        uses: github/codeql-action/upload-sarif@main
-        with:
-          sarif_file: service/build/reports/spotbugs/main.sarif
-
-  jib:
-    needs: [ build ]
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up JDK 17
-        uses: actions/setup-java@v2
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-
-      - name: Gradle cache
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: v1-${{ runner.os }}-gradle-${{ github.ref }}-${{ github.sha }}
-
-      - name: Add Google Cloud Profiler to Docker Image
-        run: docker build ./service -t drshub:local
-
-      - name: Build image locally with jib
-        # build the docker image to make sure it does not error
-        run: |
-          ./gradlew --build-cache :service:jibDockerBuild \
-          -Djib.from.image=docker://drshub:local \
-          -Djib.console=plain
-
-  unit-tests:
-    needs: [ build ]
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up JDK 17
-        uses: actions/setup-java@v2
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-
-      - name: Git secrets setup
-        run: |
-          git clone https://github.com/awslabs/git-secrets.git ~/git-secrets
-          cd ~/git-secrets
-          git checkout b9e96b3212fa06aea65964ff0d5cda84ce935f38
-          sudo make install
-
-      - name: Secrets check
-        run: |
-          sudo ln -s "$(which echo)" /usr/local/bin/say
-          ./minnie-kenny.sh --force
-          git secrets --scan-history
-
-      - name: Gradle cache
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: v1-${{ runner.os }}-gradle-${{ github.ref }}-${{ github.sha }}
-
-      - name: Test with coverage
-        run: ./gradlew --build-cache jacocoTestReport --scan
-
-      - name: Codecov
-        uses: codecov/codecov-action@v3
-        with:
-          files: ./service/build/reports/jacoco/test/jacocoTestReport.xml
-
-  integration-tests:
-    needs: [ build ]
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up JDK 17
-        uses: actions/setup-java@v2
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-
-      - name: Gradle cache
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: v1-${{ runner.os }}-gradle-${{ github.ref }}-${{ github.sha }}
-
-      - name: Render GitHub Secrets
-        env:
-          DEV_FIRECLOUD_ACCOUNT_B64: ${{ secrets.DEV_FIRECLOUD_ACCOUNT_B64 }}
-        run: echo "$DEV_FIRECLOUD_ACCOUNT_B64" | base64 -d >"./integration/src/main/resources/rendered/user-delegated-sa.json"
-
-      - name: Launch the background process for integration tests
-        run: ./gradlew --build-cache :service:bootRunDev | tee application.log &
-
-      - name: Prep the integration project
-        run: ./gradlew --build-cache :integration:classes
-
-      - name: Wait for boot run to be ready
-        run: |
-          timeout 60 bash -c 'until echo > /dev/tcp/localhost/8080; do sleep 1; done'
-          resultStatus=$(echo > /dev/tcp/localhost/8080; echo $?)
-          if [[ $resultStatus == 0 ]]; then
-            echo "Server started successfully"
-          else
-            echo "Server did not start successfully."
-            exit 1
-          fi
-
-      - name: Run the integration test suite
-        run: ./gradlew --build-cache :integration:runTest --args="suites/FullIntegration.json /tmp/foo"
-
-      - name: Archive logs
-        id: archive_logs
-        if: always()
-        uses: actions/upload-artifact@v2
-        with:
-          name: application-logs
-          path: |
-            application.log
-
   notify-slack:
-    needs: [ build, jib, unit-tests, integration-tests ]
     runs-on: ubuntu-latest
-
-    if: failure() && github.ref == 'refs/heads/dev'
-
     steps:
-      - name: Notify slack on failure
+      - name: Notify on kicking off job
         id: slack
         uses: slackapi/slack-github-action@v1.24.0
         with:
+          # The following message update step does not accept a channel name.
+          # Setting a channel ID here for consistency is highly recommended.
+          channel-id: "CMYTGJVFY"
           payload: |
             {
-              "workflow_url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
-              "workflow_name": "Build and Test",
-              "branch" : "${{ github.ref }}"
+              "text": "DRSHub Build and Test Action (Running)",
+              "attachments": [
+                {
+                  "pretext": "Job Started",
+                  "color": "DBAB09",
+                  "fields": [
+                    {
+                      "title": "Status",
+                      "short": true,
+                      "value": "In progress"
+                    }
+                  ]
+                }
+              ]
             }
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.TEST_JADE_ALERTS_SLACK_WEBHOOK }}
-
-  dispatch-tag:
-    needs: [ build, jib, unit-tests, integration-tests ]
-    runs-on: ubuntu-latest
-
-    if: success() && github.ref == 'refs/heads/dev'
-
-    steps:
-      - name: Fire off tag action
-        uses: benc-uk/workflow-dispatch@v1
+          SLACK_BOT_TOKEN: ${{ secrets.TEST_SLACK_BOT_TOKEN}}
+      - name: Sleep for 1 minute
+        run: sleep 60s
+        shell: bash
+      - name: Notify on completing job
+        uses: slackapi/slack-github-action@v1.24.0
         with:
-          workflow: Tag
-          token: ${{ secrets.BROADBOT_TOKEN }}
-
-  source-clear:
-    needs: [ build ]
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up JDK
-        uses: actions/setup-java@v2
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-          cache: 'gradle'
-
-      - name: SourceClear scan
+            # Unlike the step posting a new message, this step does not accept a channel name.
+            # Please use a channel ID, not a name here.
+            channel-id: "CMYTGJVFY"
+            update-ts: ${{ steps.slack.outputs.ts }}
+            payload: |
+              {
+                "text": "DRSHub Build and Test Action (Completed)",
+                "attachments": [
+                  {
+                    "pretext": "Job Completed",
+                    "color": "28a745",
+                    "fields": [
+                      {
+                        "title": "Status",
+                        "short": true,
+                        "value": "Completed"
+                      }
+                    ]
+                  }
+                ]
+              }
         env:
-          SRCCLR_API_TOKEN: ${{ secrets.SRCCLR_API_TOKEN }}
-        run: ./gradlew --build-cache srcclr
+          SLACK_BOT_TOKEN: ${{ secrets.TEST_SLACK_BOT_TOKEN }}
+  # notify-slack:
+  #   needs: [ build, jib, unit-tests, integration-tests ]
+  #   runs-on: ubuntu-latest
+
+  #   if: failure() && github.ref == 'refs/heads/dev'
+
+  #   steps:
+  #     - name: Notify slack on failure
+  #       id: slack
+  #       uses: slackapi/slack-github-action@v1.24.0
+  #       with:
+  #         payload: |
+  #           {
+  #             "workflow_url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+  #             "workflow_name": "Build and Test",
+  #             "branch" : "${{ github.ref }}"
+  #           }
+  #       env:
+  #         SLACK_WEBHOOK_URL: ${{ secrets.TEST_JADE_ALERTS_SLACK_WEBHOOK }}
+  # build:
+  #   runs-on: ubuntu-latest
+
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Set up JDK 17
+  #       uses: actions/setup-java@v2
+  #       with:
+  #         java-version: '17'
+  #         distribution: 'temurin'
+
+  #     - name: Gradle cache
+  #       uses: actions/cache@v2
+  #       with:
+  #         path: |
+  #           ~/.gradle/caches
+  #           ~/.gradle/wrapper
+  #         key: v1-${{ runner.os }}-gradle-${{ github.ref }}-${{ github.sha }}
+  #         restore-keys: v1-${{ runner.os }}-gradle-${{ github.ref }}
+
+  #     - name: Cache SonarCloud packages
+  #       uses: actions/cache@v1
+  #       with:
+  #         path: ~/.sonar/cache
+  #         key: ${{ runner.os }}-sonar
+  #         restore-keys: ${{ runner.os }}-sonar
+
+  #     - name: Gradle build service
+  #       run: ./gradlew --build-cache :service:build -x test
+
+  #     - name: SonarQube scan service
+  #       env:
+  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
+  #         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+  #       run: ./gradlew --build-cache :service:sonarqube
+
+  #     - name: Upload spotbugs results
+  #       uses: github/codeql-action/upload-sarif@main
+  #       with:
+  #         sarif_file: service/build/reports/spotbugs/main.sarif
+
+  # jib:
+  #   needs: [ build ]
+  #   runs-on: ubuntu-latest
+
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Set up JDK 17
+  #       uses: actions/setup-java@v2
+  #       with:
+  #         java-version: '17'
+  #         distribution: 'temurin'
+
+  #     - name: Gradle cache
+  #       uses: actions/cache@v2
+  #       with:
+  #         path: |
+  #           ~/.gradle/caches
+  #           ~/.gradle/wrapper
+  #         key: v1-${{ runner.os }}-gradle-${{ github.ref }}-${{ github.sha }}
+
+  #     - name: Add Google Cloud Profiler to Docker Image
+  #       run: docker build ./service -t drshub:local
+
+  #     - name: Build image locally with jib
+  #       # build the docker image to make sure it does not error
+  #       run: |
+  #         ./gradlew --build-cache :service:jibDockerBuild \
+  #         -Djib.from.image=docker://drshub:local \
+  #         -Djib.console=plain
+
+  # unit-tests:
+  #   needs: [ build ]
+  #   runs-on: ubuntu-latest
+
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Set up JDK 17
+  #       uses: actions/setup-java@v2
+  #       with:
+  #         java-version: '17'
+  #         distribution: 'temurin'
+
+  #     - name: Git secrets setup
+  #       run: |
+  #         git clone https://github.com/awslabs/git-secrets.git ~/git-secrets
+  #         cd ~/git-secrets
+  #         git checkout b9e96b3212fa06aea65964ff0d5cda84ce935f38
+  #         sudo make install
+
+  #     - name: Secrets check
+  #       run: |
+  #         sudo ln -s "$(which echo)" /usr/local/bin/say
+  #         ./minnie-kenny.sh --force
+  #         git secrets --scan-history
+
+  #     - name: Gradle cache
+  #       uses: actions/cache@v2
+  #       with:
+  #         path: |
+  #           ~/.gradle/caches
+  #           ~/.gradle/wrapper
+  #         key: v1-${{ runner.os }}-gradle-${{ github.ref }}-${{ github.sha }}
+
+  #     - name: Test with coverage
+  #       run: ./gradlew --build-cache jacocoTestReport --scan
+
+  #     - name: Codecov
+  #       uses: codecov/codecov-action@v3
+  #       with:
+  #         files: ./service/build/reports/jacoco/test/jacocoTestReport.xml
+
+  # integration-tests:
+  #   needs: [ build ]
+  #   runs-on: ubuntu-latest
+
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Set up JDK 17
+  #       uses: actions/setup-java@v2
+  #       with:
+  #         java-version: '17'
+  #         distribution: 'temurin'
+
+  #     - name: Gradle cache
+  #       uses: actions/cache@v2
+  #       with:
+  #         path: |
+  #           ~/.gradle/caches
+  #           ~/.gradle/wrapper
+  #         key: v1-${{ runner.os }}-gradle-${{ github.ref }}-${{ github.sha }}
+
+  #     - name: Render GitHub Secrets
+  #       env:
+  #         DEV_FIRECLOUD_ACCOUNT_B64: ${{ secrets.DEV_FIRECLOUD_ACCOUNT_B64 }}
+  #       run: echo "$DEV_FIRECLOUD_ACCOUNT_B64" | base64 -d >"./integration/src/main/resources/rendered/user-delegated-sa.json"
+
+  #     - name: Launch the background process for integration tests
+  #       run: ./gradlew --build-cache :service:bootRunDev | tee application.log &
+
+  #     - name: Prep the integration project
+  #       run: ./gradlew --build-cache :integration:classes
+
+  #     - name: Wait for boot run to be ready
+  #       run: |
+  #         timeout 60 bash -c 'until echo > /dev/tcp/localhost/8080; do sleep 1; done'
+  #         resultStatus=$(echo > /dev/tcp/localhost/8080; echo $?)
+  #         if [[ $resultStatus == 0 ]]; then
+  #           echo "Server started successfully"
+  #         else
+  #           echo "Server did not start successfully."
+  #           exit 1
+  #         fi
+
+  #     - name: Run the integration test suite
+  #       run: ./gradlew --build-cache :integration:runTest --args="suites/FullIntegration.json /tmp/foo"
+
+  #     - name: Archive logs
+  #       id: archive_logs
+  #       if: always()
+  #       uses: actions/upload-artifact@v2
+  #       with:
+  #         name: application-logs
+  #         path: |
+  #           application.log
+
+  # dispatch-tag:
+  #   needs: [ build, jib, unit-tests, integration-tests ]
+  #   runs-on: ubuntu-latest
+
+  #   if: success() && github.ref == 'refs/heads/dev'
+
+  #   steps:
+  #     - name: Fire off tag action
+  #       uses: benc-uk/workflow-dispatch@v1
+  #       with:
+  #         workflow: Tag
+  #         token: ${{ secrets.BROADBOT_TOKEN }}
+
+  # source-clear:
+  #   needs: [ build ]
+  #   runs-on: ubuntu-latest
+
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Set up JDK
+  #       uses: actions/setup-java@v2
+  #       with:
+  #         java-version: '17'
+  #         distribution: 'temurin'
+  #         cache: 'gradle'
+
+  #     - name: SourceClear scan
+  #       env:
+  #         SRCCLR_API_TOKEN: ${{ secrets.SRCCLR_API_TOKEN }}
+  #       run: ./gradlew --build-cache srcclr

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -9,211 +9,216 @@ on:
   workflow_dispatch: {}
 
 jobs:
-  notify-slack:
-    # needs: [ build, jib, unit-tests, integration-tests ]
+  build:
     runs-on: ubuntu-latest
 
-    # if: failure() && github.ref == 'refs/heads/dev'
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v2
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Gradle cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: v1-${{ runner.os }}-gradle-${{ github.ref }}-${{ github.sha }}
+          restore-keys: v1-${{ runner.os }}-gradle-${{ github.ref }}
+
+      - name: Cache SonarCloud packages
+        uses: actions/cache@v1
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+
+      - name: Gradle build service
+        run: ./gradlew --build-cache :service:build -x test
+
+      - name: SonarQube scan service
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: ./gradlew --build-cache :service:sonarqube
+
+      - name: Upload spotbugs results
+        uses: github/codeql-action/upload-sarif@main
+        with:
+          sarif_file: service/build/reports/spotbugs/main.sarif
+
+  jib:
+    needs: [ build ]
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v2
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Gradle cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: v1-${{ runner.os }}-gradle-${{ github.ref }}-${{ github.sha }}
+
+      - name: Add Google Cloud Profiler to Docker Image
+        run: docker build ./service -t drshub:local
+
+      - name: Build image locally with jib
+        # build the docker image to make sure it does not error
+        run: |
+          ./gradlew --build-cache :service:jibDockerBuild \
+          -Djib.from.image=docker://drshub:local \
+          -Djib.console=plain
+
+  unit-tests:
+    needs: [ build ]
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v2
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Git secrets setup
+        run: |
+          git clone https://github.com/awslabs/git-secrets.git ~/git-secrets
+          cd ~/git-secrets
+          git checkout b9e96b3212fa06aea65964ff0d5cda84ce935f38
+          sudo make install
+
+      - name: Secrets check
+        run: |
+          sudo ln -s "$(which echo)" /usr/local/bin/say
+          ./minnie-kenny.sh --force
+          git secrets --scan-history
+
+      - name: Gradle cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: v1-${{ runner.os }}-gradle-${{ github.ref }}-${{ github.sha }}
+
+      - name: Test with coverage
+        run: ./gradlew --build-cache jacocoTestReport --scan
+
+      - name: Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          files: ./service/build/reports/jacoco/test/jacocoTestReport.xml
+
+  integration-tests:
+    needs: [ build ]
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v2
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Gradle cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: v1-${{ runner.os }}-gradle-${{ github.ref }}-${{ github.sha }}
+
+      - name: Render GitHub Secrets
+        env:
+          DEV_FIRECLOUD_ACCOUNT_B64: ${{ secrets.DEV_FIRECLOUD_ACCOUNT_B64 }}
+        run: echo "$DEV_FIRECLOUD_ACCOUNT_B64" | base64 -d >"./integration/src/main/resources/rendered/user-delegated-sa.json"
+
+      - name: Launch the background process for integration tests
+        run: ./gradlew --build-cache :service:bootRunDev | tee application.log &
+
+      - name: Prep the integration project
+        run: ./gradlew --build-cache :integration:classes
+
+      - name: Wait for boot run to be ready
+        run: |
+          timeout 60 bash -c 'until echo > /dev/tcp/localhost/8080; do sleep 1; done'
+          resultStatus=$(echo > /dev/tcp/localhost/8080; echo $?)
+          if [[ $resultStatus == 0 ]]; then
+            echo "Server started successfully"
+          else
+            echo "Server did not start successfully."
+            exit 1
+          fi
+
+      - name: Run the integration test suite
+        run: ./gradlew --build-cache :integration:runTest --args="suites/FullIntegration.json /tmp/foo"
+
+      - name: Archive logs
+        id: archive_logs
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: application-logs
+          path: |
+            application.log
+
+  notify-slack:
+    needs: [ build, jib, unit-tests, integration-tests ]
+    runs-on: ubuntu-latest
+
+    if: failure() && github.ref == 'refs/heads/dev'
 
     steps:
       - name: Notify slack on failure
-        id: slack
-        uses: slackapi/slack-github-action@v1.24.0
+        uses: 8398a7/action-slack@v3
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.TEST_JADE_ALERTS_SLACK_WEBHOOK }}
-  # build:
-  #   runs-on: ubuntu-latest
+          SLACK_WEBHOOK_URL: ${{ secrets.POLICY_INT_WEBHOOK_URL }}
+        with:
+          status: failure
+          author_name: Build on dev (drs-hub)
+          fields: workflow,message
+          text: 'Build failed :sadpanda:'
 
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - name: Set up JDK 17
-  #       uses: actions/setup-java@v2
-  #       with:
-  #         java-version: '17'
-  #         distribution: 'temurin'
+  dispatch-tag:
+    needs: [ build, jib, unit-tests, integration-tests ]
+    runs-on: ubuntu-latest
 
-  #     - name: Gradle cache
-  #       uses: actions/cache@v2
-  #       with:
-  #         path: |
-  #           ~/.gradle/caches
-  #           ~/.gradle/wrapper
-  #         key: v1-${{ runner.os }}-gradle-${{ github.ref }}-${{ github.sha }}
-  #         restore-keys: v1-${{ runner.os }}-gradle-${{ github.ref }}
+    if: success() && github.ref == 'refs/heads/dev'
 
-  #     - name: Cache SonarCloud packages
-  #       uses: actions/cache@v1
-  #       with:
-  #         path: ~/.sonar/cache
-  #         key: ${{ runner.os }}-sonar
-  #         restore-keys: ${{ runner.os }}-sonar
+    steps:
+      - name: Fire off tag action
+        uses: benc-uk/workflow-dispatch@v1
+        with:
+          workflow: Tag
+          token: ${{ secrets.BROADBOT_TOKEN }}
 
-  #     - name: Gradle build service
-  #       run: ./gradlew --build-cache :service:build -x test
+  source-clear:
+    needs: [ build ]
+    runs-on: ubuntu-latest
 
-  #     - name: SonarQube scan service
-  #       env:
-  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
-  #         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-  #       run: ./gradlew --build-cache :service:sonarqube
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK
+        uses: actions/setup-java@v2
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: 'gradle'
 
-  #     - name: Upload spotbugs results
-  #       uses: github/codeql-action/upload-sarif@main
-  #       with:
-  #         sarif_file: service/build/reports/spotbugs/main.sarif
-
-  # jib:
-  #   needs: [ build ]
-  #   runs-on: ubuntu-latest
-
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - name: Set up JDK 17
-  #       uses: actions/setup-java@v2
-  #       with:
-  #         java-version: '17'
-  #         distribution: 'temurin'
-
-  #     - name: Gradle cache
-  #       uses: actions/cache@v2
-  #       with:
-  #         path: |
-  #           ~/.gradle/caches
-  #           ~/.gradle/wrapper
-  #         key: v1-${{ runner.os }}-gradle-${{ github.ref }}-${{ github.sha }}
-
-  #     - name: Add Google Cloud Profiler to Docker Image
-  #       run: docker build ./service -t drshub:local
-
-  #     - name: Build image locally with jib
-  #       # build the docker image to make sure it does not error
-  #       run: |
-  #         ./gradlew --build-cache :service:jibDockerBuild \
-  #         -Djib.from.image=docker://drshub:local \
-  #         -Djib.console=plain
-
-  # unit-tests:
-  #   needs: [ build ]
-  #   runs-on: ubuntu-latest
-
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - name: Set up JDK 17
-  #       uses: actions/setup-java@v2
-  #       with:
-  #         java-version: '17'
-  #         distribution: 'temurin'
-
-  #     - name: Git secrets setup
-  #       run: |
-  #         git clone https://github.com/awslabs/git-secrets.git ~/git-secrets
-  #         cd ~/git-secrets
-  #         git checkout b9e96b3212fa06aea65964ff0d5cda84ce935f38
-  #         sudo make install
-
-  #     - name: Secrets check
-  #       run: |
-  #         sudo ln -s "$(which echo)" /usr/local/bin/say
-  #         ./minnie-kenny.sh --force
-  #         git secrets --scan-history
-
-  #     - name: Gradle cache
-  #       uses: actions/cache@v2
-  #       with:
-  #         path: |
-  #           ~/.gradle/caches
-  #           ~/.gradle/wrapper
-  #         key: v1-${{ runner.os }}-gradle-${{ github.ref }}-${{ github.sha }}
-
-  #     - name: Test with coverage
-  #       run: ./gradlew --build-cache jacocoTestReport --scan
-
-  #     - name: Codecov
-  #       uses: codecov/codecov-action@v3
-  #       with:
-  #         files: ./service/build/reports/jacoco/test/jacocoTestReport.xml
-
-  # integration-tests:
-  #   needs: [ build ]
-  #   runs-on: ubuntu-latest
-
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - name: Set up JDK 17
-  #       uses: actions/setup-java@v2
-  #       with:
-  #         java-version: '17'
-  #         distribution: 'temurin'
-
-  #     - name: Gradle cache
-  #       uses: actions/cache@v2
-  #       with:
-  #         path: |
-  #           ~/.gradle/caches
-  #           ~/.gradle/wrapper
-  #         key: v1-${{ runner.os }}-gradle-${{ github.ref }}-${{ github.sha }}
-
-  #     - name: Render GitHub Secrets
-  #       env:
-  #         DEV_FIRECLOUD_ACCOUNT_B64: ${{ secrets.DEV_FIRECLOUD_ACCOUNT_B64 }}
-  #       run: echo "$DEV_FIRECLOUD_ACCOUNT_B64" | base64 -d >"./integration/src/main/resources/rendered/user-delegated-sa.json"
-
-  #     - name: Launch the background process for integration tests
-  #       run: ./gradlew --build-cache :service:bootRunDev | tee application.log &
-
-  #     - name: Prep the integration project
-  #       run: ./gradlew --build-cache :integration:classes
-
-  #     - name: Wait for boot run to be ready
-  #       run: |
-  #         timeout 60 bash -c 'until echo > /dev/tcp/localhost/8080; do sleep 1; done'
-  #         resultStatus=$(echo > /dev/tcp/localhost/8080; echo $?)
-  #         if [[ $resultStatus == 0 ]]; then
-  #           echo "Server started successfully"
-  #         else
-  #           echo "Server did not start successfully."
-  #           exit 1
-  #         fi
-
-  #     - name: Run the integration test suite
-  #       run: ./gradlew --build-cache :integration:runTest --args="suites/FullIntegration.json /tmp/foo"
-
-  #     - name: Archive logs
-  #       id: archive_logs
-  #       if: always()
-  #       uses: actions/upload-artifact@v2
-  #       with:
-  #         name: application-logs
-  #         path: |
-  #           application.log
-
-  # dispatch-tag:
-  #   needs: [ build, jib, unit-tests, integration-tests ]
-  #   runs-on: ubuntu-latest
-
-  #   if: success() && github.ref == 'refs/heads/dev'
-
-  #   steps:
-  #     - name: Fire off tag action
-  #       uses: benc-uk/workflow-dispatch@v1
-  #       with:
-  #         workflow: Tag
-  #         token: ${{ secrets.BROADBOT_TOKEN }}
-
-  # source-clear:
-  #   needs: [ build ]
-  #   runs-on: ubuntu-latest
-
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - name: Set up JDK
-  #       uses: actions/setup-java@v2
-  #       with:
-  #         java-version: '17'
-  #         distribution: 'temurin'
-  #         cache: 'gradle'
-
-  #     - name: SourceClear scan
-  #       env:
-  #         SRCCLR_API_TOKEN: ${{ secrets.SRCCLR_API_TOKEN }}
-  #       run: ./gradlew --build-cache srcclr
+      - name: SourceClear scan
+        env:
+          SRCCLR_API_TOKEN: ${{ secrets.SRCCLR_API_TOKEN }}
+        run: ./gradlew --build-cache srcclr

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -9,217 +9,212 @@ on:
   workflow_dispatch: {}
 
 jobs:
-  notify-slack:
-    # needs: [ build, jib, unit-tests, integration-tests ]
+  build:
     runs-on: ubuntu-latest
 
-    # if: failure() && github.ref == 'refs/heads/dev'
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v2
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Gradle cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: v1-${{ runner.os }}-gradle-${{ github.ref }}-${{ github.sha }}
+          restore-keys: v1-${{ runner.os }}-gradle-${{ github.ref }}
+
+      - name: Cache SonarCloud packages
+        uses: actions/cache@v1
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+
+      - name: Gradle build service
+        run: ./gradlew --build-cache :service:build -x test
+
+      - name: SonarQube scan service
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: ./gradlew --build-cache :service:sonarqube
+
+      - name: Upload spotbugs results
+        uses: github/codeql-action/upload-sarif@main
+        with:
+          sarif_file: service/build/reports/spotbugs/main.sarif
+
+  jib:
+    needs: [ build ]
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v2
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Gradle cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: v1-${{ runner.os }}-gradle-${{ github.ref }}-${{ github.sha }}
+
+      - name: Add Google Cloud Profiler to Docker Image
+        run: docker build ./service -t drshub:local
+
+      - name: Build image locally with jib
+        # build the docker image to make sure it does not error
+        run: |
+          ./gradlew --build-cache :service:jibDockerBuild \
+          -Djib.from.image=docker://drshub:local \
+          -Djib.console=plain
+
+  unit-tests:
+    needs: [ build ]
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v2
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Git secrets setup
+        run: |
+          git clone https://github.com/awslabs/git-secrets.git ~/git-secrets
+          cd ~/git-secrets
+          git checkout b9e96b3212fa06aea65964ff0d5cda84ce935f38
+          sudo make install
+
+      - name: Secrets check
+        run: |
+          sudo ln -s "$(which echo)" /usr/local/bin/say
+          ./minnie-kenny.sh --force
+          git secrets --scan-history
+
+      - name: Gradle cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: v1-${{ runner.os }}-gradle-${{ github.ref }}-${{ github.sha }}
+
+      - name: Test with coverage
+        run: ./gradlew --build-cache jacocoTestReport --scan
+
+      - name: Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          files: ./service/build/reports/jacoco/test/jacocoTestReport.xml
+
+  integration-tests:
+    needs: [ build ]
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v2
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Gradle cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: v1-${{ runner.os }}-gradle-${{ github.ref }}-${{ github.sha }}
+
+      - name: Render GitHub Secrets
+        env:
+          DEV_FIRECLOUD_ACCOUNT_B64: ${{ secrets.DEV_FIRECLOUD_ACCOUNT_B64 }}
+        run: echo "$DEV_FIRECLOUD_ACCOUNT_B64" | base64 -d >"./integration/src/main/resources/rendered/user-delegated-sa.json"
+
+      - name: Launch the background process for integration tests
+        run: ./gradlew --build-cache :service:bootRunDev | tee application.log &
+
+      - name: Prep the integration project
+        run: ./gradlew --build-cache :integration:classes
+
+      - name: Wait for boot run to be ready
+        run: |
+          timeout 60 bash -c 'until echo > /dev/tcp/localhost/8080; do sleep 1; done'
+          resultStatus=$(echo > /dev/tcp/localhost/8080; echo $?)
+          if [[ $resultStatus == 0 ]]; then
+            echo "Server started successfully"
+          else
+            echo "Server did not start successfully."
+            exit 1
+          fi
+
+      - name: Run the integration test suite
+        run: ./gradlew --build-cache :integration:runTest --args="suites/FullIntegration.json /tmp/foo"
+
+      - name: Archive logs
+        id: archive_logs
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: application-logs
+          path: |
+            application.log
+
+  notify-slack:
+    needs: [ build, jib, unit-tests, integration-tests ]
+    runs-on: ubuntu-latest
+
+    if: failure() && github.ref == 'refs/heads/dev'
 
     steps:
       - name: Notify slack on failure
         id: slack
         uses: slackapi/slack-github-action@v1.24.0
-        with:
-          # This data can be any valid JSON from a previous step in the GitHub Action
-          payload: |
-            {
-              "workflow_url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
-              "workflow_name": "Build and Test",
-              "branch" : "${{ github.ref }}"
-            }
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.TEST_JADE_ALERTS_SLACK_WEBHOOK }}
 
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - name: Set up JDK 17
-  #       uses: actions/setup-java@v2
-  #       with:
-  #         java-version: '17'
-  #         distribution: 'temurin'
+  dispatch-tag:
+    needs: [ build, jib, unit-tests, integration-tests ]
+    runs-on: ubuntu-latest
 
-  #     - name: Gradle cache
-  #       uses: actions/cache@v2
-  #       with:
-  #         path: |
-  #           ~/.gradle/caches
-  #           ~/.gradle/wrapper
-  #         key: v1-${{ runner.os }}-gradle-${{ github.ref }}-${{ github.sha }}
-  #         restore-keys: v1-${{ runner.os }}-gradle-${{ github.ref }}
+    if: success() && github.ref == 'refs/heads/dev'
 
-  #     - name: Cache SonarCloud packages
-  #       uses: actions/cache@v1
-  #       with:
-  #         path: ~/.sonar/cache
-  #         key: ${{ runner.os }}-sonar
-  #         restore-keys: ${{ runner.os }}-sonar
+    steps:
+      - name: Fire off tag action
+        uses: benc-uk/workflow-dispatch@v1
+        with:
+          workflow: Tag
+          token: ${{ secrets.BROADBOT_TOKEN }}
 
-  #     - name: Gradle build service
-  #       run: ./gradlew --build-cache :service:build -x test
+  source-clear:
+    needs: [ build ]
+    runs-on: ubuntu-latest
 
-  #     - name: SonarQube scan service
-  #       env:
-  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
-  #         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-  #       run: ./gradlew --build-cache :service:sonarqube
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK
+        uses: actions/setup-java@v2
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: 'gradle'
 
-  #     - name: Upload spotbugs results
-  #       uses: github/codeql-action/upload-sarif@main
-  #       with:
-  #         sarif_file: service/build/reports/spotbugs/main.sarif
-
-  # jib:
-  #   needs: [ build ]
-  #   runs-on: ubuntu-latest
-
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - name: Set up JDK 17
-  #       uses: actions/setup-java@v2
-  #       with:
-  #         java-version: '17'
-  #         distribution: 'temurin'
-
-  #     - name: Gradle cache
-  #       uses: actions/cache@v2
-  #       with:
-  #         path: |
-  #           ~/.gradle/caches
-  #           ~/.gradle/wrapper
-  #         key: v1-${{ runner.os }}-gradle-${{ github.ref }}-${{ github.sha }}
-
-  #     - name: Add Google Cloud Profiler to Docker Image
-  #       run: docker build ./service -t drshub:local
-
-  #     - name: Build image locally with jib
-  #       # build the docker image to make sure it does not error
-  #       run: |
-  #         ./gradlew --build-cache :service:jibDockerBuild \
-  #         -Djib.from.image=docker://drshub:local \
-  #         -Djib.console=plain
-
-  # unit-tests:
-  #   needs: [ build ]
-  #   runs-on: ubuntu-latest
-
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - name: Set up JDK 17
-  #       uses: actions/setup-java@v2
-  #       with:
-  #         java-version: '17'
-  #         distribution: 'temurin'
-
-  #     - name: Git secrets setup
-  #       run: |
-  #         git clone https://github.com/awslabs/git-secrets.git ~/git-secrets
-  #         cd ~/git-secrets
-  #         git checkout b9e96b3212fa06aea65964ff0d5cda84ce935f38
-  #         sudo make install
-
-  #     - name: Secrets check
-  #       run: |
-  #         sudo ln -s "$(which echo)" /usr/local/bin/say
-  #         ./minnie-kenny.sh --force
-  #         git secrets --scan-history
-
-  #     - name: Gradle cache
-  #       uses: actions/cache@v2
-  #       with:
-  #         path: |
-  #           ~/.gradle/caches
-  #           ~/.gradle/wrapper
-  #         key: v1-${{ runner.os }}-gradle-${{ github.ref }}-${{ github.sha }}
-
-  #     - name: Test with coverage
-  #       run: ./gradlew --build-cache jacocoTestReport --scan
-
-  #     - name: Codecov
-  #       uses: codecov/codecov-action@v3
-  #       with:
-  #         files: ./service/build/reports/jacoco/test/jacocoTestReport.xml
-
-  # integration-tests:
-  #   needs: [ build ]
-  #   runs-on: ubuntu-latest
-
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - name: Set up JDK 17
-  #       uses: actions/setup-java@v2
-  #       with:
-  #         java-version: '17'
-  #         distribution: 'temurin'
-
-  #     - name: Gradle cache
-  #       uses: actions/cache@v2
-  #       with:
-  #         path: |
-  #           ~/.gradle/caches
-  #           ~/.gradle/wrapper
-  #         key: v1-${{ runner.os }}-gradle-${{ github.ref }}-${{ github.sha }}
-
-  #     - name: Render GitHub Secrets
-  #       env:
-  #         DEV_FIRECLOUD_ACCOUNT_B64: ${{ secrets.DEV_FIRECLOUD_ACCOUNT_B64 }}
-  #       run: echo "$DEV_FIRECLOUD_ACCOUNT_B64" | base64 -d >"./integration/src/main/resources/rendered/user-delegated-sa.json"
-
-  #     - name: Launch the background process for integration tests
-  #       run: ./gradlew --build-cache :service:bootRunDev | tee application.log &
-
-  #     - name: Prep the integration project
-  #       run: ./gradlew --build-cache :integration:classes
-
-  #     - name: Wait for boot run to be ready
-  #       run: |
-  #         timeout 60 bash -c 'until echo > /dev/tcp/localhost/8080; do sleep 1; done'
-  #         resultStatus=$(echo > /dev/tcp/localhost/8080; echo $?)
-  #         if [[ $resultStatus == 0 ]]; then
-  #           echo "Server started successfully"
-  #         else
-  #           echo "Server did not start successfully."
-  #           exit 1
-  #         fi
-
-  #     - name: Run the integration test suite
-  #       run: ./gradlew --build-cache :integration:runTest --args="suites/FullIntegration.json /tmp/foo"
-
-  #     - name: Archive logs
-  #       id: archive_logs
-  #       if: always()
-  #       uses: actions/upload-artifact@v2
-  #       with:
-  #         name: application-logs
-  #         path: |
-  #           application.log
-
-  # dispatch-tag:
-  #   needs: [ build, jib, unit-tests, integration-tests ]
-  #   runs-on: ubuntu-latest
-
-  #   if: success() && github.ref == 'refs/heads/dev'
-
-  #   steps:
-  #     - name: Fire off tag action
-  #       uses: benc-uk/workflow-dispatch@v1
-  #       with:
-  #         workflow: Tag
-  #         token: ${{ secrets.BROADBOT_TOKEN }}
-
-  # source-clear:
-  #   needs: [ build ]
-  #   runs-on: ubuntu-latest
-
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - name: Set up JDK
-  #       uses: actions/setup-java@v2
-  #       with:
-  #         java-version: '17'
-  #         distribution: 'temurin'
-  #         cache: 'gradle'
-
-  #     - name: SourceClear scan
-  #       env:
-  #         SRCCLR_API_TOKEN: ${{ secrets.SRCCLR_API_TOKEN }}
-  #       run: ./gradlew --build-cache srcclr
+      - name: SourceClear scan
+        env:
+          SRCCLR_API_TOKEN: ${{ secrets.SRCCLR_API_TOKEN }}
+        run: ./gradlew --build-cache srcclr

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -9,212 +9,217 @@ on:
   workflow_dispatch: {}
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up JDK 17
-        uses: actions/setup-java@v2
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-
-      - name: Gradle cache
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: v1-${{ runner.os }}-gradle-${{ github.ref }}-${{ github.sha }}
-          restore-keys: v1-${{ runner.os }}-gradle-${{ github.ref }}
-
-      - name: Cache SonarCloud packages
-        uses: actions/cache@v1
-        with:
-          path: ~/.sonar/cache
-          key: ${{ runner.os }}-sonar
-          restore-keys: ${{ runner.os }}-sonar
-
-      - name: Gradle build service
-        run: ./gradlew --build-cache :service:build -x test
-
-      - name: SonarQube scan service
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: ./gradlew --build-cache :service:sonarqube
-
-      - name: Upload spotbugs results
-        uses: github/codeql-action/upload-sarif@main
-        with:
-          sarif_file: service/build/reports/spotbugs/main.sarif
-
-  jib:
-    needs: [ build ]
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up JDK 17
-        uses: actions/setup-java@v2
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-
-      - name: Gradle cache
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: v1-${{ runner.os }}-gradle-${{ github.ref }}-${{ github.sha }}
-
-      - name: Add Google Cloud Profiler to Docker Image
-        run: docker build ./service -t drshub:local
-
-      - name: Build image locally with jib
-        # build the docker image to make sure it does not error
-        run: |
-          ./gradlew --build-cache :service:jibDockerBuild \
-          -Djib.from.image=docker://drshub:local \
-          -Djib.console=plain
-
-  unit-tests:
-    needs: [ build ]
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up JDK 17
-        uses: actions/setup-java@v2
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-
-      - name: Git secrets setup
-        run: |
-          git clone https://github.com/awslabs/git-secrets.git ~/git-secrets
-          cd ~/git-secrets
-          git checkout b9e96b3212fa06aea65964ff0d5cda84ce935f38
-          sudo make install
-
-      - name: Secrets check
-        run: |
-          sudo ln -s "$(which echo)" /usr/local/bin/say
-          ./minnie-kenny.sh --force
-          git secrets --scan-history
-
-      - name: Gradle cache
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: v1-${{ runner.os }}-gradle-${{ github.ref }}-${{ github.sha }}
-
-      - name: Test with coverage
-        run: ./gradlew --build-cache jacocoTestReport --scan
-
-      - name: Codecov
-        uses: codecov/codecov-action@v3
-        with:
-          files: ./service/build/reports/jacoco/test/jacocoTestReport.xml
-
-  integration-tests:
-    needs: [ build ]
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up JDK 17
-        uses: actions/setup-java@v2
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-
-      - name: Gradle cache
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: v1-${{ runner.os }}-gradle-${{ github.ref }}-${{ github.sha }}
-
-      - name: Render GitHub Secrets
-        env:
-          DEV_FIRECLOUD_ACCOUNT_B64: ${{ secrets.DEV_FIRECLOUD_ACCOUNT_B64 }}
-        run: echo "$DEV_FIRECLOUD_ACCOUNT_B64" | base64 -d >"./integration/src/main/resources/rendered/user-delegated-sa.json"
-
-      - name: Launch the background process for integration tests
-        run: ./gradlew --build-cache :service:bootRunDev | tee application.log &
-
-      - name: Prep the integration project
-        run: ./gradlew --build-cache :integration:classes
-
-      - name: Wait for boot run to be ready
-        run: |
-          timeout 60 bash -c 'until echo > /dev/tcp/localhost/8080; do sleep 1; done'
-          resultStatus=$(echo > /dev/tcp/localhost/8080; echo $?)
-          if [[ $resultStatus == 0 ]]; then
-            echo "Server started successfully"
-          else
-            echo "Server did not start successfully."
-            exit 1
-          fi
-
-      - name: Run the integration test suite
-        run: ./gradlew --build-cache :integration:runTest --args="suites/FullIntegration.json /tmp/foo"
-
-      - name: Archive logs
-        id: archive_logs
-        if: always()
-        uses: actions/upload-artifact@v2
-        with:
-          name: application-logs
-          path: |
-            application.log
-
   notify-slack:
-    needs: [ build, jib, unit-tests, integration-tests ]
+    # needs: [ build, jib, unit-tests, integration-tests ]
     runs-on: ubuntu-latest
 
-    if: failure() && github.ref == 'refs/heads/dev'
+    # if: failure() && github.ref == 'refs/heads/dev'
 
     steps:
       - name: Notify slack on failure
         id: slack
         uses: slackapi/slack-github-action@v1.24.0
+        with:
+          # This data can be any valid JSON from a previous step in the GitHub Action
+          payload: |
+            {
+              "workflow_url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+              "workflow_name": "Build and Test",
+              "branch" : "${{ github.ref }}"
+            }
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.TEST_JADE_ALERTS_SLACK_WEBHOOK }}
 
-  dispatch-tag:
-    needs: [ build, jib, unit-tests, integration-tests ]
-    runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Set up JDK 17
+  #       uses: actions/setup-java@v2
+  #       with:
+  #         java-version: '17'
+  #         distribution: 'temurin'
 
-    if: success() && github.ref == 'refs/heads/dev'
+  #     - name: Gradle cache
+  #       uses: actions/cache@v2
+  #       with:
+  #         path: |
+  #           ~/.gradle/caches
+  #           ~/.gradle/wrapper
+  #         key: v1-${{ runner.os }}-gradle-${{ github.ref }}-${{ github.sha }}
+  #         restore-keys: v1-${{ runner.os }}-gradle-${{ github.ref }}
 
-    steps:
-      - name: Fire off tag action
-        uses: benc-uk/workflow-dispatch@v1
-        with:
-          workflow: Tag
-          token: ${{ secrets.BROADBOT_TOKEN }}
+  #     - name: Cache SonarCloud packages
+  #       uses: actions/cache@v1
+  #       with:
+  #         path: ~/.sonar/cache
+  #         key: ${{ runner.os }}-sonar
+  #         restore-keys: ${{ runner.os }}-sonar
 
-  source-clear:
-    needs: [ build ]
-    runs-on: ubuntu-latest
+  #     - name: Gradle build service
+  #       run: ./gradlew --build-cache :service:build -x test
 
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up JDK
-        uses: actions/setup-java@v2
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-          cache: 'gradle'
+  #     - name: SonarQube scan service
+  #       env:
+  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
+  #         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+  #       run: ./gradlew --build-cache :service:sonarqube
 
-      - name: SourceClear scan
-        env:
-          SRCCLR_API_TOKEN: ${{ secrets.SRCCLR_API_TOKEN }}
-        run: ./gradlew --build-cache srcclr
+  #     - name: Upload spotbugs results
+  #       uses: github/codeql-action/upload-sarif@main
+  #       with:
+  #         sarif_file: service/build/reports/spotbugs/main.sarif
+
+  # jib:
+  #   needs: [ build ]
+  #   runs-on: ubuntu-latest
+
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Set up JDK 17
+  #       uses: actions/setup-java@v2
+  #       with:
+  #         java-version: '17'
+  #         distribution: 'temurin'
+
+  #     - name: Gradle cache
+  #       uses: actions/cache@v2
+  #       with:
+  #         path: |
+  #           ~/.gradle/caches
+  #           ~/.gradle/wrapper
+  #         key: v1-${{ runner.os }}-gradle-${{ github.ref }}-${{ github.sha }}
+
+  #     - name: Add Google Cloud Profiler to Docker Image
+  #       run: docker build ./service -t drshub:local
+
+  #     - name: Build image locally with jib
+  #       # build the docker image to make sure it does not error
+  #       run: |
+  #         ./gradlew --build-cache :service:jibDockerBuild \
+  #         -Djib.from.image=docker://drshub:local \
+  #         -Djib.console=plain
+
+  # unit-tests:
+  #   needs: [ build ]
+  #   runs-on: ubuntu-latest
+
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Set up JDK 17
+  #       uses: actions/setup-java@v2
+  #       with:
+  #         java-version: '17'
+  #         distribution: 'temurin'
+
+  #     - name: Git secrets setup
+  #       run: |
+  #         git clone https://github.com/awslabs/git-secrets.git ~/git-secrets
+  #         cd ~/git-secrets
+  #         git checkout b9e96b3212fa06aea65964ff0d5cda84ce935f38
+  #         sudo make install
+
+  #     - name: Secrets check
+  #       run: |
+  #         sudo ln -s "$(which echo)" /usr/local/bin/say
+  #         ./minnie-kenny.sh --force
+  #         git secrets --scan-history
+
+  #     - name: Gradle cache
+  #       uses: actions/cache@v2
+  #       with:
+  #         path: |
+  #           ~/.gradle/caches
+  #           ~/.gradle/wrapper
+  #         key: v1-${{ runner.os }}-gradle-${{ github.ref }}-${{ github.sha }}
+
+  #     - name: Test with coverage
+  #       run: ./gradlew --build-cache jacocoTestReport --scan
+
+  #     - name: Codecov
+  #       uses: codecov/codecov-action@v3
+  #       with:
+  #         files: ./service/build/reports/jacoco/test/jacocoTestReport.xml
+
+  # integration-tests:
+  #   needs: [ build ]
+  #   runs-on: ubuntu-latest
+
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Set up JDK 17
+  #       uses: actions/setup-java@v2
+  #       with:
+  #         java-version: '17'
+  #         distribution: 'temurin'
+
+  #     - name: Gradle cache
+  #       uses: actions/cache@v2
+  #       with:
+  #         path: |
+  #           ~/.gradle/caches
+  #           ~/.gradle/wrapper
+  #         key: v1-${{ runner.os }}-gradle-${{ github.ref }}-${{ github.sha }}
+
+  #     - name: Render GitHub Secrets
+  #       env:
+  #         DEV_FIRECLOUD_ACCOUNT_B64: ${{ secrets.DEV_FIRECLOUD_ACCOUNT_B64 }}
+  #       run: echo "$DEV_FIRECLOUD_ACCOUNT_B64" | base64 -d >"./integration/src/main/resources/rendered/user-delegated-sa.json"
+
+  #     - name: Launch the background process for integration tests
+  #       run: ./gradlew --build-cache :service:bootRunDev | tee application.log &
+
+  #     - name: Prep the integration project
+  #       run: ./gradlew --build-cache :integration:classes
+
+  #     - name: Wait for boot run to be ready
+  #       run: |
+  #         timeout 60 bash -c 'until echo > /dev/tcp/localhost/8080; do sleep 1; done'
+  #         resultStatus=$(echo > /dev/tcp/localhost/8080; echo $?)
+  #         if [[ $resultStatus == 0 ]]; then
+  #           echo "Server started successfully"
+  #         else
+  #           echo "Server did not start successfully."
+  #           exit 1
+  #         fi
+
+  #     - name: Run the integration test suite
+  #       run: ./gradlew --build-cache :integration:runTest --args="suites/FullIntegration.json /tmp/foo"
+
+  #     - name: Archive logs
+  #       id: archive_logs
+  #       if: always()
+  #       uses: actions/upload-artifact@v2
+  #       with:
+  #         name: application-logs
+  #         path: |
+  #           application.log
+
+  # dispatch-tag:
+  #   needs: [ build, jib, unit-tests, integration-tests ]
+  #   runs-on: ubuntu-latest
+
+  #   if: success() && github.ref == 'refs/heads/dev'
+
+  #   steps:
+  #     - name: Fire off tag action
+  #       uses: benc-uk/workflow-dispatch@v1
+  #       with:
+  #         workflow: Tag
+  #         token: ${{ secrets.BROADBOT_TOKEN }}
+
+  # source-clear:
+  #   needs: [ build ]
+  #   runs-on: ubuntu-latest
+
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Set up JDK
+  #       uses: actions/setup-java@v2
+  #       with:
+  #         java-version: '17'
+  #         distribution: 'temurin'
+  #         cache: 'gradle'
+
+  #     - name: SourceClear scan
+  #       env:
+  #         SRCCLR_API_TOKEN: ${{ secrets.SRCCLR_API_TOKEN }}
+  #       run: ./gradlew --build-cache srcclr

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -185,6 +185,13 @@ jobs:
       - name: Notify slack on failure
         id: slack
         uses: slackapi/slack-github-action@v1.24.0
+        with:
+          payload: |
+            {
+              "workflow_url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+              "workflow_name": "Build and Test",
+              "branch" : "${{ github.ref }}"
+            }
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.TEST_JADE_ALERTS_SLACK_WEBHOOK }}
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -183,14 +183,10 @@ jobs:
 
     steps:
       - name: Notify slack on failure
-        uses: 8398a7/action-slack@v3
+        id: slack
+        uses: slackapi/slack-github-action@v1.24.0
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.POLICY_INT_WEBHOOK_URL }}
-        with:
-          status: failure
-          author_name: Build on dev (drs-hub)
-          fields: workflow,message
-          text: 'Build failed :sadpanda:'
+          SLACK_WEBHOOK_URL: ${{ secrets.TEST_JADE_ALERTS_SLACK_WEBHOOK }}
 
   dispatch-tag:
     needs: [ build, jib, unit-tests, integration-tests ]

--- a/.github/workflows/nightly-perf-tests.yml
+++ b/.github/workflows/nightly-perf-tests.yml
@@ -77,21 +77,9 @@ jobs:
         run: ./gradlew uploadResults --args="CompressDirectoryToTerraKernelK8S.json /tmp/test-results"
 
   notify-slack:
-   needs: [ performance-tests ]
-   runs-on: ubuntu-latest
-
-   if: failure()
-
-   steps:
-    - name: Notify slack on failure
-      id: slack
-      uses: slackapi/slack-github-action@v1.24.0
-      with:
-        payload: |
-          {
-            "workflow_url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
-            "workflow_name": "Nightly Perf Tests",
-            "branch" : "${{ github.ref }}"
-          }
-      env:
-        SLACK_WEBHOOK_URL: ${{ secrets.TEST_JADE_ALERTS_SLACK_WEBHOOK }}
+    needs: [ performance-tests ]
+    uses: ./.github/workflows/slack-notify.yml
+    if: failure()
+    secrets: inherit
+    with:
+      workflow_name: DRShub Nightly Perf Tests

--- a/.github/workflows/nightly-perf-tests.yml
+++ b/.github/workflows/nightly-perf-tests.yml
@@ -76,10 +76,9 @@ jobs:
       - name: Upload results to Google Bucket
         run: ./gradlew uploadResults --args="CompressDirectoryToTerraKernelK8S.json /tmp/test-results"
 
-  notify-slack:
+  notify-slack-on-failure:
     needs: [ performance-tests ]
-    uses: ./.github/workflows/slack-notify.yml
-    if: failure()
+    uses: ./.github/workflows/slack-notify-on-failure.yml
     secrets: inherit
     with:
       workflow_name: Nightly Perf Tests

--- a/.github/workflows/nightly-perf-tests.yml
+++ b/.github/workflows/nightly-perf-tests.yml
@@ -82,4 +82,4 @@ jobs:
     if: failure()
     secrets: inherit
     with:
-      workflow_name: DRShub Nightly Perf Tests
+      workflow_name: Nightly Perf Tests

--- a/.github/workflows/nightly-perf-tests.yml
+++ b/.github/workflows/nightly-perf-tests.yml
@@ -83,12 +83,15 @@ jobs:
    if: failure()
 
    steps:
-     - name: Notify slack on failure
-       uses: 8398a7/action-slack@v3
-       env:
-         SLACK_WEBHOOK_URL: ${{ secrets.POLICY_INT_WEBHOOK_URL }}
-       with:
-         status: failure
-         author_name: Test Runner
-         fields: workflow,message
-         text: 'DrsHub nightly perf tests failed :sadpanda:'
+    - name: Notify slack on failure
+      id: slack
+      uses: slackapi/slack-github-action@v1.24.0
+      with:
+        payload: |
+          {
+            "workflow_url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+            "workflow_name": "Nightly Perf Tests",
+            "branch" : "${{ github.ref }}"
+          }
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.TEST_JADE_ALERTS_SLACK_WEBHOOK }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -98,4 +98,4 @@ jobs:
     uses: ./.github/workflows/slack-notify.yml
     secrets: inherit
     with:
-      workflow_name: DRShub Publish
+      workflow_name: Publish

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -94,18 +94,8 @@ jobs:
 
   notify-slack-failures:
     needs: [publish-job, report-to-sherlock, set-version-in-dev]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Notify slack on failure
-        id: slack
-        if: failure()
-        uses: slackapi/slack-github-action@v1.24.0
-        with:
-          payload: |
-            {
-              "workflow_url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
-              "workflow_name": "Publish to Dev",
-              "branch" : "${{ github.ref }}"
-            }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.TEST_JADE_ALERTS_SLACK_WEBHOOK }}
+    if: failure()
+    uses: ./.github/workflows/slack-notify.yml
+    secrets: inherit
+    with:
+      workflow_name: DRShub Publish

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -97,12 +97,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Notify slack on failure
-        uses: broadinstitute/action-slack@v3
+        id: slack
         if: failure()
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.POLICY_INT_WEBHOOK_URL }}
+        uses: slackapi/slack-github-action@v1.24.0
         with:
-          status: ${{ job.status }}
-          author_name: Publish to dev
-          fields: job
-          text: 'Publish failed :sadpanda:'
+          payload: |
+            {
+              "workflow_url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+              "workflow_name": "Publish to Dev",
+              "branch" : "${{ github.ref }}"
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.TEST_JADE_ALERTS_SLACK_WEBHOOK }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -97,7 +97,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Notify slack on failure
-        uses: 8398a7/action-slack@v3
+        uses: broadinstitute/action-slack@v3
         if: failure()
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.POLICY_INT_WEBHOOK_URL }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -92,10 +92,9 @@ jobs:
     permissions:
       id-token: 'write'
 
-  notify-slack-failures:
+  notify-slack-on-failure:
     needs: [publish-job, report-to-sherlock, set-version-in-dev]
-    if: failure()
-    uses: ./.github/workflows/slack-notify.yml
+    uses: ./.github/workflows/slack-notify-on-failure.yml
     secrets: inherit
     with:
       workflow_name: Publish

--- a/.github/workflows/slack-notify-on-failure.yml
+++ b/.github/workflows/slack-notify-on-failure.yml
@@ -8,7 +8,8 @@ on:
 jobs:
     notify-slack:
         runs-on: ubuntu-latest
-        if: failure()
+        #Uncomment before merge
+        #if: failure()
         steps:
           - name: Notify slack on failure
             id: slack

--- a/.github/workflows/slack-notify-on-failure.yml
+++ b/.github/workflows/slack-notify-on-failure.yml
@@ -8,7 +8,7 @@ on:
 jobs:
     notify-slack:
         runs-on: ubuntu-latest
-        if: failure()
+        if: failure() && github.ref == 'refs/heads/dev'
         steps:
           - name: Notify slack on failure
             id: slack

--- a/.github/workflows/slack-notify-on-failure.yml
+++ b/.github/workflows/slack-notify-on-failure.yml
@@ -1,4 +1,4 @@
-name: slack-notify
+name: slack-notify-on-failure
 on:
     workflow_call:
       inputs:
@@ -8,6 +8,7 @@ on:
 jobs:
     notify-slack:
         runs-on: ubuntu-latest
+        if: failure()
         steps:
           - name: Notify slack on failure
             id: slack

--- a/.github/workflows/slack-notify-on-failure.yml
+++ b/.github/workflows/slack-notify-on-failure.yml
@@ -8,8 +8,7 @@ on:
 jobs:
     notify-slack:
         runs-on: ubuntu-latest
-        #Uncomment before merge
-        #if: failure()
+        if: failure()
         steps:
           - name: Notify slack on failure
             id: slack

--- a/.github/workflows/slack-notify-on-failure.yml
+++ b/.github/workflows/slack-notify-on-failure.yml
@@ -34,4 +34,4 @@ jobs:
                   ]
                 }
             env:
-              SLACK_BOT_TOKEN: ${{ secrets.TEST_SLACK_BOT_TOKEN}}
+              SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN}}

--- a/.github/workflows/slack-notify.yml
+++ b/.github/workflows/slack-notify.yml
@@ -1,0 +1,36 @@
+name: slack-notify
+on:
+    workflow_call:
+      inputs:
+        workflow_name:
+          required: true
+          type: string
+jobs:
+    notify-slack:
+        runs-on: ubuntu-latest
+        steps:
+          - name: Notify slack on failure
+            id: slack
+            uses: slackapi/slack-github-action@v1.24.0
+            with:
+              channel-id: "CMYTGJVFY"
+              payload: |
+                {
+                  "text": "DRSHub Github Action",
+                  "attachments": [
+                    {
+                      "title": "${{ inputs.workflow_name }} Failed",
+                      "title_link" : "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                      "color": "e51313",
+                      "fields": [
+                        {
+                          "title": "Status",
+                          "short": true,
+                          "value": "Failed"
+                        }
+                      ]
+                    }
+                  ]
+                }
+            env:
+              SLACK_BOT_TOKEN: ${{ secrets.TEST_SLACK_BOT_TOKEN}}

--- a/.github/workflows/slack-notify.yml
+++ b/.github/workflows/slack-notify.yml
@@ -20,7 +20,7 @@ jobs:
                   "attachments": [
                     {
                       "title": "${{ inputs.workflow_name }} Failed",
-                      "title_link" : "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                      "title_link" : "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
                       "color": "e51313",
                       "fields": [
                         {

--- a/.github/workflows/slack-notify.yml
+++ b/.github/workflows/slack-notify.yml
@@ -16,7 +16,7 @@ jobs:
               channel-id: "CMYTGJVFY"
               payload: |
                 {
-                  "text": "DRSHub Github Action",
+                  "text": "DRS Hub ${{ inputs.workflow_name }}",
                   "attachments": [
                     {
                       "title": "${{ inputs.workflow_name }} Failed",


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DR-3365
_________________
TODO:

- [x] Add bot token to slack secrets via [ap_deployments PR](https://github.com/broadinstitute/terraform-ap-deployments/pull/1314)
- [x] Rename secret

### Using Slack GHA integration with Slack Apps
- Utilizing the [slack-backed GHA](https://github.com/slackapi/slack-github-action?tab=readme-ov-file#technique-2-slack-app) integration
- Created new slack app named "DRS Hub Notification" and added app to #jade-alerts channel
- Gave the bot associated with the app "chat:write" permissions and then added the bot's token to github action secrets
- App can be managed here: https://api.slack.com/apps/A06CD9LRN92

### The Notifications
A new re-usable workflow has been added that only send notifications to #jade-alerts channel on failure. 

![image](https://github.com/DataBiosphere/terra-drs-hub/assets/13254229/ef970ce7-991e-4cca-a9b7-00aeaac1db78)


