### PR TITLE
[DR-3421] DrsHub should handle Bard errors

### DIFF
--- a/service/src/main/java/bio/terra/drshub/services/TrackingService.java
+++ b/service/src/main/java/bio/terra/drshub/services/TrackingService.java
@@ -45,23 +45,17 @@ public class TrackingService {
    */
   private void syncUser(BardApi bardApi, BearerToken bearerToken) {
     String key = bearerToken.getToken();
-    bearerTokenCache.computeIfAbsent(key, k -> syncProfile(bardApi) ? "" : null);
-  }
-
-  /**
-   * Syncs profile info from orchestration to mixpanel to improve querying/reporting capabilities in
-   * the mixpanel reports.
-   *
-   * @return boolean - if the sync request was successful.
-   */
-  private boolean syncProfile(BardApi bardApi) {
-    try {
-      bardApi.syncProfile();
-      return true;
-    } catch (Exception ex) {
-      log.warn("Error syncing user profile in bard", ex);
-      return false;
-    }
+    bearerTokenCache.computeIfAbsent(
+        key,
+        k -> {
+          try {
+            bardApi.syncProfile();
+            return "";
+          } catch (Exception ex) {
+            log.warn("Error syncing user profile in bard", ex);
+            return null;
+          }
+        });
   }
 
   private void logEvent(BardApi bardApi, String eventName, Map<String, ?> properties) {

--- a/service/src/main/java/bio/terra/drshub/services/TrackingService.java
+++ b/service/src/main/java/bio/terra/drshub/services/TrackingService.java
@@ -11,7 +11,6 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.map.PassiveExpiringMap;
-import org.springframework.http.ResponseEntity;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
@@ -57,7 +56,8 @@ public class TrackingService {
    */
   private boolean syncProfile(BardApi bardApi) {
     try {
-      return bardApi.syncProfileWithHttpInfo().getStatusCode().is2xxSuccessful();
+      bardApi.syncProfile();
+      return true;
     } catch (Exception ex) {
       log.warn("Error syncing user profile in bard", ex);
       return false;
@@ -72,10 +72,7 @@ public class TrackingService {
     Event event = new Event().event(eventName).properties(eventProperties);
 
     try {
-      ResponseEntity<Void> response = bardApi.eventWithHttpInfo(event);
-      if (!response.getStatusCode().is2xxSuccessful()) {
-        log.warn("Error sending event to bard: {}", response.getStatusCode());
-      }
+      bardApi.event(event);
     } catch (Exception ex) {
       log.warn("Error sending event to bard", ex);
     }


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DR-3421

BardApi docstrings indicate that a RestClientException is thrown if an error occurs while attempting to invoke the API.  If a response body is returned, it will have a 2xx status code.

```
    /**
     * Log a user event
     * Records the event to a log and optionally forwards it to mixpanel. Optionally takes an authorization token which must be verified with Sam. If properties['pushToMixpanel'] is false, only log the event (the property defaults to true). The logs will still get sent to BigQuery via a log sink.
     * <p><b>200</b> - Event was logged successfully
     * @param body  (required)
     * @return ResponseEntity<Void>
     * @throws RestClientException if an error occurs while attempting to invoke the API
     */
    public ResponseEntity<Void> eventWithHttpInfo(Event body) throws RestClientException {
…
```

Right now, we do not handle such errors and they show up as unhandled exception errors in our logs:

```
Unexpected exception occurred invoking async method: public void bio.terra.drshub.services.TrackingService.logEvent(bio.terra.common.iam.BearerToken,java.lang.String,java.util.Map)
org.springframework.web.client.HttpClientErrorException$NotFound: 404 Not Found: "<!DOCTYPE html><EOL><html lang="en"><EOL><head><EOL><meta charset="utf-8"><EOL><title>Error</title><EOL></head><EOL><body><EOL><pre>Cannot POST /api/event</pre><EOL></body><EOL></html><EOL>"
	at org.springframework.web.client.HttpClientErrorException.create(HttpClientErrorException.java:112)
	at org.springframework.web.client.DefaultResponseErrorHandler.handleError(DefaultResponseErrorHandler.java:183)
	at org.springframework.web.client.DefaultResponseErrorHandler.handleError(DefaultResponseErrorHandler.java:137)
	at org.springframework.web.client.ResponseErrorHandler.handleError(ResponseErrorHandler.java:63)
	at org.springframework.web.client.RestTemplate.handleResponse(RestTemplate.java:915)
	at org.springframework.web.client.RestTemplate.doExecute(RestTemplate.java:864)
	at org.springframework.web.client.RestTemplate.exchange(RestTemplate.java:714)
	at bio.terra.bard.client.ApiClient.invokeAPI(ApiClient.java:498)
	at bio.terra.bard.api.BardApi.eventWithHttpInfo(BardApi.java:91)
	at bio.terra.drshub.services.TrackingService.logEvent(TrackingService.java:60)
	at bio.terra.drshub.services.TrackingService.logEvent(TrackingService.java:40)
	at jdk.internal.reflect.GeneratedMethodAccessor212.invoke(Unknown Source)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)
	at java.base/java.lang.reflect.Method.invoke(Unknown Source)
	at org.springframework.aop.support.AopUtils.invokeJoinpointUsingReflection(AopUtils.java:343)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.invokeJoinpoint(ReflectiveMethodInvocation.java:196)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:163)
	at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:751)
	at org.springframework.aop.interceptor.AsyncExecutionInterceptor.lambda$invoke$0(AsyncExecutionInterceptor.java:115)
	at java.base/java.util.concurrent.FutureTask.run(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
	at java.base/java.lang.Thread.run(Unknown Source)
```

Over the course of debugging a high number of blocked `asyncExecutor` threads in a 20K DRS URI production scale test, I saw ~300 of these errors: https://cloudlogging.app.goo.gl/vuLjBHrr7syR8cmn9

I don't think they were a driving factor behind the atypical thread usage but figured this was worth the fix.