### PR TITLE
DR-3365: Move workflow failure check to calling GHA

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -181,6 +181,7 @@ jobs:
     needs: [ build, jib, unit-tests, integration-tests ]
     uses: ./.github/workflows/slack-notify-on-failure.yml
     secrets: inherit
+    if: ${{ failure() }}
     with:
       workflow_name: Build and Test
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -56,6 +56,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+      - name: force fail
+        run: exit 1
       - name: Set up JDK 17
         uses: actions/setup-java@v2
         with:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -56,8 +56,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - name: force fail
-        run: exit 1
       - name: Set up JDK 17
         uses: actions/setup-java@v2
         with:

--- a/.github/workflows/nightly-perf-tests.yml
+++ b/.github/workflows/nightly-perf-tests.yml
@@ -80,5 +80,6 @@ jobs:
     needs: [ performance-tests ]
     uses: ./.github/workflows/slack-notify-on-failure.yml
     secrets: inherit
+    if: ${{ failure() }}
     with:
       workflow_name: Nightly Perf Tests

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -96,5 +96,6 @@ jobs:
     needs: [publish-job, report-to-sherlock, set-version-in-dev]
     uses: ./.github/workflows/slack-notify-on-failure.yml
     secrets: inherit
+    if: ${{ failure() }}
     with:
       workflow_name: Publish

--- a/.github/workflows/slack-notify-on-failure.yml
+++ b/.github/workflows/slack-notify-on-failure.yml
@@ -8,7 +8,7 @@ on:
 jobs:
     notify-slack:
         runs-on: ubuntu-latest
-        #if: github.ref == 'refs/heads/dev'
+        if: github.ref == 'refs/heads/dev'
         steps:
           - name: Notify slack on failure
             id: slack

--- a/.github/workflows/slack-notify-on-failure.yml
+++ b/.github/workflows/slack-notify-on-failure.yml
@@ -8,7 +8,7 @@ on:
 jobs:
     notify-slack:
         runs-on: ubuntu-latest
-        if: github.ref == 'refs/heads/dev'
+        #if: github.ref == 'refs/heads/dev'
         steps:
           - name: Notify slack on failure
             id: slack

--- a/.github/workflows/slack-notify-on-failure.yml
+++ b/.github/workflows/slack-notify-on-failure.yml
@@ -8,7 +8,7 @@ on:
 jobs:
     notify-slack:
         runs-on: ubuntu-latest
-        if: ${{ failure() }}#&& github.ref == 'refs/heads/dev'
+        if: github.ref == 'refs/heads/dev'
         steps:
           - name: Notify slack on failure
             id: slack

--- a/.github/workflows/slack-notify-on-failure.yml
+++ b/.github/workflows/slack-notify-on-failure.yml
@@ -8,7 +8,7 @@ on:
 jobs:
     notify-slack:
         runs-on: ubuntu-latest
-        if: failure() && github.ref == 'refs/heads/dev'
+        if: ${{ failure() }}#&& github.ref == 'refs/heads/dev'
         steps:
           - name: Notify slack on failure
             id: slack


### PR DESCRIPTION
The current slack notification workflow isn't picking up on failures. From testing, it appears we need to check the workflow status when calling the reusable workflow rather than in the reusable workflow.

### Testing
**AFTER** change - Forced to fail and now successfully sends notification
![image](https://github.com/DataBiosphere/terra-drs-hub/assets/13254229/c5349a9b-548f-4a76-b06b-e0aceb515b34)



**BEFORE** change - Slack notification step was skipped.
![image](https://github.com/DataBiosphere/terra-drs-hub/assets/13254229/094a0018-b140-47e6-975a-0e4e31264fe5)
