### PR TITLE
ID-1038 Upgrade Spring Boot

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
 	id 'idea'
 
 	id 'io.spring.dependency-management' version '1.1.4' apply false
-	id 'org.springframework.boot' version '3.1.7' apply false
+	id 'org.springframework.boot' version '3.2.2' apply false
 	id 'com.diffplug.spotless' version '6.3.0' apply false
 	// ^^ for some reason, can't use spotless in multiple subprojects without this ^^
 	id 'com.google.cloud.tools.jib' version '3.1.4' apply false
@@ -31,7 +31,7 @@ subprojects {
 
 		dependencies {
 			dependency 'io.swagger.core.v3:swagger-annotations:2.2.12'
-			dependency 'io.swagger.codegen.v3:swagger-codegen-cli:3.0.47'
+			dependency 'io.swagger.codegen.v3:swagger-codegen-cli:3.0.52'
 		}
 	}
 

--- a/service/src/test/java/bio/terra/drshub/controllers/VerifyPactDrsHubApiController.java
+++ b/service/src/test/java/bio/terra/drshub/controllers/VerifyPactDrsHubApiController.java
@@ -83,8 +83,7 @@ class VerifyPactsDrsHubApiController {
     // Otherwise, this is a PR, verify all consumer pacts in Pact Broker marked with a deployment
     // tag (e.g. dev, alpha).
     if (StringUtils.isBlank(CONSUMER_BRANCH)) {
-      return new SelectorBuilder().mainBranch()
-          .deployedOrReleased();
+      return new SelectorBuilder().mainBranch().deployedOrReleased();
     } else {
       return new SelectorBuilder().branch(CONSUMER_BRANCH, CONSUMER_NAME);
     }

--- a/service/src/test/java/bio/terra/drshub/tracking/TrackingInterceptorTest.java
+++ b/service/src/test/java/bio/terra/drshub/tracking/TrackingInterceptorTest.java
@@ -99,9 +99,17 @@ class TrackingInterceptorTest {
   @Test
   void testDoesNotLogOn404() throws Exception {
     mockBardEmissionsEnabled();
+    String url = "/api/v4/drs/resolve";
     postRequest(
-            "/api/v4/foo",
-            objectMapper.writeValueAsString(Map.of("url", DRS_URI, "fields", List.of())))
+            url,
+            objectMapper.writeValueAsString(
+                Map.of(
+                    "url",
+                    DRS_URI + "notfound",
+                    "cloudPlatform",
+                    CloudPlatformEnum.GS,
+                    "fields",
+                    List.of())))
         .andExpect(status().isNotFound());
     verify(trackingService, never()).logEvent(any(BearerToken.class), anyString(), any(Map.class));
   }

--- a/service/src/test/java/bio/terra/drshub/util/SignedUrlTestUtils.java
+++ b/service/src/test/java/bio/terra/drshub/util/SignedUrlTestUtils.java
@@ -1,6 +1,7 @@
 package bio.terra.drshub.util;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.doReturn;
@@ -41,6 +42,8 @@ import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.bouncycastle.openssl.jcajce.JcaPEMWriter;
 import org.bouncycastle.openssl.jcajce.JcaPKCS8Generator;
 import org.junit.jupiter.api.Tag;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.client.HttpClientErrorException;
 
 @Tag("Unit")
 public class SignedUrlTestUtils {
@@ -94,6 +97,20 @@ public class SignedUrlTestUtils {
         .when(drsResolutionService)
         .resolveDrsObject(
             eq(drsUri),
+            eq(RequestObject.CloudPlatformEnum.GS),
+            any(List.class),
+            any(BearerToken.class),
+            eq(forceAccessUrl),
+            nullable(String.class),
+            nullable(String.class));
+
+    doReturn(
+            CompletableFuture.failedFuture(
+                HttpClientErrorException.NotFound.create(
+                    HttpStatus.NOT_FOUND, "Not found", null, null, null)))
+        .when(drsResolutionService)
+        .resolveDrsObject(
+            argThat(uri -> !uri.equals(drsUri)),
             eq(RequestObject.CloudPlatformEnum.GS),
             any(List.class),
             any(BearerToken.class),


### PR DESCRIPTION
Upgrading Spring Boot to use a non-vulnerable version of Spring Core. Ended up having to fix a test that broke in the upgrade. 

```tlangs at battle-station in ~/Documents/Dev/terra-drs-hub on tl_ID-1038_upgrade_spring_core*
$ ./gradlew service:dependencyInsight --dependency org.springframework:spring-core

> Task :service:dependencyInsight
org.springframework:spring-core:6.1.3 (selected by rule)
```