### PR TITLE
Update slack-notify-on-failure.yml to point to identiteam-alerts

### DIFF
--- a/.github/workflows/slack-notify-on-failure.yml
+++ b/.github/workflows/slack-notify-on-failure.yml
@@ -14,7 +14,7 @@ jobs:
             id: slack
             uses: slackapi/slack-github-action@v1.24.0
             with:
-              channel-id: "CMYTGJVFY"
+              channel-id: "C03HV2AD20N"
               payload: |
                 {
                   "text": "DRS Hub ${{ inputs.workflow_name }}",


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/ID-1081

Will now point to #identiteam-alerts