### PR TITLE
ID-1108 Exclude postgresql from terra-common-lib

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -53,6 +53,7 @@ dependencies {
 		exclude group: 'bio.terra', module: 'stairway'
 		exclude group: 'org.springframework.boot', module: 'spring-boot-starter-data-jdbc'
 		exclude group: 'com.google.oauth-client', module: 'google-oauth-client'
+		exclude group: 'org.postgresql', module: 'postgresql'
 	}
 	implementation 'org.broadinstitute.dsde.workbench:sam-client_2.13:0.1-6a32c36'
 	implementation 'bio.terra:externalcreds-client-resttemplate:1.0.0-SNAPSHOT'


### PR DESCRIPTION
DRSHub doesn't have a database, so it should exclude the postgresql dependency it gets from Terra Common Lib. Another example of Terra Common Lib doing too much.