### PR TITLE
ID-1130 Upgrade to Spring Boot 3.2.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
 	id 'idea'
 
 	id 'io.spring.dependency-management' version '1.1.4' apply false
-	id 'org.springframework.boot' version '3.2.2' apply false
+	id 'org.springframework.boot' version '3.2.3' apply false
 	id 'com.diffplug.spotless' version '6.3.0' apply false
 	// ^^ for some reason, can't use spotless in multiple subprojects without this ^^
 	id 'com.google.cloud.tools.jib' version '3.1.4' apply false


### PR DESCRIPTION
Upgrade to Spring Boot 3.2.3 to use a non-vulnerable version of Spring Web, remediating https://nvd.nist.gov/vuln/detail/CVE-2024-22243