### PR TITLE
ID-1157 Increase HTTP Header Max Size

### DIFF
--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -94,6 +94,7 @@ otel:
           name: ${spring.application.name}
 
 server:
+  max-http-request-header-size: 32KB
   compression:
     enabled: true
     mime-types: text/css,application/javascript


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/ID-1157

Apparently, the default Spring config doesn't allow for headers big enough to handle Google Account profile pictures. This fixes that.