### PR TITLE
[ID-1265] Upgrade vulnerable spring-web version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
 	id 'idea'
 
 	id 'io.spring.dependency-management' version '1.1.4' apply false
-	id 'org.springframework.boot' version '3.2.3' apply false
+	id 'org.springframework.boot' version '3.2.5' apply false
 	id 'com.diffplug.spotless' version '6.3.0' apply false
 	// ^^ for some reason, can't use spotless in multiple subprojects without this ^^
 	id 'com.google.cloud.tools.jib' version '3.1.4' apply false


### PR DESCRIPTION
**Ticket:** https://broadworkbench.atlassian.net/browse/ID-1265

**Changes:**
Upgrade `org.springframework.boot` from version 3.2.3 (which has a vulnerable version of org.springframework:spring-web to 3.2.5. 

I ran `./gradlew :service:dependencyInsight --dependency org.springframework:spring-web` to see which version was being pulled in.

Before:
```
org.springframework:spring-web:6.1.4
+--- org.springframework:spring-webmvc:6.1.4
|    \--- org.springframework.boot:spring-boot-starter-web:3.2.3
|         \--- compileClasspath (requested org.springframework.boot:spring-boot-starter-web)
+--- org.springframework.boot:spring-boot-starter-json:3.2.3
|    +--- org.springframework.boot:spring-boot-starter-web:3.2.3 (*)
|    \--- bio.terra:externalcreds-client-resttemplate:1.20.0-SNAPSHOT:20240318.171436-1
|         \--- compileClasspath
\--- org.springframework.boot:spring-boot-starter-web:3.2.3 (*)
```
After:
Spring-web 6.1.5+ is the fixed version: https://spring.io/security/cve-2024-22259
```
org.springframework:spring-web:6.1.6
+--- org.springframework:spring-webmvc:6.1.6
|    \--- org.springframework.boot:spring-boot-starter-web:3.2.5
|         \--- compileClasspath (requested org.springframework.boot:spring-boot-starter-web)
+--- org.springframework.boot:spring-boot-starter-json:3.2.5
|    +--- org.springframework.boot:spring-boot-starter-web:3.2.5 (*)
|    \--- bio.terra:externalcreds-client-resttemplate:1.20.0-SNAPSHOT:20240318.171436-1 (requested org.springframework.boot:spring-boot-starter-json:3.2.3)
|         \--- compileClasspath
\--- org.springframework.boot:spring-boot-starter-web:3.2.5 (*)
```