### PR TITLE
[ID-1326] Fix parsing accessUrl from DRS Response

### DIFF
--- a/service/src/main/java/bio/terra/drshub/tracking/TrackingInterceptor.java
+++ b/service/src/main/java/bio/terra/drshub/tracking/TrackingInterceptor.java
@@ -119,13 +119,13 @@ public record TrackingInterceptor(
   public void addResolvedCloudToProperties(
       HttpServletResponse response, Map<String, Object> properties) {
     Map<String, Object> responseBody = readResponseBody(response);
-    if (responseBody.containsKey("accessUrl")) {
-      Map<String, String> accessUrlResponse = (Map<String, String>) responseBody.get("accessUrl");
-      String accessUrl = accessUrlResponse.get("url");
+    if (responseBody.get("accessUrl") != null) {
+      Map<String, String> accessURLResponse = (Map<String, String>) responseBody.get("accessUrl");
+      String url = accessURLResponse.get("url");
       String resolvedCloud = "";
-      if (accessUrl.contains("windows.net")) {
+      if (url.contains("windows.net")) {
         resolvedCloud = "azure";
-      } else if (accessUrl.contains("googleapis.com")) {
+      } else if (url.contains("googleapis.com")) {
         resolvedCloud = "gcp";
       }
       properties.put("resolvedCloud", resolvedCloud);


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/ID-1326

Context:
If a user is trying to get the access url for a file they do not have permissions for, DrsHub will return `"accessUrl": null` in the response body instead of `"accessUrl": {"url": <url>}`. This causes a null pointer exception in the tracking interceptor when trying to determine the cloud that a file was resolved from.

Changes:
Make sure the `accessUrl` field in the response is not null before trying to parse it