### PR TITLE
ID-1207 Use X-App-ID instead

### DIFF
--- a/service/src/main/java/bio/terra/drshub/tracking/TrackingInterceptor.java
+++ b/service/src/main/java/bio/terra/drshub/tracking/TrackingInterceptor.java
@@ -64,7 +64,7 @@ public record TrackingInterceptor(
       addToPropertiesIfPresentInHeader(
           request, properties, "drshub-force-access-url", "forceAccessUrl");
       addResolvedCloudToProperties(response, properties);
-      addToPropertiesIfPresentInHeader(request, properties, "x-terra-service-id", "serviceName");
+      addToPropertiesIfPresentInHeader(request, properties, "x-app-id", "serviceName");
 
       trackingService.logEvent(bearerToken, EVENT_NAME, properties);
     }

--- a/service/src/main/java/bio/terra/drshub/util/RequestUtils.java
+++ b/service/src/main/java/bio/terra/drshub/util/RequestUtils.java
@@ -7,11 +7,22 @@ import java.util.Optional;
 public class RequestUtils {
 
   public static Optional<ServiceName> serviceNameFromRequest(HttpServletRequest request) {
-    var header = Optional.ofNullable(request.getHeader("x-terra-service-id"));
-    var result = header.map(String::toLowerCase).map(ServiceName::fromValue);
+    var header = Optional.ofNullable(request.getHeader("x-app-id"));
+    var result =
+        header
+            .map(String::toLowerCase)
+            .map(RequestUtils::serviceNameMapper)
+            .map(ServiceName::fromValue);
     if (header.isPresent() && result.isEmpty()) {
       throw new IllegalArgumentException("Invalid service name: " + header.get());
     }
     return result;
+  }
+
+  private static String serviceNameMapper(String name) {
+    return switch (name) {
+      case "saturn" -> "terra_ui";
+      default -> name;
+    };
   }
 }

--- a/service/src/test/java/bio/terra/drshub/tracking/TrackingInterceptorTest.java
+++ b/service/src/test/java/bio/terra/drshub/tracking/TrackingInterceptorTest.java
@@ -117,7 +117,7 @@ class TrackingInterceptorTest {
             post(REQUEST_URL)
                 .header("authorization", "bearer " + TEST_ACCESS_TOKEN)
                 .header("X-Forwarded-For", TEST_IP_ADDRESS)
-                .header("X-Terra-Service-ID", "badServiceName")
+                .header("X-App-Id", "badServiceName")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(
                     objectMapper.writeValueAsString(
@@ -240,7 +240,7 @@ class TrackingInterceptorTest {
         post(url)
             .header("authorization", "bearer " + TEST_ACCESS_TOKEN)
             .header("X-Forwarded-For", TEST_IP_ADDRESS)
-            .header("X-Terra-Service-ID", "terra_ui")
+            .header("X-App-Id", "terra_ui")
             .contentType(MediaType.APPLICATION_JSON)
             .content(requestBody));
   }

--- a/service/src/test/java/bio/terra/drshub/util/RequestUtilsTest.java
+++ b/service/src/test/java/bio/terra/drshub/util/RequestUtilsTest.java
@@ -16,7 +16,7 @@ class RequestUtilsTest extends BaseTest {
   void testServiceNameFromRequest() {
     // Arrange
     var request = new MockHttpServletRequest();
-    request.addHeader("x-terra-service-id", "terra_ui");
+    request.addHeader("x-app-id", "terra_ui");
 
     // Act
     var result = RequestUtils.serviceNameFromRequest(request);
@@ -29,7 +29,7 @@ class RequestUtilsTest extends BaseTest {
   void testServiceNameFromRequestWithCapitalizations() {
     // Arrange
     var request = new MockHttpServletRequest();
-    request.addHeader("X-Terra-Service-ID", "Terra_UI");
+    request.addHeader("X-App-Id", "Terra_UI");
 
     // Act
     var result = RequestUtils.serviceNameFromRequest(request);
@@ -54,11 +54,24 @@ class RequestUtilsTest extends BaseTest {
   void testServiceNameFromRequestInvalidHeader() {
     // Arrange
     var request = new MockHttpServletRequest();
-    request.addHeader("x-terra-service-id", "invalid");
+    request.addHeader("x-app-id", "invalid");
 
     // Act
     // Assert
     assertThrows(
         IllegalArgumentException.class, () -> RequestUtils.serviceNameFromRequest(request));
+  }
+
+  @Test
+  void testServiceNameFromRequestTranslatesAppId() {
+    // Arrange
+    var request = new MockHttpServletRequest();
+    request.addHeader("x-app-id", "saturn");
+
+    // Act
+    var result = RequestUtils.serviceNameFromRequest(request);
+
+    // Assert
+    assertEquals(Optional.of(ServiceName.TERRA_UI), result);
   }
 }


### PR DESCRIPTION
Turns out, we tightly control what headers our proxy will let through. So, use the legacy X-App-ID instead. This will require translating service names from what they might have been in the past, but its better than changing every service's proxy config just for a DRSHub change.