### PR TITLE
[ID-1329] Update Tomcat-Embed-Core

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
 	id 'idea'
 
 	id 'io.spring.dependency-management' version '1.1.4' apply false
-	id 'org.springframework.boot' version '3.2.5' apply false
+	id 'org.springframework.boot' version '3.3.2' apply false
 	id 'com.diffplug.spotless' version '6.3.0' apply false
 	// ^^ for some reason, can't use spotless in multiple subprojects without this ^^
 	id 'com.google.cloud.tools.jib' version '3.4.3' apply false

--- a/client-resttemplate/build.gradle
+++ b/client-resttemplate/build.gradle
@@ -3,7 +3,7 @@ plugins {
 	id 'java-library'
 	id 'maven-publish'
 
-	id 'com.jfrog.artifactory' version '4.18.2'
+	id 'com.jfrog.artifactory' version '5.2.3'
 	id 'org.hidetake.swagger.generator'
 }
 


### PR DESCRIPTION
**Ticket:** https://broadworkbench.atlassian.net/browse/ID-1329

**Changes:**
Update the `org.springframework.boot` gradle plugin version, which was using an older version of `tomcat-embed-core`.

**Before:**
```
> Task :service:dependencyInsight
org.apache.tomcat.embed:tomcat-embed-core:10.1.20
+--- org.apache.tomcat.embed:tomcat-embed-websocket:10.1.20
|    \--- org.springframework.boot:spring-boot-starter-tomcat:3.2.5
|         \--- org.springframework.boot:spring-boot-starter-web:3.2.5
|              \--- compileClasspath (requested org.springframework.boot:spring-boot-starter-web)
\--- org.springframework.boot:spring-boot-starter-tomcat:3.2.5 (*)

```

**After:**
```
> Task :service:dependencyInsight
org.apache.tomcat.embed:tomcat-embed-core:10.1.26
+--- org.apache.tomcat.embed:tomcat-embed-websocket:10.1.26
|    \--- org.springframework.boot:spring-boot-starter-tomcat:3.3.2
|         \--- org.springframework.boot:spring-boot-starter-web:3.3.2
|              \--- compileClasspath (requested org.springframework.boot:spring-boot-starter-web)
\--- org.springframework.boot:spring-boot-starter-tomcat:3.3.2 (*)
```