### PR TITLE
[ID-1363] Add transaction id to resolveDrs requests

### DIFF
--- a/service/src/main/java/bio/terra/drshub/controllers/DrsHubApiController.java
+++ b/service/src/main/java/bio/terra/drshub/controllers/DrsHubApiController.java
@@ -14,7 +14,6 @@ import bio.terra.drshub.util.RequestUtils;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.ArrayList;
 import java.util.Objects;
-import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -42,7 +41,7 @@ public record DrsHubApiController(
     var serviceName = RequestUtils.serviceNameFromRequest(request);
 
     log.info("Received URL {} from agent {} on IP {}", body.getUrl(), userAgent, ip);
-    String transactionId = UUID.randomUUID().toString();
+    String transactionId = drsResolutionService.getTransactionId();
     userLoggingMetrics.set("transactionId", transactionId);
 
     return asyncUtils.runAndCatch(

--- a/service/src/main/java/bio/terra/drshub/services/DrsResolutionService.java
+++ b/service/src/main/java/bio/terra/drshub/services/DrsResolutionService.java
@@ -28,6 +28,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -370,5 +371,9 @@ public class DrsResolutionService {
         .drsMetadata(drsMetadata)
         .drsProvider(drsProvider)
         .build();
+  }
+
+  public String getTransactionId() {
+    return UUID.randomUUID().toString();
   }
 }

--- a/service/src/main/java/bio/terra/drshub/services/DrsResolutionService.java
+++ b/service/src/main/java/bio/terra/drshub/services/DrsResolutionService.java
@@ -47,7 +47,8 @@ public class DrsResolutionService {
   private final AuthService authService;
   private final AuditLogger auditLogger;
   private final UserLoggingMetrics userLoggingMetrics;
-  private static final String TRANSACTION_ID_FIELD_NAME = "transactionId";
+  public static final String TRANSACTION_ID_FIELD_NAME = "transactionId";
+  public static final String TRANSACTION_ID_HEADER_NAME = "X-Transaction-Id";
 
   @Autowired
   public DrsResolutionService(
@@ -249,7 +250,7 @@ public class DrsResolutionService {
     log.info(drsRequestLogMessage);
 
     var drsApi = drsApiFactory.getApiFromUriComponents(uriComponents, drsProvider);
-    drsApi.setHeader("x-transaction-id", transactionId);
+    drsApi.setHeader(TRANSACTION_ID_HEADER_NAME, transactionId);
     if (sendMetadataAuth) {
       // Currently, no provider needs a fence_token for metadata auth.
       // If that changes, this will need to get updated.
@@ -293,7 +294,7 @@ public class DrsResolutionService {
     if (googleProject != null) {
       drsApi.setHeader("x-user-project", googleProject);
     }
-    drsApi.setHeader("x-transaction-id", transactionId);
+    drsApi.setHeader(TRANSACTION_ID_HEADER_NAME, transactionId);
 
     for (var authorization : drsHubAuthorizations) {
       Optional<List<String>> auth =

--- a/service/src/main/java/bio/terra/drshub/services/DrsResolutionService.java
+++ b/service/src/main/java/bio/terra/drshub/services/DrsResolutionService.java
@@ -15,6 +15,7 @@ import bio.terra.drshub.models.AnnotatedResourceMetadata;
 import bio.terra.drshub.models.DrsHubAuthorization;
 import bio.terra.drshub.models.DrsMetadata;
 import bio.terra.drshub.models.Fields;
+import bio.terra.drshub.tracking.UserLoggingMetrics;
 import bio.terra.drshub.util.AccessMethodUtils;
 import com.google.common.annotations.VisibleForTesting;
 import io.github.ga4gh.drs.model.AccessMethod;
@@ -45,17 +46,21 @@ public class DrsResolutionService {
   private final DrsProviderService drsProviderService;
   private final AuthService authService;
   private final AuditLogger auditLogger;
+  private final UserLoggingMetrics userLoggingMetrics;
+  private static final String TRANSACTION_ID_FIELD_NAME = "transactionId";
 
   @Autowired
   public DrsResolutionService(
       DrsApiFactory drsApiFactory,
       DrsProviderService drsProviderService,
       AuthService authService,
-      AuditLogger auditLogger) {
+      AuditLogger auditLogger,
+      UserLoggingMetrics userLoggingMetrics) {
     this.drsApiFactory = drsApiFactory;
     this.drsProviderService = drsProviderService;
     this.authService = authService;
     this.auditLogger = auditLogger;
+    this.userLoggingMetrics = userLoggingMetrics;
   }
 
   /**
@@ -130,6 +135,7 @@ public class DrsResolutionService {
     final DrsObject drsResponse;
     final List<DrsHubAuthorization> authorizations;
     String transactionId = UUID.randomUUID().toString();
+    userLoggingMetrics.set(TRANSACTION_ID_FIELD_NAME, transactionId);
 
     if (Fields.shouldRequestObjectInfo(requestedFields)) {
       try {

--- a/service/src/main/java/bio/terra/drshub/services/SignedUrlService.java
+++ b/service/src/main/java/bio/terra/drshub/services/SignedUrlService.java
@@ -20,7 +20,6 @@ import io.github.ga4gh.drs.model.AccessMethod;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Optional;
-import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -128,7 +127,7 @@ public record SignedUrlService(
             true,
             ip,
             googleProject,
-            UUID.randomUUID().toString());
+            drsResolutionService.getTransactionId());
     return asyncUtils.runAndCatch(objectFuture, result -> BlobId.fromGsUtilUri(result.getGsUri()));
   }
 }

--- a/service/src/main/java/bio/terra/drshub/services/SignedUrlService.java
+++ b/service/src/main/java/bio/terra/drshub/services/SignedUrlService.java
@@ -20,6 +20,7 @@ import io.github.ga4gh.drs.model.AccessMethod;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -126,7 +127,8 @@ public record SignedUrlService(
             bearerToken,
             true,
             ip,
-            googleProject);
+            googleProject,
+            UUID.randomUUID().toString());
     return asyncUtils.runAndCatch(objectFuture, result -> BlobId.fromGsUtilUri(result.getGsUri()));
   }
 }

--- a/service/src/main/java/bio/terra/drshub/tracking/TrackingInterceptor.java
+++ b/service/src/main/java/bio/terra/drshub/tracking/TrackingInterceptor.java
@@ -33,7 +33,8 @@ public record TrackingInterceptor(
     AsyncUtils asyncUtils,
     BearerTokenFactory bearerTokenFactory,
     ObjectMapper objectMapper,
-    DrsHubConfig config)
+    DrsHubConfig config,
+    UserLoggingMetrics eventProperties)
     implements HandlerInterceptor {
 
   public static final String EVENT_NAME = "drshub:api";
@@ -56,7 +57,6 @@ public record TrackingInterceptor(
       var properties =
           new HashMap<String, Object>(
               Map.of("statusCode", responseStatus.value(), "requestUrl", path));
-
       properties.putAll(readRequestBody(request));
 
       // There are all the known headers that are potentially sent to DRSHub that we want to track
@@ -66,7 +66,8 @@ public record TrackingInterceptor(
       addResolvedCloudToProperties(response, properties);
       addToPropertiesIfPresentInHeader(request, properties, "x-app-id", "serviceName");
 
-      trackingService.logEvent(bearerToken, EVENT_NAME, properties);
+      eventProperties.setAll(properties);
+      trackingService.logEvent(bearerToken, EVENT_NAME, eventProperties.get());
     }
   }
 

--- a/service/src/main/java/bio/terra/drshub/tracking/UserLoggingMetrics.java
+++ b/service/src/main/java/bio/terra/drshub/tracking/UserLoggingMetrics.java
@@ -1,0 +1,48 @@
+package bio.terra.drshub.tracking;
+
+import java.util.HashMap;
+import org.springframework.stereotype.Component;
+
+/**
+ * This class wraps a ThreadLocal variable to store API request properties to log (e.g. method,
+ * path, billing profile id).
+ *
+ * <p>Only one instance of the ThreadLocal is created per thread, so properties added in a single
+ * API request will get grouped together even if they are set in different methods.
+ */
+@Component
+public class UserLoggingMetrics {
+
+  private static final ThreadLocal<HashMap<String, Object>> metrics =
+      ThreadLocal.withInitial(() -> new HashMap<>());
+
+  /**
+   * Get the current thread's metrics instance. If no metrics have been set, return the default
+   * empty HashMap.
+   *
+   * @return HashMap<String, Object> metrics
+   */
+  public HashMap<String, Object> get() {
+    return metrics.get();
+  }
+
+  /**
+   * Add a new value to the current thread's metrics map. If the map already contains a value for
+   * this key it will be replaced.
+   */
+  public void set(String key, Object value) {
+    metrics.get().put(key, value);
+  }
+
+  /**
+   * Add multiple values to the current thread's metrics map. Any existing values with the same key
+   * will get replaced.
+   *
+   * @param value HashMap of metrics to add
+   */
+  public void setAll(HashMap<String, Object> value) {
+    HashMap<String, Object> properties = metrics.get();
+    properties.putAll(value);
+    metrics.set(properties);
+  }
+}

--- a/service/src/test/java/bio/terra/drshub/controllers/GcsApiControllerTest.java
+++ b/service/src/test/java/bio/terra/drshub/controllers/GcsApiControllerTest.java
@@ -1,5 +1,6 @@
 package bio.terra.drshub.controllers;
 
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -83,7 +84,8 @@ public class GcsApiControllerTest extends BaseTest {
             eq(new BearerToken(TEST_ACCESS_TOKEN)),
             eq(true),
             eq(null),
-            eq(googleProject));
+            eq(googleProject),
+            eq(anyString()));
   }
 
   private ResultActions getSignedUrlRequest(

--- a/service/src/test/java/bio/terra/drshub/controllers/GcsApiControllerTest.java
+++ b/service/src/test/java/bio/terra/drshub/controllers/GcsApiControllerTest.java
@@ -1,8 +1,8 @@
 package bio.terra.drshub.controllers;
 
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 
@@ -19,6 +19,7 @@ import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -62,6 +63,7 @@ public class GcsApiControllerTest extends BaseTest {
     var objectName = "my-test-folder/my-test-object.txt";
     var googleProject = "test-google-project";
     var url = new URL("https", "storage.cloud.google.com", "/" + bucketName + "/" + objectName);
+    var transactionId = UUID.randomUUID().toString();
 
     SignedUrlTestUtils.setupSignedUrlMocks(authService, googleStorageService, googleProject, url);
     SignedUrlTestUtils.setupDrsResolutionServiceMocks(
@@ -73,6 +75,7 @@ public class GcsApiControllerTest extends BaseTest {
         Optional.empty(),
         true);
 
+    when(drsResolutionService.getTransactionId()).thenReturn(transactionId);
     var response = getSignedUrlRequest(TEST_ACCESS_TOKEN, null, null, drsUri, googleProject);
     response.andExpect(content().string(url.toString()));
     verify(drsResolutionService)
@@ -85,7 +88,7 @@ public class GcsApiControllerTest extends BaseTest {
             eq(true),
             eq(null),
             eq(googleProject),
-            eq(anyString()));
+            eq(transactionId));
   }
 
   private ResultActions getSignedUrlRequest(

--- a/service/src/test/java/bio/terra/drshub/controllers/VerifyPactDrsHubApiController.java
+++ b/service/src/test/java/bio/terra/drshub/controllers/VerifyPactDrsHubApiController.java
@@ -26,6 +26,7 @@ import bio.terra.drshub.services.DrsApiFactory;
 import bio.terra.drshub.services.DrsProviderService;
 import bio.terra.drshub.services.DrsResolutionService;
 import bio.terra.drshub.services.TrackingService;
+import bio.terra.drshub.tracking.UserLoggingMetrics;
 import bio.terra.drshub.util.AsyncUtils;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.ga4gh.drs.model.AccessMethod;
@@ -69,6 +70,7 @@ class VerifyPactsDrsHubApiController {
   @SpyBean private DrsResolutionService drsResolutionService;
   @SpyBean private DrsProviderService drsProviderService;
   @SpyBean private AsyncUtils asyncUtils;
+  @SpyBean private UserLoggingMetrics userLoggingMetrics;
 
   @Autowired private ObjectMapper objectMapper;
 

--- a/service/src/test/java/bio/terra/drshub/services/DrsResolutionServiceTest.java
+++ b/service/src/test/java/bio/terra/drshub/services/DrsResolutionServiceTest.java
@@ -19,7 +19,6 @@ import bio.terra.drshub.models.AccessMethodConfigTypeEnum;
 import bio.terra.drshub.models.AccessUrlAuthEnum;
 import bio.terra.drshub.models.DrsApi;
 import bio.terra.drshub.models.DrsHubAuthorization;
-import bio.terra.drshub.tracking.UserLoggingMetrics;
 import bio.terra.drshub.util.SignedUrlTestUtils;
 import io.github.ga4gh.drs.model.AccessMethod.TypeEnum;
 import io.github.ga4gh.drs.model.AccessURL;
@@ -58,7 +57,6 @@ class DrsResolutionServiceTest {
   @Mock private UriComponents uriComponents;
   @Mock private AuthService authService;
   @Mock private GoogleStorageService googleStorageService;
-  @Mock private UserLoggingMetrics userLoggingMetrics;
 
   private static final String PATH = "path";
 
@@ -101,11 +99,7 @@ class DrsResolutionServiceTest {
 
     drsResolutionService =
         new DrsResolutionService(
-            drsApiFactory,
-            mock(DrsProviderService.class),
-            authService,
-            mock(AuditLogger.class),
-            userLoggingMetrics);
+            drsApiFactory, mock(DrsProviderService.class), authService, mock(AuditLogger.class));
 
     when(uriComponents.getHost()).thenReturn("host.com");
     when(uriComponents.getPath()).thenReturn(PATH);

--- a/service/src/test/java/bio/terra/drshub/services/DrsResolutionServiceTest.java
+++ b/service/src/test/java/bio/terra/drshub/services/DrsResolutionServiceTest.java
@@ -29,6 +29,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
@@ -90,6 +91,8 @@ class DrsResolutionServiceTest {
                           .setAuth(AccessUrlAuthEnum.current_request)
                           .setFetchAccessUrl(true))));
 
+  private static final String TRANSACTION_ID = UUID.randomUUID().toString();
+
   @BeforeEach
   void before() throws Exception {
     DrsApiFactory drsApiFactory = mock(DrsApiFactory.class);
@@ -112,7 +115,12 @@ class DrsResolutionServiceTest {
 
     var actual =
         drsResolutionService.fetchObjectInfo(
-            DRS_PROVIDER_UNAUTH, uriComponents, "drsUri", TOKEN, List.of(PASSPORTAUTH, BEARERAUTH));
+            DRS_PROVIDER_UNAUTH,
+            uriComponents,
+            "drsUri",
+            TOKEN,
+            List.of(PASSPORTAUTH, BEARERAUTH),
+            TRANSACTION_ID);
 
     // When authorization isn't required, we don't pass the bearer token to the API.
     verify(drsApi, never()).setBearerToken(any());
@@ -124,6 +132,8 @@ class DrsResolutionServiceTest {
         "Object fetched via getObject without token when authorization not required",
         actual,
         equalTo(DRS_OBJECT));
+    // Verify transaction id header is set when fetching object info
+    verify(drsApi).setHeader("x-transaction-id", TRANSACTION_ID);
   }
 
   @Test
@@ -132,7 +142,7 @@ class DrsResolutionServiceTest {
 
     var actual =
         drsResolutionService.fetchObjectInfo(
-            DRS_PROVIDER_AUTH, uriComponents, "drsUri", TOKEN, List.of(BEARERAUTH));
+            DRS_PROVIDER_AUTH, uriComponents, "drsUri", TOKEN, List.of(BEARERAUTH), TRANSACTION_ID);
 
     // When authorization is required, we pass the bearer token to the API.
     verify(drsApi).setBearerToken(TOKEN.getToken());
@@ -153,7 +163,12 @@ class DrsResolutionServiceTest {
 
     var actual =
         drsResolutionService.fetchObjectInfo(
-            DRS_PROVIDER_AUTH, uriComponents, "drsUri", TOKEN, List.of(BEARERAUTH, PASSPORTAUTH));
+            DRS_PROVIDER_AUTH,
+            uriComponents,
+            "drsUri",
+            TOKEN,
+            List.of(BEARERAUTH, PASSPORTAUTH),
+            TRANSACTION_ID);
 
     // When authorization is required, we pass the bearer token to the API.
     verify(drsApi).setBearerToken(TOKEN.getToken());
@@ -178,7 +193,12 @@ class DrsResolutionServiceTest {
 
     var actual =
         drsResolutionService.fetchObjectInfo(
-            DRS_PROVIDER_AUTH, uriComponents, "drsUri", TOKEN, List.of(BEARERAUTH, PASSPORTAUTH));
+            DRS_PROVIDER_AUTH,
+            uriComponents,
+            "drsUri",
+            TOKEN,
+            List.of(BEARERAUTH, PASSPORTAUTH),
+            TRANSACTION_ID);
 
     // When authorization is required, we pass the bearer token to the API.
     verify(drsApi).setBearerToken(TOKEN.getToken());
@@ -198,7 +218,12 @@ class DrsResolutionServiceTest {
 
     var actual =
         drsResolutionService.fetchObjectInfo(
-            DRS_PROVIDER_AUTH, uriComponents, "drsUri", TOKEN, List.of(BEARERAUTH, PASSPORTAUTH));
+            DRS_PROVIDER_AUTH,
+            uriComponents,
+            "drsUri",
+            TOKEN,
+            List.of(BEARERAUTH, PASSPORTAUTH),
+            TRANSACTION_ID);
 
     // When authorization is required, we pass the bearer token to the API.
     verify(drsApi).setBearerToken(TOKEN.getToken());
@@ -221,7 +246,12 @@ class DrsResolutionServiceTest {
 
     var actual =
         drsResolutionService.fetchObjectInfo(
-            DRS_PROVIDER_AUTH, uriComponents, "drsUri", TOKEN, List.of(BEARERAUTH, PASSPORTAUTH));
+            DRS_PROVIDER_AUTH,
+            uriComponents,
+            "drsUri",
+            TOKEN,
+            List.of(BEARERAUTH, PASSPORTAUTH),
+            TRANSACTION_ID);
 
     // When authorization is required, we pass the bearer token to the API.
     verify(drsApi).setBearerToken(TOKEN.getToken());
@@ -247,7 +277,8 @@ class DrsResolutionServiceTest {
             List.of(BEARERAUTH),
             new AuditLogEvent.Builder(),
             ip,
-            googleProject);
+            googleProject,
+            TRANSACTION_ID);
     assertThat(
         "google signed url is properly returned", response.getUrl(), equalTo(url.toString()));
     verify(drsApi).setHeader("x-user-project", googleProject);
@@ -268,7 +299,8 @@ class DrsResolutionServiceTest {
             List.of(BEARERAUTH),
             new AuditLogEvent.Builder(),
             ip,
-            googleProject);
+            googleProject,
+            TRANSACTION_ID);
     assertThat("signed url is properly returned", response.getUrl(), equalTo(url.toString()));
     verify(drsApi).setHeader("X-Forwarded-For", ip);
   }
@@ -289,9 +321,11 @@ class DrsResolutionServiceTest {
             List.of(BEARERAUTH),
             new AuditLogEvent.Builder(),
             ip,
-            googleProject);
+            googleProject,
+            TRANSACTION_ID);
     assertThat("signed url is properly returned", response.getUrl(), equalTo(url.toString()));
     verify(drsApi, never()).setHeader("X-Forwarded-For", ip);
     verify(drsApi, never()).setHeader("x-user-project", googleProject);
+    verify(drsApi).setHeader("x-transaction-id", TRANSACTION_ID);
   }
 }

--- a/service/src/test/java/bio/terra/drshub/services/DrsResolutionServiceTest.java
+++ b/service/src/test/java/bio/terra/drshub/services/DrsResolutionServiceTest.java
@@ -139,7 +139,7 @@ class DrsResolutionServiceTest {
         actual,
         equalTo(DRS_OBJECT));
     // Verify transaction id header is set when fetching object info
-    verify(drsApi).setHeader("x-transaction-id", TRANSACTION_ID);
+    verify(drsApi).setHeader(DrsResolutionService.TRANSACTION_ID_HEADER_NAME, TRANSACTION_ID);
   }
 
   @Test
@@ -332,6 +332,6 @@ class DrsResolutionServiceTest {
     assertThat("signed url is properly returned", response.getUrl(), equalTo(url.toString()));
     verify(drsApi, never()).setHeader("X-Forwarded-For", ip);
     verify(drsApi, never()).setHeader("x-user-project", googleProject);
-    verify(drsApi).setHeader("x-transaction-id", TRANSACTION_ID);
+    verify(drsApi).setHeader(DrsResolutionService.TRANSACTION_ID_HEADER_NAME, TRANSACTION_ID);
   }
 }

--- a/service/src/test/java/bio/terra/drshub/services/DrsResolutionServiceTest.java
+++ b/service/src/test/java/bio/terra/drshub/services/DrsResolutionServiceTest.java
@@ -19,6 +19,7 @@ import bio.terra.drshub.models.AccessMethodConfigTypeEnum;
 import bio.terra.drshub.models.AccessUrlAuthEnum;
 import bio.terra.drshub.models.DrsApi;
 import bio.terra.drshub.models.DrsHubAuthorization;
+import bio.terra.drshub.tracking.UserLoggingMetrics;
 import bio.terra.drshub.util.SignedUrlTestUtils;
 import io.github.ga4gh.drs.model.AccessMethod.TypeEnum;
 import io.github.ga4gh.drs.model.AccessURL;
@@ -57,6 +58,7 @@ class DrsResolutionServiceTest {
   @Mock private UriComponents uriComponents;
   @Mock private AuthService authService;
   @Mock private GoogleStorageService googleStorageService;
+  @Mock private UserLoggingMetrics userLoggingMetrics;
 
   private static final String PATH = "path";
 
@@ -99,7 +101,11 @@ class DrsResolutionServiceTest {
 
     drsResolutionService =
         new DrsResolutionService(
-            drsApiFactory, mock(DrsProviderService.class), authService, mock(AuditLogger.class));
+            drsApiFactory,
+            mock(DrsProviderService.class),
+            authService,
+            mock(AuditLogger.class),
+            userLoggingMetrics);
 
     when(uriComponents.getHost()).thenReturn("host.com");
     when(uriComponents.getPath()).thenReturn(PATH);

--- a/service/src/test/java/bio/terra/drshub/services/SignedUrlServiceTest.java
+++ b/service/src/test/java/bio/terra/drshub/services/SignedUrlServiceTest.java
@@ -12,6 +12,7 @@ import bio.terra.drshub.util.SignedUrlTestUtils;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Optional;
+import java.util.UUID;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -82,6 +83,7 @@ public class SignedUrlServiceTest extends BaseTest {
     var ip = "test.ip";
     var googleProject = "test-google-project";
     var url = new URL("https", "storage.cloud.google.com", "/" + bucketName + "/" + objectName);
+    var transactionId = UUID.randomUUID().toString();
 
     SignedUrlTestUtils.setupSignedUrlMocks(authService, googleStorageService, googleProject, url);
     SignedUrlTestUtils.setupDrsResolutionServiceMocks(
@@ -92,6 +94,7 @@ public class SignedUrlServiceTest extends BaseTest {
         googleProject,
         Optional.empty(),
         true);
+    when(drsResolutionService.getTransactionId()).thenReturn(transactionId);
     var signedUrl =
         signedUrlService.getSignedUrl(
             null,

--- a/service/src/test/java/bio/terra/drshub/tracking/TrackingInterceptorTest.java
+++ b/service/src/test/java/bio/terra/drshub/tracking/TrackingInterceptorTest.java
@@ -188,6 +188,7 @@ class TrackingInterceptorTest {
   void testHappyPathEmittingToBardWithTransactionId() throws Exception {
     mockBardEmissionsEnabled();
     String transactionId = UUID.randomUUID().toString();
+    when(drsResolutionService.getTransactionId()).thenReturn(transactionId);
     userLoggingMetrics.set("transactionId", transactionId);
     postRequest(
             REQUEST_URL,

--- a/service/src/test/java/bio/terra/drshub/tracking/TrackingInterceptorTest.java
+++ b/service/src/test/java/bio/terra/drshub/tracking/TrackingInterceptorTest.java
@@ -289,7 +289,7 @@ class TrackingInterceptorTest {
             .build();
 
     when(drsResolutionService.resolveDrsObject(
-            anyString(), any(), any(), any(), any(), any(), any(), any()))
+            anyString(), any(), any(), any(), any(), any(), any(), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(metadata));
   }
 

--- a/service/src/test/java/bio/terra/drshub/tracking/TrackingInterceptorTest.java
+++ b/service/src/test/java/bio/terra/drshub/tracking/TrackingInterceptorTest.java
@@ -54,6 +54,8 @@ class TrackingInterceptorTest {
   private static final String TEST_IP_ADDRESS = "1.1.1.1";
   private static final String GOOGLE_PROJECT = "myproject";
 
+  private static String TRANSACTION_ID = UUID.randomUUID().toString();
+
   @Autowired private MockMvc mvc;
   @Autowired private ObjectMapper objectMapper;
   @Autowired private UserLoggingMetrics userLoggingMetrics;
@@ -64,6 +66,7 @@ class TrackingInterceptorTest {
   @BeforeEach
   void setUp(TestInfo testInfo) {
     userLoggingMetrics.get().clear();
+    when(drsResolutionService.getTransactionId()).thenReturn(TRANSACTION_ID);
     var excludeServiceName = testInfo.getTags().contains("noServiceNameEmitted");
     Optional<ServiceName> serviceName =
         excludeServiceName ? Optional.empty() : Optional.of(ServiceName.TERRA_UI);
@@ -309,7 +312,9 @@ class TrackingInterceptorTest {
                 "fields",
                 fields,
                 "serviceName",
-                ServiceName.TERRA_UI.toString()));
+                ServiceName.TERRA_UI.toString(),
+                "transactionId",
+                TRANSACTION_ID));
     if (resolvedCloud != null) {
       properties.put("resolvedCloud", resolvedCloud);
     }

--- a/service/src/test/java/bio/terra/drshub/util/SignedUrlTestUtils.java
+++ b/service/src/test/java/bio/terra/drshub/util/SignedUrlTestUtils.java
@@ -106,7 +106,8 @@ public class SignedUrlTestUtils {
             any(BearerToken.class),
             eq(forceAccessUrl),
             nullable(String.class),
-            nullable(String.class));
+            nullable(String.class),
+            any(String.class));
 
     doReturn(
             CompletableFuture.failedFuture(
@@ -121,7 +122,8 @@ public class SignedUrlTestUtils {
             any(BearerToken.class),
             eq(forceAccessUrl),
             nullable(String.class),
-            nullable(String.class));
+            nullable(String.class),
+            any(String.class));
   }
 
   public static String generateSaKeyObjectString()


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/ID-1363

For every request to the resolveDrs endpoint, drshub sends a request to the drs provider (such as TDR) to get object info and optionally another request to get the access url. We need a way to join the Drshub and TDR requests in Bard so that we can then gather drs metrics using the billing profile/dataset/snapshot info.

Changes:
- Copied the `UserLoggingMetrics` class from TDR to allow additional Bard properties to be specified outside of the `TrackingInterceptor` class
- Log a transaction id (a random UUID) to Bard for resolveDrs requests
- Set this transaction id as a header on the requests to TDR (when getting the object metadata and access url)