### PR TITLE
[ID-1209] Log DRS provider to Bard

### DIFF
--- a/service/src/main/java/bio/terra/drshub/services/DrsResolutionService.java
+++ b/service/src/main/java/bio/terra/drshub/services/DrsResolutionService.java
@@ -42,19 +42,14 @@ import org.springframework.web.util.UriComponents;
 public class DrsResolutionService {
 
   private final DrsApiFactory drsApiFactory;
-  private final DrsProviderService drsProviderService;
   private final AuthService authService;
   private final AuditLogger auditLogger;
   public static final String TRANSACTION_ID_HEADER_NAME = "X-Transaction-Id";
 
   @Autowired
   public DrsResolutionService(
-      DrsApiFactory drsApiFactory,
-      DrsProviderService drsProviderService,
-      AuthService authService,
-      AuditLogger auditLogger) {
+      DrsApiFactory drsApiFactory, AuthService authService, AuditLogger auditLogger) {
     this.drsApiFactory = drsApiFactory;
-    this.drsProviderService = drsProviderService;
     this.authService = authService;
     this.auditLogger = auditLogger;
   }
@@ -79,12 +74,11 @@ public class DrsResolutionService {
       Boolean forceAccessUrl,
       String ip,
       String googleProject,
-      String transactionId) {
+      String transactionId,
+      UriComponents uriComponents,
+      DrsProvider provider) {
 
     var requestedFields = isEmpty(rawRequestedFields) ? Fields.DEFAULT_FIELDS : rawRequestedFields;
-
-    var uriComponents = drsProviderService.getUriComponents(drsUri);
-    var provider = drsProviderService.determineDrsProvider(uriComponents);
 
     log.info(
         "Drs URI {} will use provider {}, requested fields {}",

--- a/service/src/test/java/bio/terra/drshub/controllers/GcsApiControllerTest.java
+++ b/service/src/test/java/bio/terra/drshub/controllers/GcsApiControllerTest.java
@@ -1,5 +1,6 @@
 package bio.terra.drshub.controllers;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -8,6 +9,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import bio.terra.common.iam.BearerToken;
 import bio.terra.drshub.BaseTest;
+import bio.terra.drshub.config.DrsProvider;
 import bio.terra.drshub.generated.model.RequestObject.CloudPlatformEnum;
 import bio.terra.drshub.models.Fields;
 import bio.terra.drshub.services.AuthService;
@@ -28,6 +30,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.web.util.UriComponents;
 
 @Tag("Unit")
 @AutoConfigureMockMvc
@@ -88,7 +91,9 @@ public class GcsApiControllerTest extends BaseTest {
             eq(true),
             eq(null),
             eq(googleProject),
-            eq(transactionId));
+            eq(transactionId),
+            any(UriComponents.class),
+            any(DrsProvider.class));
   }
 
   private ResultActions getSignedUrlRequest(

--- a/service/src/test/java/bio/terra/drshub/services/DrsResolutionServiceTest.java
+++ b/service/src/test/java/bio/terra/drshub/services/DrsResolutionServiceTest.java
@@ -98,8 +98,7 @@ class DrsResolutionServiceTest {
     DrsApiFactory drsApiFactory = mock(DrsApiFactory.class);
 
     drsResolutionService =
-        new DrsResolutionService(
-            drsApiFactory, mock(DrsProviderService.class), authService, mock(AuditLogger.class));
+        new DrsResolutionService(drsApiFactory, authService, mock(AuditLogger.class));
 
     when(uriComponents.getHost()).thenReturn("host.com");
     when(uriComponents.getPath()).thenReturn(PATH);

--- a/service/src/test/java/bio/terra/drshub/tracking/TrackingInterceptorTest.java
+++ b/service/src/test/java/bio/terra/drshub/tracking/TrackingInterceptorTest.java
@@ -293,7 +293,7 @@ class TrackingInterceptorTest {
             .build();
 
     when(drsResolutionService.resolveDrsObject(
-            anyString(), any(), any(), any(), any(), any(), any(), any(), any()))
+            anyString(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(metadata));
   }
 

--- a/service/src/test/java/bio/terra/drshub/tracking/TrackingInterceptorTest.java
+++ b/service/src/test/java/bio/terra/drshub/tracking/TrackingInterceptorTest.java
@@ -14,8 +14,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import bio.terra.common.iam.BearerToken;
 import bio.terra.drshub.DrsHubApplication;
 import bio.terra.drshub.config.DrsHubConfig;
+import bio.terra.drshub.config.DrsProvider;
+import bio.terra.drshub.config.ProviderAccessMethodConfig;
 import bio.terra.drshub.generated.model.RequestObject.CloudPlatformEnum;
 import bio.terra.drshub.generated.model.ServiceName;
+import bio.terra.drshub.models.AccessMethodConfigTypeEnum;
+import bio.terra.drshub.models.AccessUrlAuthEnum;
 import bio.terra.drshub.models.AnnotatedResourceMetadata;
 import bio.terra.drshub.models.DrsMetadata;
 import bio.terra.drshub.services.DrsResolutionService;
@@ -23,6 +27,7 @@ import bio.terra.drshub.services.TrackingService;
 import bio.terra.drshub.util.SignedUrlTestUtils;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.ga4gh.drs.model.AccessURL;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -50,7 +55,10 @@ class TrackingInterceptorTest {
   private static final String REQUEST_URL = "/api/v4/drs/resolve";
   private static final String TEST_ACCESS_TOKEN = "I_am_an_access_token";
   private static final BearerToken TEST_BEARER_TOKEN = new BearerToken(TEST_ACCESS_TOKEN);
-  private static final String DRS_URI = "drs://foo/object_id";
+  private static final String DRS_URI =
+      String.format(
+          "drs://jade.datarepo-dev.broadinstitute.org/v1_%s/%s",
+          UUID.randomUUID(), UUID.randomUUID());
   private static final String TEST_IP_ADDRESS = "1.1.1.1";
   private static final String GOOGLE_PROJECT = "myproject";
 
@@ -66,6 +74,7 @@ class TrackingInterceptorTest {
   @BeforeEach
   void setUp(TestInfo testInfo) {
     userLoggingMetrics.get().clear();
+    mockProviders();
     when(drsResolutionService.getTransactionId()).thenReturn(TRANSACTION_ID);
     var excludeServiceName = testInfo.getTags().contains("noServiceNameEmitted");
     Optional<ServiceName> serviceName =
@@ -312,6 +321,8 @@ class TrackingInterceptorTest {
                 CloudPlatformEnum.GS.toString(),
                 "fields",
                 fields,
+                "provider",
+                "terraDataRepo",
                 "serviceName",
                 ServiceName.TERRA_UI.toString(),
                 "transactionId",
@@ -320,5 +331,21 @@ class TrackingInterceptorTest {
       properties.put("resolvedCloud", resolvedCloud);
     }
     return properties;
+  }
+
+  private void mockProviders() {
+    DrsProvider tdrProvider = DrsProvider.create();
+    tdrProvider.setName("terraDataRepo");
+    tdrProvider.setMetadataAuth(true);
+    var accessMethod =
+        ProviderAccessMethodConfig.create()
+            .setType(AccessMethodConfigTypeEnum.gs)
+            .setAuth(AccessUrlAuthEnum.fence_token)
+            .setFetchAccessUrl(true);
+    ArrayList<ProviderAccessMethodConfig> accessMethods = new ArrayList<>();
+    accessMethods.add(accessMethod);
+    tdrProvider.setAccessMethodConfigs(accessMethods);
+    tdrProvider.setHostRegex(".*data.*[-.](?:broadinstitute\\.org|terra\\.bio)");
+    when(drsHubConfig.getDrsProviders()).thenReturn(Map.of("terraDataRepo", tdrProvider));
   }
 }

--- a/service/src/test/java/bio/terra/drshub/util/SignedUrlTestUtils.java
+++ b/service/src/test/java/bio/terra/drshub/util/SignedUrlTestUtils.java
@@ -46,6 +46,7 @@ import org.bouncycastle.openssl.jcajce.JcaPKCS8Generator;
 import org.junit.jupiter.api.Tag;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.util.UriComponents;
 
 @Tag("Unit")
 public class SignedUrlTestUtils {
@@ -107,7 +108,9 @@ public class SignedUrlTestUtils {
             eq(forceAccessUrl),
             nullable(String.class),
             nullable(String.class),
-            any(String.class));
+            any(String.class),
+            any(UriComponents.class),
+            any(DrsProvider.class));
 
     doReturn(
             CompletableFuture.failedFuture(
@@ -123,7 +126,9 @@ public class SignedUrlTestUtils {
             eq(forceAccessUrl),
             nullable(String.class),
             nullable(String.class),
-            any(String.class));
+            any(String.class),
+            any(UriComponents.class),
+            any(DrsProvider.class));
   }
 
   public static String generateSaKeyObjectString()


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/ID-1209

Changes: 
- Get the provider in the DRS API controller (instead of the DrsResolutionService) so that it can be included in the Bard properties for that request.
- Update the signedUrlService since it also calls `drsResolutionService.resolveDrsObject`