### PR TITLE
[ID-1365] Log fileName to Bard (if in response)

### DIFF
--- a/service/src/main/java/bio/terra/drshub/tracking/TrackingInterceptor.java
+++ b/service/src/main/java/bio/terra/drshub/tracking/TrackingInterceptor.java
@@ -136,7 +136,8 @@ public record TrackingInterceptor(
     }
   }
 
-  public void addToPropertiesIfPresentInResponse(HttpServletResponse response, Map<String, Object> properties, String propertyName) {
+  private void addToPropertiesIfPresentInResponse(
+      HttpServletResponse response, Map<String, Object> properties, String propertyName) {
     Map<String, Object> responseBody = readResponseBody(response);
     if (responseBody.get(propertyName) != null) {
       String property = responseBody.get(propertyName).toString();

--- a/service/src/main/java/bio/terra/drshub/tracking/TrackingInterceptor.java
+++ b/service/src/main/java/bio/terra/drshub/tracking/TrackingInterceptor.java
@@ -63,8 +63,9 @@ public record TrackingInterceptor(
       addToPropertiesIfPresentInHeader(request, properties, "x-user-project", "userProject");
       addToPropertiesIfPresentInHeader(
           request, properties, "drshub-force-access-url", "forceAccessUrl");
-      addResolvedCloudToProperties(response, properties);
       addToPropertiesIfPresentInHeader(request, properties, "x-app-id", "serviceName");
+      addResolvedCloudToProperties(response, properties);
+      addToPropertiesIfPresentInResponse(response, properties, "fileName");
 
       eventProperties.setAll(properties);
       trackingService.logEvent(bearerToken, EVENT_NAME, eventProperties.get());
@@ -132,6 +133,14 @@ public record TrackingInterceptor(
         resolvedCloud = "gcp";
       }
       properties.put("resolvedCloud", resolvedCloud);
+    }
+  }
+
+  public void addToPropertiesIfPresentInResponse(HttpServletResponse response, Map<String, Object> properties, String propertyName) {
+    Map<String, Object> responseBody = readResponseBody(response);
+    if (responseBody.get(propertyName) != null) {
+      String property = responseBody.get(propertyName).toString();
+      properties.put(propertyName, property);
     }
   }
 }


### PR DESCRIPTION
**Ticket:** https://broadworkbench.atlassian.net/browse/ID-1365

**Purpose:**
Collaborators want metrics around usage/access of the data they store in TDR and Terra, such as which files get accessed the most.

**Changes:**
If the `fileName` field is present in the response when resolving a DRS url, include it in the properties logged to Bard.