### PR TITLE
[CORE-47] Upgrade Swagger UI to 5.17.14 to resolve dompurify vulnerability.

### DIFF
--- a/service/generators.gradle
+++ b/service/generators.gradle
@@ -17,7 +17,6 @@ swaggerSources {
 			additionalProperties = [
 					modelPackage     : "${artifactGroup}.generated.model",
 					apiPackage       : "${artifactGroup}.generated.api",
-					apiPackage       : "${artifactGroup}.generated.api",
 					dateLibrary      : 'java11',
 					jakarta          : 'true',
 					interfaceOnly    : 'true',

--- a/service/generators.gradle
+++ b/service/generators.gradle
@@ -1,6 +1,6 @@
 dependencies {
 	implementation 'io.swagger.core.v3:swagger-annotations'
-	runtimeOnly 'org.webjars.npm:swagger-ui-dist:4.18.1'
+	runtimeOnly 'org.webjars.npm:swagger-ui-dist:5.17.14'
 	swaggerCodegen 'io.swagger.codegen.v3:swagger-codegen-cli'
 
 	// Versioned by Spring:
@@ -16,6 +16,7 @@ swaggerSources {
 			components = ['models', 'apis']
 			additionalProperties = [
 					modelPackage     : "${artifactGroup}.generated.model",
+					apiPackage       : "${artifactGroup}.generated.api",
 					apiPackage       : "${artifactGroup}.generated.api",
 					dateLibrary      : 'java11',
 					jakarta          : 'true',


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/CORE-47

**Description:**

This PR updates Swagger-UI to version `5.17.14`, which includes `dompurify v3.1.4`. This resolves a prototype pollution vulnerability that could lead to cross-site scripting (XSS) attacks.

**Impact:**

- Fixes a security vulnerability.
- Improves protection against XSS exploits.

**Testing:**

- Verified the build version of swagger-ui matches `5.17.14`