### PR TITLE
CORE-163 end support of googleServiceAccount field

### DIFF
--- a/service/src/main/java/bio/terra/drshub/services/DrsResolutionService.java
+++ b/service/src/main/java/bio/terra/drshub/services/DrsResolutionService.java
@@ -149,11 +149,6 @@ public class DrsResolutionService {
     var accessMethod = AccessMethodUtils.getAccessMethod(drsResponse, drsProvider, cloudPlatform);
     var accessMethodType = accessMethod.map(AccessMethod::getType).orElse(null);
 
-    if (drsProvider.shouldFetchUserServiceAccount(accessMethodType, requestedFields)) {
-      var saKey = authService.fetchUserServiceAccount(drsProvider, bearerToken);
-      drsMetadataBuilder.bondSaKey(saKey);
-    }
-
     if (drsResponse != null) {
       drsMetadataBuilder.drsResponse(drsResponse);
       setDrsResponseValues(

--- a/service/src/test/java/bio/terra/drshub/controllers/DrsHubApiControllerTest.java
+++ b/service/src/test/java/bio/terra/drshub/controllers/DrsHubApiControllerTest.java
@@ -12,7 +12,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import bio.terra.drshub.BaseTest;
-import bio.terra.drshub.generated.model.SaKeyObject;
 import bio.terra.drshub.models.DrsApi;
 import bio.terra.drshub.models.Fields;
 import bio.terra.drshub.services.AuthService;
@@ -220,45 +219,6 @@ public class DrsHubApiControllerTest extends BaseTest {
         .andExpect(content().json(objectMapper.writeValueAsString(drsObjectMap), true));
 
     verify(externalCredsApiFactory, times(0)).getApi(any());
-  }
-
-  @Test
-  void testDrsProviderDoesNotSupportGoogle() throws Exception {
-    var cidProviderHost = getProviderHosts("kidsFirst");
-
-    postDrsHubRequest(
-            TEST_ACCESS_TOKEN,
-            cidProviderHost.compactUriPrefix(),
-            UUID.randomUUID().toString(),
-            List.of(Fields.GOOGLE_SERVICE_ACCOUNT))
-        .andExpect(status().isOk())
-        .andExpect(content().json("{}"));
-  }
-
-  @Test
-  void testDrsProviderDoesSupportGoogle() throws Exception {
-    var cidProviderHost = getProviderHosts("bioDataCatalyst");
-
-    Map<String, Object> fenceAccountKey = new HashMap<>();
-    fenceAccountKey.put("foo", "sa key");
-    ObjectMapper mapper = new ObjectMapper();
-    mockExternalCredsFenceAccountKeyApi(
-        Provider.fromValue(cidProviderHost.drsProvider().getEcmFenceProvider().get().getUriValue()),
-        TEST_ACCESS_TOKEN,
-        mapper.writeValueAsString(fenceAccountKey));
-
-    var saKeyObject = new SaKeyObject().data(fenceAccountKey);
-    postDrsHubRequest(
-            TEST_ACCESS_TOKEN,
-            cidProviderHost.compactUriPrefix(),
-            UUID.randomUUID().toString(),
-            List.of(Fields.GOOGLE_SERVICE_ACCOUNT))
-        .andExpect(status().isOk())
-        .andExpect(
-            content()
-                .json(
-                    objectMapper.writeValueAsString(
-                        Map.of(Fields.GOOGLE_SERVICE_ACCOUNT, saKeyObject))));
   }
 
   @Test


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/CORE-163

The problem in the ticket stems from ECM not properly purging expired fence service account keys. And because they never get removed, ECM never gets a new one. However, ECM never returns the expired key but returns a 404 instead. This triggers a 404 in DrsHub when the googleServiceAccount field is requested which causes failures in rawls when it is validating DRS URIs and workflows when it tries to resolve.

According to https://broadworkbench.atlassian.net/browse/PREQ-28, we no longer need these keys even though they are requested. Both rawls and cromwell should be able to handle their absence because there are already cases where they don't exist (e.g. kids first which is AWS).

I think it is better to discontinue use than to fix ECM's expiration problem.