### PR TITLE
DT-1425: Enable dependabot builds

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,8 +24,5 @@ updates:
       time: "06:00"
       timezone: "America/New_York"
     target-branch: "dev"
-    labels:
-      - "dependency"
-      - "gradle"
     commit-message:
       prefix: "[DT-400-gradle]"

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -13,11 +13,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           persist-credentials: false
       - name: Set up JDK 17
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'
@@ -43,7 +43,7 @@ jobs:
 
       - name: SonarQube scan service
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
+          GITHUB_TOKEN: ${{ secrets.BROADBOT_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: ./gradlew --build-cache :service:sonarqube
 
@@ -57,11 +57,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           persist-credentials: false
       - name: Set up JDK 17
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'
@@ -209,11 +209,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           persist-credentials: false
       - name: Set up JDK
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'


### PR DESCRIPTION
To enable dependabot builds, use the `BROADBOT_TOKEN` secret instead of `GITHUB_TOKEN`, since `GITHUB_TOKEN` is not populated by https://github.com/broadinstitute/terraform-ap-deployments/blob/master/github/tfvars/databiosphere-terra-drs-hub.tfvars.

- update versions of actions to current versions.
- remove labels from dependabot config