### PR TITLE
DT-1429: manually apply update for spring-cloud-gcp-starter-logging

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -62,7 +62,7 @@ dependencies {
 	implementation platform('com.google.cloud:libraries-bom:26.56.0')
 	implementation 'com.google.oauth-client:google-oauth-client'
 	implementation 'com.google.cloud:google-cloud-storage'
-	implementation 'com.google.cloud:spring-cloud-gcp-starter-logging:4.9.0'
+	implementation 'com.google.cloud:spring-cloud-gcp-starter-logging:6.1.0'
 
 	// For Micrometer metrics gathering
 	implementation 'io.micrometer:micrometer-registry-prometheus'


### PR DESCRIPTION
Manually apply update from https://github.com/DataBiosphere/terra-drs-hub/pull/132
