### PR TITLE
disable logback appender to fix localhost otel error

### DIFF
--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -92,6 +92,10 @@ otel:
         service:
           name: ${spring.application.name}
 
+  instrumentation:
+    logback-appender:
+      enabled: false
+
 server:
   max-http-request-header-size: 32KB
   compression:


### PR DESCRIPTION
Follow-on fix for terra-common-lib update. The opentelemetry fixes caused an error on startup:
```
Failed to export spans. The request could not be executed. Full error message: Failed to connect to localhost/127.0.0.1:4318
```

This fix was copied from https://github.com/DataBiosphere/terra-resource-janitor/pull/199