### PR TITLE
[CORE-413] Configure Sage DRS Provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ This is the short name, full name, and auth type(s) for each provider
   - Fence Token
 - **TDR** (Terra Data Repo)
   - Bearer Token
+- **Sage Bionetworks** (Synapse)
+  - Fence Token
 
 ## Usage
 To resolve a DRS URL, perform an HTTP `POST` to `/api/v4/drs/resolve`.

--- a/service/src/main/java/bio/terra/drshub/models/ECMFenceProviderEnum.java
+++ b/service/src/main/java/bio/terra/drshub/models/ECMFenceProviderEnum.java
@@ -4,7 +4,8 @@ public enum ECMFenceProviderEnum {
   dcf_fence("dcf-fence"),
   fence("fence"),
   anvil("anvil"),
-  kids_first("kids-first");
+  kids_first("kids-first"),
+  sage("sage");
 
   private String uriValue;
 

--- a/service/src/main/java/bio/terra/drshub/models/ECMFenceProviderEnum.java
+++ b/service/src/main/java/bio/terra/drshub/models/ECMFenceProviderEnum.java
@@ -5,7 +5,7 @@ public enum ECMFenceProviderEnum {
   fence("fence"),
   anvil("anvil"),
   kids_first("kids-first"),
-  SAGE("sage");
+  sage("sage");
 
   private String uriValue;
 

--- a/service/src/main/java/bio/terra/drshub/models/ECMFenceProviderEnum.java
+++ b/service/src/main/java/bio/terra/drshub/models/ECMFenceProviderEnum.java
@@ -5,7 +5,7 @@ public enum ECMFenceProviderEnum {
   fence("fence"),
   anvil("anvil"),
   kids_first("kids-first"),
-  sage("sage");
+  SAGE("sage");
 
   private String uriValue;
 

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -57,6 +57,15 @@ drshub:
         - type: https
           auth: current_request
           fetchAccessUrl: true # Used for Azure
+    sage:
+      name: Sage Bionetworks
+      hostRegex: 'repo-([^.]+)\.\1\.sagebase\.org' # Dev: 'repo-dev.dev.sagebase.org' & Prod: 'repo-prod.prod.sagebase.org'
+      metadataAuth: false
+      ecmFenceProvider: sage
+      accessMethodConfigs:
+        - type: s3
+          auth: fence_token
+          fetchAccessUrl: true
   pencilsDownSeconds: 58
   asyncThreads: ${TOMCAT_MAX_THREADS:200}
   restTemplateConnectionPoolSize: ${REST_TEMPLATE_CONNECTION_POOL_SIZE:500}

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -59,9 +59,9 @@ drshub:
           fetchAccessUrl: true # Used for Azure
     sage:
       name: Sage Bionetworks
-      hostRegex: 'repo-([^.]+)\.\1\.sagebase\.org' # Dev: 'repo-dev.dev.sagebase.org' & Prod: 'repo-prod.prod.sagebase.org'
+      hostRegex: 'repo-dev\.dev\.sagebase\.org|repo-prod\.prod\.sagebase\.org'
       metadataAuth: false
-      ecmFenceProvider: SAGE
+      ecmFenceProvider: sage
       accessMethodConfigs:
         - type: s3
           auth: fence_token
@@ -169,22 +169,12 @@ drshub:
       mTlsConfig:
         keyPath: rendered/ras-mtls-client.key
         certPath: rendered/ras-mtls-client.crt
-    sage:
-      name: Sage Bionetworks
-      hostRegex: 'repo-dev.dev.sagebase.org'
-      metadataAuth: false
-      ecmFenceProvider: SAGE
-      accessMethodConfigs:
-        - type: s3
-          auth: fence_token
-          fetchAccessUrl: true
   signedUrlDuration: 1h
   compactIdHosts:
     "dg.712c": staging.gen3.biodatacatalyst.nhlbi.nih.gov # biodatacatalyst staging
     "dg.4dfc": nci-crdc-staging.datacommons.io # cancer research data commons
     "dg.f82a1a": gen3staging.kidsfirstdrc.org # kidsfirst
     "dg.test0": ctds-test-env.planx-pla.net # passport test
-    "dg.sage": repo-dev.dev.sagebase.org # sage bionetworks
 ---
 # prod
 spring.config.activate.on-profile: prod
@@ -195,7 +185,6 @@ drshub:
     "drs.anv0": data.terra.bio # new anvil (hosted on TDR)
     "dg.4dfc": nci-crdc.datacommons.io # cancer research data commons
     "dg.f82a1a": data.kidsfirstdrc.org # kidsfirst
-    "dg.sage": repo-prod.prod.sagebase.org # sage bionetworks
 ---
 # dev
 spring.config.activate.on-profile: dev

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -61,7 +61,7 @@ drshub:
       name: Sage Bionetworks
       hostRegex: 'repo-([^.]+)\.\1\.sagebase\.org' # Dev: 'repo-dev.dev.sagebase.org' & Prod: 'repo-prod.prod.sagebase.org'
       metadataAuth: false
-      ecmFenceProvider: sage
+      ecmFenceProvider: SAGE
       accessMethodConfigs:
         - type: s3
           auth: fence_token
@@ -169,12 +169,22 @@ drshub:
       mTlsConfig:
         keyPath: rendered/ras-mtls-client.key
         certPath: rendered/ras-mtls-client.crt
+    sage:
+      name: Sage Bionetworks
+      hostRegex: 'repo-dev.dev.sagebase.org'
+      metadataAuth: false
+      ecmFenceProvider: SAGE
+      accessMethodConfigs:
+        - type: s3
+          auth: fence_token
+          fetchAccessUrl: true
   signedUrlDuration: 1h
   compactIdHosts:
     "dg.712c": staging.gen3.biodatacatalyst.nhlbi.nih.gov # biodatacatalyst staging
     "dg.4dfc": nci-crdc-staging.datacommons.io # cancer research data commons
     "dg.f82a1a": gen3staging.kidsfirstdrc.org # kidsfirst
     "dg.test0": ctds-test-env.planx-pla.net # passport test
+    "dg.sage": repo-dev.dev.sagebase.org # sage bionetworks
 ---
 # prod
 spring.config.activate.on-profile: prod
@@ -185,6 +195,7 @@ drshub:
     "drs.anv0": data.terra.bio # new anvil (hosted on TDR)
     "dg.4dfc": nci-crdc.datacommons.io # cancer research data commons
     "dg.f82a1a": data.kidsfirstdrc.org # kidsfirst
+    "dg.sage": repo-prod.prod.sagebase.org # sage bionetworks
 ---
 # dev
 spring.config.activate.on-profile: dev

--- a/service/src/test/java/bio/terra/drshub/services/DrsProviderServiceTest.java
+++ b/service/src/test/java/bio/terra/drshub/services/DrsProviderServiceTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import bio.terra.drshub.BaseTest;
+import java.util.List;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -18,7 +19,12 @@ class DrsProviderServiceTest extends BaseTest {
 
   @Test
   void testResolvesDnsHostsAndProviders() {
+    List<String> nonCompactIdProviders = List.of("sage");
+
     for (var providerName : config.getDrsProviders().keySet()) {
+      if (nonCompactIdProviders.contains(providerName)) {
+        continue; // Skip the non-compact ID providers
+      }
       var cidProviderHost = getProviderHosts(providerName);
 
       var testUri = String.format("drs://%s:12345", cidProviderHost.compactUriPrefix());


### PR DESCRIPTION
**Ticket:** https://broadworkbench.atlassian.net/browse/CORE-413

This PR updates `application.yml` to configure Sage's DRS provider, enabling DRShub to resolve and access Sage DRS URIs.

- **Dev:** `repo-dev.dev.sagebase.org` 
- **Prod:** `repo-prod.prod.sagebase.org`