### PR TITLE
CORE-447 retry drs api calls

### DIFF
--- a/service/src/main/java/bio/terra/drshub/models/DrsApi.java
+++ b/service/src/main/java/bio/terra/drshub/models/DrsApi.java
@@ -1,5 +1,6 @@
 package bio.terra.drshub.models;
 
+import com.google.common.annotations.VisibleForTesting;
 import io.github.ga4gh.drs.api.ObjectsApi;
 import io.github.ga4gh.drs.client.ApiClient;
 import io.github.ga4gh.drs.client.auth.OAuth;
@@ -16,47 +17,50 @@ import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.client.RestClientException;
 
 @Slf4j
-public class DrsApi extends ObjectsApi {
+public class DrsApi {
   static final int MAX_TRIALS = 4;
 
+  private ObjectsApi objectsApi;
+
   public DrsApi(ApiClient apiClient) {
-    super(apiClient);
+    this.objectsApi = new ObjectsApi(apiClient);
+  }
+
+  @VisibleForTesting
+  public ApiClient getApiClient() {
+    return objectsApi.getApiClient();
   }
 
   public void setBearerToken(String bearerToken) {
-    ((OAuth) this.getApiClient().getAuthentication("BearerAuth")).setAccessToken(bearerToken);
+    ((OAuth) objectsApi.getApiClient().getAuthentication("BearerAuth")).setAccessToken(bearerToken);
   }
 
   public void setHeader(String name, String value) {
-    this.getApiClient().addDefaultHeader(name, value);
+    objectsApi.getApiClient().addDefaultHeader(name, value);
   }
 
-  @Override
   public DrsObject postObject(Object body, String objectId) throws RestClientException {
-    return retry(() -> super.postObject(body, objectId));
+    return retry(() -> objectsApi.postObject(body, objectId));
   }
 
-  @Override
   public AccessURL postAccessURL(Object body, String objectId, String accessId)
       throws RestClientException {
-    return retry(() -> super.postAccessURL(body, objectId, accessId));
+    return retry(() -> objectsApi.postAccessURL(body, objectId, accessId));
   }
 
-  @Override
   public Authorizations optionsObject(String objectId) throws RestClientException {
-    return retry(() -> super.optionsObject(objectId));
+    return retry(() -> objectsApi.optionsObject(objectId));
   }
 
-  @Override
   public DrsObject getObject(String objectId, Boolean expand) throws RestClientException {
-    return retry(() -> super.getObject(objectId, expand));
+    return retry(() -> objectsApi.getObject(objectId, expand));
   }
 
-  @Override
   public AccessURL getAccessURL(String objectId, String accessId) throws RestClientException {
-    return retry(() -> super.getAccessURL(objectId, accessId));
+    return retry(() -> objectsApi.getAccessURL(objectId, accessId));
   }
 
+  @VisibleForTesting
   static <T> T retry(Supplier<T> supplier) {
     for (int trial = 1; true; trial++) {
       try {
@@ -74,6 +78,7 @@ public class DrsApi extends ObjectsApi {
           try {
             Thread.sleep(10L * trial);
           } catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
             throw e;
           }
         }

--- a/service/src/main/java/bio/terra/drshub/models/DrsApi.java
+++ b/service/src/main/java/bio/terra/drshub/models/DrsApi.java
@@ -3,8 +3,21 @@ package bio.terra.drshub.models;
 import io.github.ga4gh.drs.api.ObjectsApi;
 import io.github.ga4gh.drs.client.ApiClient;
 import io.github.ga4gh.drs.client.auth.OAuth;
+import io.github.ga4gh.drs.model.AccessURL;
+import io.github.ga4gh.drs.model.Authorizations;
+import io.github.ga4gh.drs.model.DrsObject;
+import java.util.function.Supplier;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.client.HttpServerErrorException.BadGateway;
+import org.springframework.web.client.HttpServerErrorException.GatewayTimeout;
+import org.springframework.web.client.HttpServerErrorException.InternalServerError;
+import org.springframework.web.client.HttpServerErrorException.ServiceUnavailable;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestClientException;
 
+@Slf4j
 public class DrsApi extends ObjectsApi {
+  static final int MAX_TRIALS = 4;
 
   public DrsApi(ApiClient apiClient) {
     super(apiClient);
@@ -16,5 +29,55 @@ public class DrsApi extends ObjectsApi {
 
   public void setHeader(String name, String value) {
     this.getApiClient().addDefaultHeader(name, value);
+  }
+
+  @Override
+  public DrsObject postObject(Object body, String objectId) throws RestClientException {
+    return retry(() -> super.postObject(body, objectId));
+  }
+
+  @Override
+  public AccessURL postAccessURL(Object body, String objectId, String accessId)
+      throws RestClientException {
+    return retry(() -> super.postAccessURL(body, objectId, accessId));
+  }
+
+  @Override
+  public Authorizations optionsObject(String objectId) throws RestClientException {
+    return retry(() -> super.optionsObject(objectId));
+  }
+
+  @Override
+  public DrsObject getObject(String objectId, Boolean expand) throws RestClientException {
+    return retry(() -> super.getObject(objectId, expand));
+  }
+
+  @Override
+  public AccessURL getAccessURL(String objectId, String accessId) throws RestClientException {
+    return retry(() -> super.getAccessURL(objectId, accessId));
+  }
+
+  static <T> T retry(Supplier<T> supplier) {
+    for (int trial = 1; true; trial++) {
+      try {
+        return supplier.get();
+      } catch (InternalServerError
+          | BadGateway
+          | ServiceUnavailable
+          | GatewayTimeout
+          | ResourceAccessException e) {
+        if (trial == MAX_TRIALS) {
+          throw e;
+        } else {
+          log.info(
+              "retrying DRS call, attempt {} of {}, error {}", trial, MAX_TRIALS, e.getMessage());
+          try {
+            Thread.sleep(10L * trial);
+          } catch (InterruptedException ex) {
+            throw e;
+          }
+        }
+      }
+    }
   }
 }

--- a/service/src/test/java/bio/terra/drshub/models/DrsApiTest.java
+++ b/service/src/test/java/bio/terra/drshub/models/DrsApiTest.java
@@ -59,7 +59,7 @@ class DrsApiTest {
       ints = {
         500, 502, 503, 504,
       }) // HttpStatus.INTERNAL_SERVER_ERROR, BAD_GATEWAY, SERVICE_UNAVAILABLE, GATEWAY_TIMEOUT
-  void testRetries(int status) {
+  void testRetriesBadGateway(int status) {
     AtomicInteger callCount = new AtomicInteger();
     assertThrows(
         HttpServerErrorException.class,

--- a/service/src/test/java/bio/terra/drshub/models/DrsApiTest.java
+++ b/service/src/test/java/bio/terra/drshub/models/DrsApiTest.java
@@ -1,17 +1,24 @@
 package bio.terra.drshub.models;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.github.ga4gh.drs.client.ApiClient;
 import io.github.ga4gh.drs.client.auth.OAuth;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.client.HttpServerErrorException;
 
 @Tag("Unit")
 @ExtendWith(MockitoExtension.class)
@@ -45,5 +52,53 @@ class DrsApiTest {
     drsApi.setHeader(name, value);
 
     verify(apiClient).addDefaultHeader(name, value);
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      ints = {
+        500, 502, 503, 504,
+      }) // HttpStatus.INTERNAL_SERVER_ERROR, BAD_GATEWAY, SERVICE_UNAVAILABLE, GATEWAY_TIMEOUT
+  void testRetries(int status) {
+    AtomicInteger callCount = new AtomicInteger();
+    assertThrows(
+        HttpServerErrorException.class,
+        () ->
+            DrsApi.retry(
+                () -> {
+                  callCount.getAndIncrement();
+                  throw HttpServerErrorException.create(
+                      HttpStatus.valueOf(status), "error", null, null, null);
+                }));
+    assertEquals(DrsApi.MAX_TRIALS, callCount.get());
+  }
+
+  @Test
+  void testDoesNotRetryNotFound() {
+    AtomicInteger callCount = new AtomicInteger();
+    assertThrows(
+        HttpServerErrorException.class,
+        () ->
+            DrsApi.retry(
+                () -> {
+                  callCount.getAndIncrement();
+                  throw HttpServerErrorException.create(
+                      HttpStatus.NOT_FOUND, "Not Found", null, null, null);
+                }));
+    assertEquals(1, callCount.get());
+  }
+
+  @Test
+  void testRetryReturnsValue() {
+    AtomicInteger callCount = new AtomicInteger();
+    var expected = "result";
+    var actual =
+        DrsApi.retry(
+            () -> {
+              callCount.getAndIncrement();
+              return expected;
+            });
+    assertEquals(1, callCount.get());
+    assertEquals(expected, actual);
   }
 }


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/CORE-447

The underlying problem is that when using passport authentication and ECM returns a 502 to TDR, TDR propagates the 502 to DrsHub, then DrsHub treats that a "passport doesn't work try something else" which returns a 403 which is the symptom the caller sees. The scale test shows just a few of these so we think a retry strategy should fix the problem instead of scaling up the infrastructure which costs $$$. Retrying is probably a good idea anyway.

I looked into using Spring's retry features but it was too much spring magic to make `DrsApi` a bean and other approaches take too much refactoring for not much benefit.