### PR TITLE
DT-1552, DT-1436, DT-1437 - Update sprint boot to 3.3.10 to resolve security vulnerabilities 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
 	id 'idea'
 
 	id 'io.spring.dependency-management' version '1.1.7' apply false
-	id 'org.springframework.boot' version '3.3.2' apply false
+	id 'org.springframework.boot' version '3.3.9' apply false
 	id 'com.diffplug.spotless' version '7.0.3' apply false
 	// ^^ for some reason, can't use spotless in multiple subprojects without this ^^
 	id 'com.google.cloud.tools.jib' version '3.4.5' apply false

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
 	id 'idea'
 
 	id 'io.spring.dependency-management' version '1.1.7' apply false
-	id 'org.springframework.boot' version '3.3.9' apply false
+	id 'org.springframework.boot' version '3.3.10' apply false
 	id 'com.diffplug.spotless' version '7.0.3' apply false
 	// ^^ for some reason, can't use spotless in multiple subprojects without this ^^
 	id 'com.google.cloud.tools.jib' version '3.4.5' apply false


### PR DESCRIPTION
Dependency Versions for Sprint Boot 3.3.10 are documented here: https://docs.spring.io/spring-boot/3.3/appendix/dependency-versions/coordinates.html


We can prove that upgrading spring boot upgrades these dependencies by looking at the dependencyInsight output with gradle. 

## Addresses
[DT-1552](https://broadworkbench.atlassian.net/browse/DT-1552)
[DT-1436](https://broadworkbench.atlassian.net/browse/DT-1436)
[DT-1437](https://broadworkbench.atlassian.net/browse/DT-1437)

## DT-1552 - Upgrade Tomcat via spring boot

```
terra-drs-hub % ./gradlew service:dependencyInsight --dependency tomcat-embed-core      

> Task :service:dependencyInsight
org.apache.tomcat.embed:tomcat-embed-core:10.1.39 (selected by rule)
  Variant compile:
    | Attribute Name                 | Provided | Requested    |
    |--------------------------------|----------|--------------|
    | org.gradle.status              | release  |              |
    | org.gradle.category            | library  | library      |
    | org.gradle.libraryelements     | jar      | classes      |
    | org.gradle.usage               | java-api | java-api     |
    | org.gradle.dependency.bundling |          | external     |
    | org.gradle.jvm.environment     |          | standard-jvm |
    | org.gradle.jvm.version         |          | 17           |

org.apache.tomcat.embed:tomcat-embed-core:10.1.39
+--- org.apache.tomcat.embed:tomcat-embed-websocket:10.1.39
|    \--- org.springframework.boot:spring-boot-starter-tomcat:3.3.10
|         \--- org.springframework.boot:spring-boot-starter-web:3.3.10
|              \--- compileClasspath (requested org.springframework.boot:spring-boot-starter-web)
\--- org.springframework.boot:spring-boot-starter-tomcat:3.3.10 (*)

(*) - dependencies omitted (listed previously)

A web-based, searchable dependency report is available by adding the --scan option.

Deprecated Gradle features were used in this build, making it incompatible with Gradle 8.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

See https://docs.gradle.org/7.6.4/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 3s
1 actionable task: 1 executed
```

## DT-1436 - Upgrade JSON Small and Fast Parser to 2.5.2 via Spring Boot Upgrade

```
 terra-drs-hub % ./gradlew service:dependencyInsight --dependency json-smart --configuration runtimeClasspath

> Task :service:dependencyInsight
net.minidev:json-smart:2.5.2 (selected by rule)
  Variant runtime:
    | Attribute Name                 | Provided     | Requested    |
    |--------------------------------|--------------|--------------|
    | org.gradle.status              | release      |              |
    | org.gradle.category            | library      | library      |
    | org.gradle.libraryelements     | jar          | jar          |
    | org.gradle.usage               | java-runtime | java-runtime |
    | org.gradle.dependency.bundling |              | external     |
    | org.gradle.jvm.environment     |              | standard-jvm |
    | org.gradle.jvm.version         |              | 17           |

net.minidev:json-smart:2.4.11 -> 2.5.2
\--- com.microsoft.azure:msal4j:1.19.0
     +--- com.azure:azure-identity:1.15.3
     |    \--- bio.terra:stairway-azure:1.1.21-SNAPSHOT:20250303.164040-2
     |         \--- bio.terra:terra-common-lib:1.1.39-SNAPSHOT:20250321.161945-1
     |              \--- runtimeClasspath
     \--- com.microsoft.azure:msal4j-persistence-extension:1.3.0 (requested com.microsoft.azure:msal4j:1.15.0)
          \--- com.azure:azure-identity:1.15.3 (*)

net.minidev:json-smart:2.5.1 -> 2.5.2
\--- com.nimbusds:oauth2-oidc-sdk:11.18
     \--- com.microsoft.azure:msal4j:1.19.0
          +--- com.azure:azure-identity:1.15.3
          |    \--- bio.terra:stairway-azure:1.1.21-SNAPSHOT:20250303.164040-2
          |         \--- bio.terra:terra-common-lib:1.1.39-SNAPSHOT:20250321.161945-1
          |              \--- runtimeClasspath
          \--- com.microsoft.azure:msal4j-persistence-extension:1.3.0 (requested com.microsoft.azure:msal4j:1.15.0)
               \--- com.azure:azure-identity:1.15.3 (*)

(*) - dependencies omitted (listed previously)

A web-based, searchable dependency report is available by adding the --scan option.

Deprecated Gradle features were used in this build, making it incompatible with Gradle 8.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

See https://docs.gradle.org/7.6.4/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 3s
1 actionable task: 1 executed
```

## DT-1437 - Upgrade netty-handler to > 4.1.118.Final via Spring Boot

```
./gradlew service:dependencyInsight --dependency netty-handler --configuration runtimeClasspath

> Task :service:dependencyInsight
io.netty:netty-handler:4.1.119.Final
  Variant runtime:
    | Attribute Name                 | Provided     | Requested    |
    |--------------------------------|--------------|--------------|
    | org.gradle.status              | release      |              |
    | org.gradle.category            | library      | library      |
    | org.gradle.libraryelements     | jar          | jar          |
    | org.gradle.usage               | java-runtime | java-runtime |
    | org.gradle.dependency.bundling |              | external     |
    | org.gradle.jvm.environment     |              | standard-jvm |
    | org.gradle.jvm.version         |              | 17           |
   Selection reasons:
      - Selected by rule
      - By constraint

io.netty:netty-handler:4.1.119.Final
+--- io.netty:netty-bom:4.1.119.Final
|    \--- bio.terra:stairway-azure:1.1.21-SNAPSHOT:20250303.164040-2
|         \--- bio.terra:terra-common-lib:1.1.39-SNAPSHOT:20250321.161945-1
|              \--- runtimeClasspath
+--- io.netty:netty-codec-http:4.1.119.Final
|    +--- com.azure:azure-core-http-netty:1.15.10 (requested io.netty:netty-codec-http:4.1.118.Final)
|    |    +--- com.azure:azure-messaging-servicebus:7.17.9
|    |    |    \--- bio.terra:stairway-azure:1.1.21-SNAPSHOT:20250303.164040-2 (*)
|    |    \--- com.azure:azure-identity:1.15.3
|    |         \--- bio.terra:stairway-azure:1.1.21-SNAPSHOT:20250303.164040-2 (*)
|    +--- io.netty:netty-bom:4.1.119.Final (*)
|    +--- io.projectreactor.netty:reactor-netty-http:1.1.28
|    |    \--- com.azure:azure-core-http-netty:1.15.10 (requested io.projectreactor.netty:reactor-netty-http:1.0.48) (*)
|    +--- io.netty:netty-handler-proxy:4.1.119.Final
|    |    +--- com.azure:azure-core-http-netty:1.15.10 (requested io.netty:netty-handler-proxy:4.1.118.Final) (*)
|    |    +--- io.netty:netty-bom:4.1.119.Final (*)
|    |    \--- io.projectreactor.netty:reactor-netty-core:1.1.28
|    |         \--- io.projectreactor.netty:reactor-netty-http:1.1.28 (*)
|    \--- io.netty:netty-codec-http2:4.1.119.Final
|         +--- com.azure:azure-core-http-netty:1.15.10 (requested io.netty:netty-codec-http2:4.1.118.Final) (*)
|         +--- io.netty:netty-bom:4.1.119.Final (*)
|         \--- io.projectreactor.netty:reactor-netty-http:1.1.28 (*)
+--- io.netty:netty-codec-http2:4.1.119.Final (*)
+--- io.netty:netty-resolver-dns:4.1.119.Final
|    +--- io.netty:netty-bom:4.1.119.Final (*)
|    +--- io.projectreactor.netty:reactor-netty-http:1.1.28 (*)
|    +--- io.projectreactor.netty:reactor-netty-core:1.1.28 (*)
|    \--- io.netty:netty-resolver-dns-classes-macos:4.1.119.Final
|         +--- io.netty:netty-bom:4.1.119.Final (*)
|         \--- io.netty:netty-resolver-dns-native-macos:4.1.119.Final
|              +--- io.netty:netty-bom:4.1.119.Final (*)
|              +--- io.projectreactor.netty:reactor-netty-http:1.1.28 (*)
|              \--- io.projectreactor.netty:reactor-netty-core:1.1.28 (*)
\--- io.projectreactor.netty:reactor-netty-core:1.1.28 (*)

io.netty:netty-handler:4.1.118.Final -> 4.1.119.Final
\--- com.azure:azure-core-http-netty:1.15.10
     +--- com.azure:azure-messaging-servicebus:7.17.9
     |    \--- bio.terra:stairway-azure:1.1.21-SNAPSHOT:20250303.164040-2
     |         \--- bio.terra:terra-common-lib:1.1.39-SNAPSHOT:20250321.161945-1
     |              \--- runtimeClasspath
     \--- com.azure:azure-identity:1.15.3
          \--- bio.terra:stairway-azure:1.1.21-SNAPSHOT:20250303.164040-2 (*)

io.netty:netty-handler-proxy:4.1.119.Final
  Variant runtime:
    | Attribute Name                 | Provided     | Requested    |
    |--------------------------------|--------------|--------------|
    | org.gradle.status              | release      |              |
    | org.gradle.category            | library      | library      |
    | org.gradle.libraryelements     | jar          | jar          |
    | org.gradle.usage               | java-runtime | java-runtime |
    | org.gradle.dependency.bundling |              | external     |
    | org.gradle.jvm.environment     |              | standard-jvm |
    | org.gradle.jvm.version         |              | 17           |
   Selection reasons:
      - Selected by rule
      - By constraint

io.netty:netty-handler-proxy:4.1.119.Final
+--- io.netty:netty-bom:4.1.119.Final
|    \--- bio.terra:stairway-azure:1.1.21-SNAPSHOT:20250303.164040-2
|         \--- bio.terra:terra-common-lib:1.1.39-SNAPSHOT:20250321.161945-1
|              \--- runtimeClasspath
\--- io.projectreactor.netty:reactor-netty-core:1.1.28
     \--- io.projectreactor.netty:reactor-netty-http:1.1.28
          \--- com.azure:azure-core-http-netty:1.15.10 (requested io.projectreactor.netty:reactor-netty-http:1.0.48)
               +--- com.azure:azure-messaging-servicebus:7.17.9
               |    \--- bio.terra:stairway-azure:1.1.21-SNAPSHOT:20250303.164040-2 (*)
               \--- com.azure:azure-identity:1.15.3
                    \--- bio.terra:stairway-azure:1.1.21-SNAPSHOT:20250303.164040-2 (*)

io.netty:netty-handler-proxy:4.1.118.Final -> 4.1.119.Final
\--- com.azure:azure-core-http-netty:1.15.10
     +--- com.azure:azure-messaging-servicebus:7.17.9
     |    \--- bio.terra:stairway-azure:1.1.21-SNAPSHOT:20250303.164040-2
     |         \--- bio.terra:terra-common-lib:1.1.39-SNAPSHOT:20250321.161945-1
     |              \--- runtimeClasspath
     \--- com.azure:azure-identity:1.15.3
          \--- bio.terra:stairway-azure:1.1.21-SNAPSHOT:20250303.164040-2 (*)

(*) - dependencies omitted (listed previously)

A web-based, searchable dependency report is available by adding the --scan option.

Deprecated Gradle features were used in this build, making it incompatible with Gradle 8.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

See https://docs.gradle.org/7.6.4/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 3s
1 actionable task: 1 executed

```



[DT-1552]: https://broadworkbench.atlassian.net/browse/DT-1552?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DT-1436]: https://broadworkbench.atlassian.net/browse/DT-1436?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DT-1437]: https://broadworkbench.atlassian.net/browse/DT-1437?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ