### PR TITLE
[DT-400][DT-1430] Remove sslcontext-kickstart dependency

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -31,19 +31,8 @@ apply from: 'generators.gradle'
 apply from: 'tooling.gradle'
 apply from: 'analysis.gradle'
 
-dependencyManagement {
-	dependencies {
-		dependencySet(group:'io.github.hakky54', version: '8.2.0') {
-			entry 'sslcontext-kickstart-for-apache5'
-			entry 'sslcontext-kickstart-for-pem'
-		}
-	}
-}
-
 dependencies {
 	annotationProcessor 'org.immutables:value:2.11.3'
-	implementation 'io.github.hakky54:sslcontext-kickstart-for-apache5'
-	implementation 'io.github.hakky54:sslcontext-kickstart-for-pem'
 
 	implementation('bio.terra:terra-common-lib:1.1.39-SNAPSHOT') {
 		// remove transitive database deps, drshub has no db
@@ -74,6 +63,10 @@ dependencies {
 		// Fixes warning about multiple occurrences of JSONObject on the classpath
 		exclude group: 'com.vaadin.external.google', module: 'android-json'
 	}
+
+	// BouncyCastle for test key generation utilities
+	testImplementation 'org.bouncycastle:bcprov-jdk18on:1.78.1'
+	testImplementation 'org.bouncycastle:bcpkix-jdk18on:1.78.1'
 
 	testImplementation('au.com.dius.pact.provider:junit5:4.6.17')
 	testImplementation('au.com.dius.pact.provider:junit5spring:4.6.17')

--- a/service/src/main/java/bio/terra/drshub/services/RestTemplateFactory.java
+++ b/service/src/main/java/bio/terra/drshub/services/RestTemplateFactory.java
@@ -2,14 +2,13 @@ package bio.terra.drshub.services;
 
 import bio.terra.drshub.config.DrsHubConfig;
 import bio.terra.drshub.config.MTlsConfig;
-import nl.altindag.ssl.SSLFactory;
-import nl.altindag.ssl.apache5.util.Apache5SslUtils;
-import nl.altindag.ssl.pem.util.PemUtils;
+import javax.net.ssl.SSLContext;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.impl.classic.HttpClients;
 import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
 import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder;
 import org.apache.hc.client5.http.socket.LayeredConnectionSocketFactory;
+import org.apache.hc.client5.http.ssl.SSLConnectionSocketFactory;
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
@@ -18,9 +17,11 @@ import org.springframework.web.client.RestTemplate;
 public class RestTemplateFactory {
 
   private final int connectionPoolSize;
+  private final SSLContextFactory sslContextFactory;
 
-  public RestTemplateFactory(DrsHubConfig drsHubConfig) {
-    connectionPoolSize = drsHubConfig.restTemplateConnectionPoolSize();
+  public RestTemplateFactory(DrsHubConfig drsHubConfig, SSLContextFactory sslContextFactory) {
+    this.connectionPoolSize = drsHubConfig.restTemplateConnectionPoolSize();
+    this.sslContextFactory = sslContextFactory;
   }
 
   /**
@@ -35,12 +36,9 @@ public class RestTemplateFactory {
    *     must also be authenticated)
    */
   public RestTemplate makeMTlsRestTemplateWithPooling(MTlsConfig mTlsConfig) {
-    var keyManager =
-        PemUtils.loadIdentityMaterial(mTlsConfig.getCertPath(), mTlsConfig.getKeyPath());
-    var sslFactory = SSLFactory.builder().withIdentityMaterial(keyManager).build();
-    var socketFactory = Apache5SslUtils.toSocketFactory(sslFactory);
-
-    return makeRestTemplateWithPooling(socketFactory);
+    SSLContext sslContext = sslContextFactory.createSSLContextWithClientCert(mTlsConfig);
+    SSLConnectionSocketFactory sslSocketFactory = new SSLConnectionSocketFactory(sslContext);
+    return makeRestTemplateWithPooling(sslSocketFactory);
   }
 
   /**

--- a/service/src/main/java/bio/terra/drshub/services/SSLContextFactory.java
+++ b/service/src/main/java/bio/terra/drshub/services/SSLContextFactory.java
@@ -5,7 +5,11 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.security.*;
+import java.security.KeyFactory;
+import java.security.KeyStore;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.security.SecureRandom;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
@@ -14,7 +18,9 @@ import java.security.spec.InvalidKeySpecException;
 import java.security.spec.PKCS8EncodedKeySpec;
 import java.util.Base64;
 import java.util.regex.Pattern;
-import javax.net.ssl.*;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManagerFactory;
 import org.springframework.stereotype.Component;
 
 /**

--- a/service/src/main/java/bio/terra/drshub/services/SSLContextFactory.java
+++ b/service/src/main/java/bio/terra/drshub/services/SSLContextFactory.java
@@ -1,0 +1,143 @@
+package bio.terra.drshub.services;
+
+import bio.terra.drshub.config.MTlsConfig;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.security.*;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.util.Base64;
+import java.util.regex.Pattern;
+import javax.net.ssl.*;
+import org.springframework.stereotype.Component;
+
+/**
+ * Factory class for creating SSL contexts with client certificate authentication. This class
+ * handles loading PEM files and creating SSL contexts for mutual TLS.
+ */
+@Component
+public class SSLContextFactory {
+
+  /**
+   * Creates an SSLContext with client certificate authentication (mutual TLS)
+   *
+   * @param mTlsConfig Configuration containing paths to certificate and private key files
+   * @return Configured SSLContext for mutual TLS
+   * @throws RuntimeException if SSL context creation fails
+   */
+  public SSLContext createSSLContextWithClientCert(MTlsConfig mTlsConfig) {
+    try {
+      // Load certificate and private key
+      X509Certificate certificate = loadCertificateFromPem(mTlsConfig.getCertPath());
+      PrivateKey privateKey = loadPrivateKeyFromPem(mTlsConfig.getKeyPath());
+
+      // Create keystore with client certificate
+      KeyStore keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
+      keyStore.load(null, null);
+      keyStore.setKeyEntry("client", privateKey, new char[0], new Certificate[] {certificate});
+
+      // Initialize key manager
+      KeyManagerFactory keyManagerFactory =
+          KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+      keyManagerFactory.init(keyStore, new char[0]);
+
+      // Initialize trust manager (use default)
+      TrustManagerFactory trustManagerFactory =
+          TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+      trustManagerFactory.init((KeyStore) null);
+
+      // Create SSL context
+      SSLContext sslContext = SSLContext.getInstance("TLS");
+      sslContext.init(
+          keyManagerFactory.getKeyManagers(),
+          trustManagerFactory.getTrustManagers(),
+          new SecureRandom());
+
+      return sslContext;
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to create SSL context with client certificate", e);
+    }
+  }
+
+  /**
+   * Loads an X509 certificate from a PEM file
+   *
+   * @param certificatePath Path to the certificate PEM file
+   * @return X509Certificate loaded from the file
+   * @throws IOException if file reading fails
+   * @throws CertificateException if certificate parsing fails
+   */
+  private X509Certificate loadCertificateFromPem(String certificatePath)
+      throws IOException, CertificateException {
+    String pemContent = Files.readString(Paths.get(certificatePath));
+    String certificateData = extractPemContent(pemContent, "CERTIFICATE");
+
+    byte[] certBytes = Base64.getDecoder().decode(certificateData);
+    CertificateFactory certificateFactory = CertificateFactory.getInstance("X.509");
+
+    return (X509Certificate)
+        certificateFactory.generateCertificate(new ByteArrayInputStream(certBytes));
+  }
+
+  /**
+   * Loads a private key from a PEM file
+   *
+   * @param privateKeyPath Path to the private key PEM file
+   * @return PrivateKey loaded from the file
+   * @throws IOException if file reading fails
+   * @throws NoSuchAlgorithmException if key algorithm is not supported
+   * @throws InvalidKeySpecException if key parsing fails
+   */
+  private PrivateKey loadPrivateKeyFromPem(String privateKeyPath)
+      throws IOException, NoSuchAlgorithmException, InvalidKeySpecException {
+    String pemContent = Files.readString(Paths.get(privateKeyPath));
+    String keyData = extractPemContent(pemContent, "PRIVATE KEY");
+
+    byte[] keyBytes = Base64.getDecoder().decode(keyData);
+    PKCS8EncodedKeySpec keySpec = new PKCS8EncodedKeySpec(keyBytes);
+
+    String[] algorithms = {"RSA", "EC", "DSA"};
+    for (String algorithm : algorithms) {
+      try {
+        KeyFactory keyFactory = KeyFactory.getInstance(algorithm);
+        return keyFactory.generatePrivate(keySpec);
+      } catch (InvalidKeySpecException e) {
+        // Try next algorithm
+      }
+    }
+
+    throw new InvalidKeySpecException("Unable to parse private key with any supported algorithm");
+  }
+
+  /**
+   * Extracts the Base64 content from a PEM block
+   *
+   * @param pemContent The PEM file content
+   * @param blockType The type of PEM block (e.g., "CERTIFICATE", "PRIVATE KEY")
+   * @return Base64 decoded content of the PEM block
+   * @throws IllegalArgumentException if PEM block is not found
+   */
+  private String extractPemContent(String pemContent, String blockType) {
+    Pattern pattern =
+        Pattern.compile(
+            "-----BEGIN "
+                + blockType
+                + "-----\\s*([A-Za-z0-9+/=\\s]+)\\s*-----END "
+                + blockType
+                + "-----",
+            Pattern.MULTILINE | Pattern.DOTALL);
+
+    var matcher = pattern.matcher(pemContent);
+    if (matcher.find()) {
+      return matcher.group(1).replaceAll("\\s", "");
+    }
+
+    throw new IllegalArgumentException("No " + blockType + " block found in PEM content");
+  }
+}

--- a/service/src/test/java/bio/terra/drshub/services/SSLContextFactoryTest.java
+++ b/service/src/test/java/bio/terra/drshub/services/SSLContextFactoryTest.java
@@ -1,32 +1,17 @@
 package bio.terra.drshub.services;
 
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import bio.terra.drshub.config.MTlsConfig;
 import java.io.IOException;
-import java.math.BigInteger;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.security.KeyPair;
-import java.security.KeyPairGenerator;
-import java.security.PrivateKey;
-import java.security.SecureRandom;
-import java.security.Security;
-import java.security.cert.X509Certificate;
-import java.time.Instant;
-import java.time.temporal.ChronoUnit;
-import java.util.Base64;
-import java.util.Date;
 import javax.net.ssl.SSLContext;
-import org.bouncycastle.asn1.x500.X500Name;
-import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
-import org.bouncycastle.cert.X509CertificateHolder;
-import org.bouncycastle.cert.X509v3CertificateBuilder;
-import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
-import org.bouncycastle.jce.provider.BouncyCastleProvider;
-import org.bouncycastle.operator.ContentSigner;
-import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -35,38 +20,22 @@ import org.junit.jupiter.api.io.TempDir;
 @Tag("Unit")
 class SSLContextFactoryTest {
 
+  private static final String FAKE_CERT_PATH = "src/test/resources/fake.crt";
+  private static final String FAKE_KEY_PATH = "src/test/resources/fake.key";
+
   private SSLContextFactory sslContextFactory;
   private MTlsConfig mockMTlsConfig;
 
   @TempDir Path tempDir;
 
-  private Path certFile;
-  private Path keyFile;
-  private KeyPair testKeyPair;
-  private X509Certificate testCertificate;
-
   @BeforeEach
-  void setUp() throws Exception {
-    // Add BouncyCastle provider for certificate generation
-    Security.addProvider(new BouncyCastleProvider());
-
+  void setUp() {
     sslContextFactory = new SSLContextFactory();
     mockMTlsConfig = mock(MTlsConfig.class);
 
-    // Generate test key pair and certificate
-    generateTestKeyPairAndCertificate();
-
-    // Create temporary files
-    certFile = tempDir.resolve("test.crt");
-    keyFile = tempDir.resolve("test.key");
-
-    // Write PEM files
-    writeCertificatePem(certFile, testCertificate);
-    writePrivateKeyPem(keyFile, testKeyPair.getPrivate());
-
-    // Setup mock config
-    when(mockMTlsConfig.getCertPath()).thenReturn(certFile.toString());
-    when(mockMTlsConfig.getKeyPath()).thenReturn(keyFile.toString());
+    // Setup mock config to use fake certificate files directly
+    when(mockMTlsConfig.getCertPath()).thenReturn(FAKE_CERT_PATH);
+    when(mockMTlsConfig.getKeyPath()).thenReturn(FAKE_KEY_PATH);
   }
 
   @Test
@@ -111,9 +80,11 @@ class SSLContextFactoryTest {
 
   @Test
   void testCreateSSLContextWithClientCert_InvalidCertificateContent() throws IOException {
-    // Given - write invalid certificate content
+    // Given - write invalid certificate content to temporary file
+    Path certFile = tempDir.resolve("invalid.crt");
     Files.writeString(
         certFile, "-----BEGIN CERTIFICATE-----\nINVALID_CONTENT\n-----END CERTIFICATE-----");
+    when(mockMTlsConfig.getCertPath()).thenReturn(certFile.toString());
 
     // When & Then
     RuntimeException exception =
@@ -127,9 +98,11 @@ class SSLContextFactoryTest {
 
   @Test
   void testCreateSSLContextWithClientCert_InvalidPrivateKeyContent() throws IOException {
-    // Given - write invalid private key content
+    // Given - write invalid private key content to temporary file
+    Path keyFile = tempDir.resolve("invalid.key");
     Files.writeString(
         keyFile, "-----BEGIN PRIVATE KEY-----\nINVALID_CONTENT\n-----END PRIVATE KEY-----");
+    when(mockMTlsConfig.getKeyPath()).thenReturn(keyFile.toString());
 
     // When & Then
     RuntimeException exception =
@@ -143,8 +116,10 @@ class SSLContextFactoryTest {
 
   @Test
   void testCreateSSLContextWithClientCert_MissingCertificateBlock() throws IOException {
-    // Given - write content without proper PEM block
+    // Given - write content without proper PEM block to temporary file
+    Path certFile = tempDir.resolve("missing_block.crt");
     Files.writeString(certFile, "This is not a PEM certificate");
+    when(mockMTlsConfig.getCertPath()).thenReturn(certFile.toString());
 
     // When & Then
     RuntimeException exception =
@@ -158,8 +133,10 @@ class SSLContextFactoryTest {
 
   @Test
   void testCreateSSLContextWithClientCert_MissingPrivateKeyBlock() throws IOException {
-    // Given - write content without proper PEM block
+    // Given - write content without proper PEM block to temporary file
+    Path keyFile = tempDir.resolve("missing_block.key");
     Files.writeString(keyFile, "This is not a PEM private key");
+    when(mockMTlsConfig.getKeyPath()).thenReturn(keyFile.toString());
 
     // When & Then
     RuntimeException exception =
@@ -172,39 +149,13 @@ class SSLContextFactoryTest {
   }
 
   @Test
-  void testCreateSSLContextWithClientCert_ECKeySupport() throws Exception {
-    // Given - generate EC key pair
-    KeyPairGenerator ecKeyGen = KeyPairGenerator.getInstance("EC");
-    ecKeyGen.initialize(256);
-    KeyPair ecKeyPair = ecKeyGen.generateKeyPair();
-
-    // Create certificate with EC key
-    X509Certificate ecCertificate = createSelfSignedCertificate(ecKeyPair, "EC");
-
-    // Write EC PEM files
-    Path ecCertFile = tempDir.resolve("ec_test.crt");
-    Path ecKeyFile = tempDir.resolve("ec_test.key");
-
-    writeCertificatePem(ecCertFile, ecCertificate);
-    writePrivateKeyPem(ecKeyFile, ecKeyPair.getPrivate());
-
-    when(mockMTlsConfig.getCertPath()).thenReturn(ecCertFile.toString());
-    when(mockMTlsConfig.getKeyPath()).thenReturn(ecKeyFile.toString());
-
-    // When
-    SSLContext sslContext = sslContextFactory.createSSLContextWithClientCert(mockMTlsConfig);
-
-    // Then
-    assertNotNull(sslContext);
-    assertEquals("TLS", sslContext.getProtocol());
-  }
-
-  @Test
   void testCreateSSLContextWithClientCert_CertificateWithExtraWhitespace() throws IOException {
-    // Given - write certificate with extra whitespace
-    String certContent = toPemFormat(testCertificate, "CERTIFICATE");
-    String certWithWhitespace = certContent.replace("\n", "\n  \t  "); // Add extra whitespace
+    // Given - read fake certificate and add extra whitespace
+    String fakeCertContent = Files.readString(Path.of(FAKE_CERT_PATH));
+    String certWithWhitespace = fakeCertContent.replace("\n", "\n  \t  "); // Add extra whitespace
+    Path certFile = tempDir.resolve("whitespace.crt");
     Files.writeString(certFile, certWithWhitespace);
+    when(mockMTlsConfig.getCertPath()).thenReturn(certFile.toString());
 
     // When
     SSLContext sslContext = sslContextFactory.createSSLContextWithClientCert(mockMTlsConfig);
@@ -216,10 +167,12 @@ class SSLContextFactoryTest {
 
   @Test
   void testCreateSSLContextWithClientCert_PrivateKeyWithExtraWhitespace() throws IOException {
-    // Given - write private key with extra whitespace
-    String keyContent = toPemFormat(testKeyPair.getPrivate(), "PRIVATE KEY");
-    String keyWithWhitespace = keyContent.replace("\n", "\n  \t  "); // Add extra whitespace
+    // Given - read fake private key and add extra whitespace
+    String fakeKeyContent = Files.readString(Path.of(FAKE_KEY_PATH));
+    String keyWithWhitespace = fakeKeyContent.replace("\n", "\n  \t  "); // Add extra whitespace
+    Path keyFile = tempDir.resolve("whitespace.key");
     Files.writeString(keyFile, keyWithWhitespace);
+    when(mockMTlsConfig.getKeyPath()).thenReturn(keyFile.toString());
 
     // When
     SSLContext sslContext = sslContextFactory.createSSLContextWithClientCert(mockMTlsConfig);
@@ -227,93 +180,5 @@ class SSLContextFactoryTest {
     // Then
     assertNotNull(sslContext);
     assertEquals("TLS", sslContext.getProtocol());
-  }
-
-  private void generateTestKeyPairAndCertificate() throws Exception {
-    KeyPairGenerator keyGen = KeyPairGenerator.getInstance("RSA");
-    keyGen.initialize(2048);
-    testKeyPair = keyGen.generateKeyPair();
-
-    testCertificate = createSelfSignedCertificate(testKeyPair, "RSA");
-  }
-
-  @SuppressWarnings("deprecation") // X509V3CertificateGenerator is deprecated but needed for test
-  private X509Certificate createSelfSignedCertificate(KeyPair keyPair, String algorithm)
-      throws Exception {
-    X500Name subject = new X500Name("CN=Test Certificate");
-    BigInteger serial = BigInteger.valueOf(new SecureRandom().nextLong());
-    Date notBefore = Date.from(Instant.now());
-    Date notAfter = Date.from(Instant.now().plus(365, ChronoUnit.DAYS));
-
-    SubjectPublicKeyInfo subjectPublicKeyInfo =
-        SubjectPublicKeyInfo.getInstance(keyPair.getPublic().getEncoded());
-
-    X509v3CertificateBuilder certBuilder =
-        new X509v3CertificateBuilder(
-            subject, // issuer
-            serial,
-            notBefore,
-            notAfter,
-            subject, // subject
-            subjectPublicKeyInfo);
-
-    ContentSigner signer =
-        new JcaContentSignerBuilder(getSignatureAlgorithm(algorithm))
-            .setProvider("BC")
-            .build(keyPair.getPrivate());
-
-    X509CertificateHolder certHolder = certBuilder.build(signer);
-
-    return new JcaX509CertificateConverter().setProvider("BC").getCertificate(certHolder);
-  }
-
-  private String getSignatureAlgorithm(String algorithm) {
-    switch (algorithm) {
-      case "RSA":
-        return "SHA256withRSA";
-      case "EC":
-        return "SHA256withECDSA";
-      case "DSA":
-        return "SHA256withDSA";
-      default:
-        return "SHA256with" + algorithm;
-    }
-  }
-
-  private void writeCertificatePem(Path file, X509Certificate certificate) throws IOException {
-    String pemContent = toPemFormat(certificate, "CERTIFICATE");
-    Files.writeString(file, pemContent);
-  }
-
-  private void writePrivateKeyPem(Path file, PrivateKey privateKey) throws IOException {
-    String pemContent = toPemFormat(privateKey, "PRIVATE KEY");
-    Files.writeString(file, pemContent);
-  }
-
-  private String toPemFormat(Object obj, String type) throws IOException {
-    byte[] encoded;
-    if (obj instanceof X509Certificate) {
-      try {
-        encoded = ((X509Certificate) obj).getEncoded();
-      } catch (Exception e) {
-        throw new IOException("Failed to encode certificate", e);
-      }
-    } else if (obj instanceof PrivateKey) {
-      encoded = ((PrivateKey) obj).getEncoded();
-    } else {
-      throw new IllegalArgumentException("Unsupported object type: " + obj.getClass());
-    }
-
-    String base64 = Base64.getEncoder().encodeToString(encoded);
-    StringBuilder pem = new StringBuilder();
-    pem.append("-----BEGIN ").append(type).append("-----\n");
-
-    for (int i = 0; i < base64.length(); i += 64) {
-      int end = Math.min(i + 64, base64.length());
-      pem.append(base64, i, end).append("\n");
-    }
-
-    pem.append("-----END ").append(type).append("-----\n");
-    return pem.toString();
   }
 }

--- a/service/src/test/java/bio/terra/drshub/services/SSLContextFactoryTest.java
+++ b/service/src/test/java/bio/terra/drshub/services/SSLContextFactoryTest.java
@@ -1,0 +1,319 @@
+package bio.terra.drshub.services;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import bio.terra.drshub.config.MTlsConfig;
+import java.io.IOException;
+import java.math.BigInteger;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.PrivateKey;
+import java.security.SecureRandom;
+import java.security.Security;
+import java.security.cert.X509Certificate;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Base64;
+import java.util.Date;
+import javax.net.ssl.SSLContext;
+import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
+import org.bouncycastle.cert.X509CertificateHolder;
+import org.bouncycastle.cert.X509v3CertificateBuilder;
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.operator.ContentSigner;
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+@Tag("Unit")
+class SSLContextFactoryTest {
+
+  private SSLContextFactory sslContextFactory;
+  private MTlsConfig mockMTlsConfig;
+
+  @TempDir Path tempDir;
+
+  private Path certFile;
+  private Path keyFile;
+  private KeyPair testKeyPair;
+  private X509Certificate testCertificate;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    // Add BouncyCastle provider for certificate generation
+    Security.addProvider(new BouncyCastleProvider());
+
+    sslContextFactory = new SSLContextFactory();
+    mockMTlsConfig = mock(MTlsConfig.class);
+
+    // Generate test key pair and certificate
+    generateTestKeyPairAndCertificate();
+
+    // Create temporary files
+    certFile = tempDir.resolve("test.crt");
+    keyFile = tempDir.resolve("test.key");
+
+    // Write PEM files
+    writeCertificatePem(certFile, testCertificate);
+    writePrivateKeyPem(keyFile, testKeyPair.getPrivate());
+
+    // Setup mock config
+    when(mockMTlsConfig.getCertPath()).thenReturn(certFile.toString());
+    when(mockMTlsConfig.getKeyPath()).thenReturn(keyFile.toString());
+  }
+
+  @Test
+  void testCreateSSLContextWithClientCert_Success() {
+    // When
+    SSLContext sslContext = sslContextFactory.createSSLContextWithClientCert(mockMTlsConfig);
+
+    // Then
+    assertNotNull(sslContext);
+    assertEquals("TLS", sslContext.getProtocol());
+  }
+
+  @Test
+  void testCreateSSLContextWithClientCert_InvalidCertificatePath() {
+    // Given
+    when(mockMTlsConfig.getCertPath()).thenReturn("/nonexistent/cert.pem");
+
+    // When & Then
+    RuntimeException exception =
+        assertThrows(
+            RuntimeException.class,
+            () -> sslContextFactory.createSSLContextWithClientCert(mockMTlsConfig));
+
+    assertTrue(
+        exception.getMessage().contains("Failed to create SSL context with client certificate"));
+  }
+
+  @Test
+  void testCreateSSLContextWithClientCert_InvalidPrivateKeyPath() {
+    // Given
+    when(mockMTlsConfig.getKeyPath()).thenReturn("/nonexistent/key.pem");
+
+    // When & Then
+    RuntimeException exception =
+        assertThrows(
+            RuntimeException.class,
+            () -> sslContextFactory.createSSLContextWithClientCert(mockMTlsConfig));
+
+    assertTrue(
+        exception.getMessage().contains("Failed to create SSL context with client certificate"));
+  }
+
+  @Test
+  void testCreateSSLContextWithClientCert_InvalidCertificateContent() throws IOException {
+    // Given - write invalid certificate content
+    Files.writeString(
+        certFile, "-----BEGIN CERTIFICATE-----\nINVALID_CONTENT\n-----END CERTIFICATE-----");
+
+    // When & Then
+    RuntimeException exception =
+        assertThrows(
+            RuntimeException.class,
+            () -> sslContextFactory.createSSLContextWithClientCert(mockMTlsConfig));
+
+    assertTrue(
+        exception.getMessage().contains("Failed to create SSL context with client certificate"));
+  }
+
+  @Test
+  void testCreateSSLContextWithClientCert_InvalidPrivateKeyContent() throws IOException {
+    // Given - write invalid private key content
+    Files.writeString(
+        keyFile, "-----BEGIN PRIVATE KEY-----\nINVALID_CONTENT\n-----END PRIVATE KEY-----");
+
+    // When & Then
+    RuntimeException exception =
+        assertThrows(
+            RuntimeException.class,
+            () -> sslContextFactory.createSSLContextWithClientCert(mockMTlsConfig));
+
+    assertTrue(
+        exception.getMessage().contains("Failed to create SSL context with client certificate"));
+  }
+
+  @Test
+  void testCreateSSLContextWithClientCert_MissingCertificateBlock() throws IOException {
+    // Given - write content without proper PEM block
+    Files.writeString(certFile, "This is not a PEM certificate");
+
+    // When & Then
+    RuntimeException exception =
+        assertThrows(
+            RuntimeException.class,
+            () -> sslContextFactory.createSSLContextWithClientCert(mockMTlsConfig));
+
+    assertTrue(
+        exception.getMessage().contains("Failed to create SSL context with client certificate"));
+  }
+
+  @Test
+  void testCreateSSLContextWithClientCert_MissingPrivateKeyBlock() throws IOException {
+    // Given - write content without proper PEM block
+    Files.writeString(keyFile, "This is not a PEM private key");
+
+    // When & Then
+    RuntimeException exception =
+        assertThrows(
+            RuntimeException.class,
+            () -> sslContextFactory.createSSLContextWithClientCert(mockMTlsConfig));
+
+    assertTrue(
+        exception.getMessage().contains("Failed to create SSL context with client certificate"));
+  }
+
+  @Test
+  void testCreateSSLContextWithClientCert_ECKeySupport() throws Exception {
+    // Given - generate EC key pair
+    KeyPairGenerator ecKeyGen = KeyPairGenerator.getInstance("EC");
+    ecKeyGen.initialize(256);
+    KeyPair ecKeyPair = ecKeyGen.generateKeyPair();
+
+    // Create certificate with EC key
+    X509Certificate ecCertificate = createSelfSignedCertificate(ecKeyPair, "EC");
+
+    // Write EC PEM files
+    Path ecCertFile = tempDir.resolve("ec_test.crt");
+    Path ecKeyFile = tempDir.resolve("ec_test.key");
+
+    writeCertificatePem(ecCertFile, ecCertificate);
+    writePrivateKeyPem(ecKeyFile, ecKeyPair.getPrivate());
+
+    when(mockMTlsConfig.getCertPath()).thenReturn(ecCertFile.toString());
+    when(mockMTlsConfig.getKeyPath()).thenReturn(ecKeyFile.toString());
+
+    // When
+    SSLContext sslContext = sslContextFactory.createSSLContextWithClientCert(mockMTlsConfig);
+
+    // Then
+    assertNotNull(sslContext);
+    assertEquals("TLS", sslContext.getProtocol());
+  }
+
+  @Test
+  void testCreateSSLContextWithClientCert_CertificateWithExtraWhitespace() throws IOException {
+    // Given - write certificate with extra whitespace
+    String certContent = toPemFormat(testCertificate, "CERTIFICATE");
+    String certWithWhitespace = certContent.replace("\n", "\n  \t  "); // Add extra whitespace
+    Files.writeString(certFile, certWithWhitespace);
+
+    // When
+    SSLContext sslContext = sslContextFactory.createSSLContextWithClientCert(mockMTlsConfig);
+
+    // Then
+    assertNotNull(sslContext);
+    assertEquals("TLS", sslContext.getProtocol());
+  }
+
+  @Test
+  void testCreateSSLContextWithClientCert_PrivateKeyWithExtraWhitespace() throws IOException {
+    // Given - write private key with extra whitespace
+    String keyContent = toPemFormat(testKeyPair.getPrivate(), "PRIVATE KEY");
+    String keyWithWhitespace = keyContent.replace("\n", "\n  \t  "); // Add extra whitespace
+    Files.writeString(keyFile, keyWithWhitespace);
+
+    // When
+    SSLContext sslContext = sslContextFactory.createSSLContextWithClientCert(mockMTlsConfig);
+
+    // Then
+    assertNotNull(sslContext);
+    assertEquals("TLS", sslContext.getProtocol());
+  }
+
+  private void generateTestKeyPairAndCertificate() throws Exception {
+    KeyPairGenerator keyGen = KeyPairGenerator.getInstance("RSA");
+    keyGen.initialize(2048);
+    testKeyPair = keyGen.generateKeyPair();
+
+    testCertificate = createSelfSignedCertificate(testKeyPair, "RSA");
+  }
+
+  @SuppressWarnings("deprecation") // X509V3CertificateGenerator is deprecated but needed for test
+  private X509Certificate createSelfSignedCertificate(KeyPair keyPair, String algorithm)
+      throws Exception {
+    X500Name subject = new X500Name("CN=Test Certificate");
+    BigInteger serial = BigInteger.valueOf(new SecureRandom().nextLong());
+    Date notBefore = Date.from(Instant.now());
+    Date notAfter = Date.from(Instant.now().plus(365, ChronoUnit.DAYS));
+
+    SubjectPublicKeyInfo subjectPublicKeyInfo =
+        SubjectPublicKeyInfo.getInstance(keyPair.getPublic().getEncoded());
+
+    X509v3CertificateBuilder certBuilder =
+        new X509v3CertificateBuilder(
+            subject, // issuer
+            serial,
+            notBefore,
+            notAfter,
+            subject, // subject
+            subjectPublicKeyInfo);
+
+    ContentSigner signer =
+        new JcaContentSignerBuilder(getSignatureAlgorithm(algorithm))
+            .setProvider("BC")
+            .build(keyPair.getPrivate());
+
+    X509CertificateHolder certHolder = certBuilder.build(signer);
+
+    return new JcaX509CertificateConverter().setProvider("BC").getCertificate(certHolder);
+  }
+
+  private String getSignatureAlgorithm(String algorithm) {
+    switch (algorithm) {
+      case "RSA":
+        return "SHA256withRSA";
+      case "EC":
+        return "SHA256withECDSA";
+      case "DSA":
+        return "SHA256withDSA";
+      default:
+        return "SHA256with" + algorithm;
+    }
+  }
+
+  private void writeCertificatePem(Path file, X509Certificate certificate) throws IOException {
+    String pemContent = toPemFormat(certificate, "CERTIFICATE");
+    Files.writeString(file, pemContent);
+  }
+
+  private void writePrivateKeyPem(Path file, PrivateKey privateKey) throws IOException {
+    String pemContent = toPemFormat(privateKey, "PRIVATE KEY");
+    Files.writeString(file, pemContent);
+  }
+
+  private String toPemFormat(Object obj, String type) throws IOException {
+    byte[] encoded;
+    if (obj instanceof X509Certificate) {
+      try {
+        encoded = ((X509Certificate) obj).getEncoded();
+      } catch (Exception e) {
+        throw new IOException("Failed to encode certificate", e);
+      }
+    } else if (obj instanceof PrivateKey) {
+      encoded = ((PrivateKey) obj).getEncoded();
+    } else {
+      throw new IllegalArgumentException("Unsupported object type: " + obj.getClass());
+    }
+
+    String base64 = Base64.getEncoder().encodeToString(encoded);
+    StringBuilder pem = new StringBuilder();
+    pem.append("-----BEGIN ").append(type).append("-----\n");
+
+    for (int i = 0; i < base64.length(); i += 64) {
+      int end = Math.min(i + 64, base64.length());
+      pem.append(base64, i, end).append("\n");
+    }
+
+    pem.append("-----END ").append(type).append("-----\n");
+    return pem.toString();
+  }
+}


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-400
https://broadworkbench.atlassian.net/browse/DT-1430

### Summary

Removes the `sslcontext-kickstart` dependency completely.

### Testing

I added unit tests and tested the functionality using the existing fake certificates; I also replaced the fake certificates with the real ones from dev and the tests pass.