### PR TITLE
[CTM-352] Don't return stack traces to user

### DIFF
--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -106,6 +106,11 @@ server:
     enabled: true
     mime-types: text/css,application/javascript
   port: 8080
+  error:
+    include-message: always
+    include-binding-errors: never
+    include-stacktrace: never
+    include-exception: false
   tomcat:
     # Tomcat defaults: https://docs.spring.io/spring-boot/docs/current/reference/html/application-properties.html#application-properties.server.server.tomcat.accept-count
     threads:
@@ -148,7 +153,7 @@ terra.common:
 # not-prod
 # we want this test passport provider in all non-prod envs
 # TDR is the only host that has specific values for each lower env
-spring.config.activate.on-profile: '!prod'
+spring.config.activate.on-profile: "!prod"
 drshub:
   drsProviders:
     passport:


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/CTM-352

Modifies Spring's `server.error` settings to prevent exposing stack traces and other system information when exceptions occur outside drshub's internal error-processing (which is handled in https://github.com/DataBiosphere/terra-drs-hub/blob/dev/service/src/main/java/bio/terra/drshub/controllers/GlobalExceptionHandler.java)

See https://gist.github.com/aoudiamoncef/bba3f7c79f1056a22a3a82b3a171b5b3 for information about the flags set.