### PR TITLE
[DT-3011] Add retry logic for `x-user-project` header when required by TDR

### DIFF
--- a/service/src/main/java/bio/terra/drshub/config/ProviderAccessMethodConfigInterface.java
+++ b/service/src/main/java/bio/terra/drshub/config/ProviderAccessMethodConfigInterface.java
@@ -4,6 +4,7 @@ import bio.terra.drshub.models.AccessMethodConfigTypeEnum;
 import bio.terra.drshub.models.DrsAuthEnum;
 import java.util.Optional;
 import org.immutables.value.Value;
+import org.immutables.value.Value.Default;
 
 @Value.Modifiable
 @PropertiesInterfaceStyle
@@ -15,4 +16,15 @@ public interface ProviderAccessMethodConfigInterface {
   boolean isFetchAccessUrl();
 
   Optional<DrsAuthEnum> getFallbackAuth();
+
+  /**
+   * When true, DrsHub first attempts the access-URL call WITHOUT forwarding x-user-project. If the
+   * provider returns 400 with an indication that the user project is required, DrsHub retries with
+   * the header. This allows TDR snapshots that set requireUserProject=true to direct DrsHub to bill
+   * the caller's project, without requiring callers to special-case TDR.
+   */
+  @Default
+  default boolean requiresUserProjectOnRetry() {
+    return false;
+  }
 }

--- a/service/src/main/java/bio/terra/drshub/services/DrsResolutionService.java
+++ b/service/src/main/java/bio/terra/drshub/services/DrsResolutionService.java
@@ -1,5 +1,6 @@
 package bio.terra.drshub.services;
 
+import static io.github.ga4gh.drs.model.Authorizations.SupportedTypesEnum.BEARERAUTH;
 import static org.apache.commons.lang3.ObjectUtils.isEmpty;
 
 import bio.terra.common.exception.BadRequestException;
@@ -12,6 +13,7 @@ import bio.terra.drshub.logging.AuditLogEvent;
 import bio.terra.drshub.logging.AuditLogEventType;
 import bio.terra.drshub.logging.AuditLogger;
 import bio.terra.drshub.models.AnnotatedResourceMetadata;
+import bio.terra.drshub.models.DrsApi;
 import bio.terra.drshub.models.DrsAuthEnum;
 import bio.terra.drshub.models.DrsHubAuthorization;
 import bio.terra.drshub.models.DrsMetadata;
@@ -35,6 +37,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.util.UriComponents;
 
@@ -275,49 +278,35 @@ public class DrsResolutionService {
 
     var drsApi = drsApiFactory.getApiFromUriComponents(uriComponents, drsProvider);
     var objectId = getObjectId(uriComponents);
+    var accessMethodConfig = drsProvider.getAccessMethodByType(accessMethodType);
+    boolean retryMode =
+        accessMethodConfig != null && accessMethodConfig.requiresUserProjectOnRetry();
 
-    if (ip != null) {
-      drsApi.setHeader("X-Forwarded-For", ip);
-    }
-    if (googleProject != null) {
+    // Set x-user-project immediately for providers that always want it
+    if (!retryMode && googleProject != null) {
       drsApi.setHeader("x-user-project", googleProject);
     }
-    drsApi.setHeader(TRANSACTION_ID_HEADER_NAME, transactionId);
+    addStandardHeaders(drsApi, ip, transactionId);
 
     for (var authorization : drsHubAuthorizations) {
-      Optional<List<String>> auth =
-          authorization.getAuthForAccessMethodType().apply(accessMethodType);
-      var accessUrl =
-          switch (authorization.drsAuthType()) {
-            case NONE -> drsApi.getAccessURL(objectId, accessId);
-            case BASICAUTH ->
-                throw new BadRequestException(
-                    "DRSHub does not support basic username/password authentication at this time.");
-            case BEARERAUTH -> {
-              drsApi.setBearerToken(
-                  auth.map(l -> l.get(0))
-                      .orElseThrow(
-                          () ->
-                              new BadRequestException(
-                                  String.format(
-                                      "Fence access token required for %s but is missing. Does user have an account linked in Bond?",
-                                      uriComponents.toUriString()))));
-              yield drsApi.getAccessURL(objectId, accessId);
-            }
-            case PASSPORTAUTH -> {
-              try {
-                yield auth.map(
-                        a -> drsApi.postAccessURL(Map.of("passports", a), objectId, accessId))
-                    .orElse(null);
-              } catch (RestClientException e) {
-                log.error(
-                    "Passport authorized request failed for {} with error {}",
-                    uriComponents.toUriString(),
-                    e.getMessage());
-                yield null;
-              }
-            }
-          };
+      AccessURL accessUrl;
+      try {
+        accessUrl =
+            callAccessUrl(
+                drsApi, objectId, accessId, authorization, accessMethodType, uriComponents);
+      } catch (HttpClientErrorException.BadRequest e) {
+        if (retryMode && googleProject != null && isRequireUserProjectError(e)) {
+          // Retry with a fresh client that includes x-user-project
+          var retryApi = drsApiFactory.getApiFromUriComponents(uriComponents, drsProvider);
+          addStandardHeaders(retryApi, ip, transactionId);
+          retryApi.setHeader("x-user-project", googleProject);
+          accessUrl =
+              callAccessUrl(
+                  retryApi, objectId, accessId, authorization, accessMethodType, uriComponents);
+        } else {
+          throw e;
+        }
+      }
       if (accessUrl != null) {
         auditLogEventBuilder.authType(
             drsProvider.getAccessMethodByType(accessMethodType).getAuth());
@@ -325,6 +314,58 @@ public class DrsResolutionService {
       }
     }
     return null;
+  }
+
+  private static AccessURL callAccessUrl(
+      DrsApi drsApi,
+      String objectId,
+      String accessId,
+      DrsHubAuthorization authorization,
+      TypeEnum accessMethodType,
+      UriComponents uriComponents) {
+    Optional<List<String>> auth =
+        authorization.getAuthForAccessMethodType().apply(accessMethodType);
+
+    return switch (authorization.drsAuthType()) {
+      case NONE -> drsApi.getAccessURL(objectId, accessId);
+      case BASICAUTH ->
+          throw new BadRequestException(
+              "DRSHub does not support basic username/password authentication at this time.");
+      case BEARERAUTH -> {
+        drsApi.setBearerToken(
+            auth.map(l -> l.get(0))
+                .orElseThrow(
+                    () ->
+                        new BadRequestException(
+                            String.format(
+                                "Fence access token required for %s but is missing. Does user have an account linked in Bond?",
+                                uriComponents.toUriString()))));
+        yield drsApi.getAccessURL(objectId, accessId);
+      }
+      case PASSPORTAUTH -> {
+        try {
+          yield auth.map(a -> drsApi.postAccessURL(Map.of("passports", a), objectId, accessId))
+              .orElse(null);
+        } catch (RestClientException e) {
+          log.error(
+              "Passport authorized request failed for {} with error {}",
+              uriComponents.toUriString(),
+              e.getMessage());
+          yield null;
+        }
+      }
+    };
+  }
+
+  private static boolean isRequireUserProjectError(HttpClientErrorException.BadRequest e) {
+    return e.getResponseBodyAsString().contains("Snapshot requires an x-user-project header");
+  }
+
+  private static void addStandardHeaders(DrsApi drsApi, String ip, String transactionId) {
+    if (ip != null) {
+      drsApi.setHeader("X-Forwarded-For", ip);
+    }
+    drsApi.setHeader(TRANSACTION_ID_HEADER_NAME, transactionId);
   }
 
   static String getObjectId(UriComponents uriComponents) {

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -50,9 +50,11 @@ drshub:
         - type: gs
           auth: current_request
           fetchAccessUrl: true
+          requiresUserProjectOnRetry: true
         - type: https
           auth: current_request
           fetchAccessUrl: true # Used for Azure
+          requiresUserProjectOnRetry: false  # Azure doesn't have requester-pays
     sage:
       name: Sage Bionetworks
       hostRegex: 'repo-dev\.dev\.sagebase\.org|repo-prod\.prod\.sagebase\.org'

--- a/service/src/test/java/bio/terra/drshub/services/DrsResolutionServiceTest.java
+++ b/service/src/test/java/bio/terra/drshub/services/DrsResolutionServiceTest.java
@@ -2,6 +2,7 @@ package bio.terra.drshub.services;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -42,6 +43,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
+import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.util.UriComponents;
 
@@ -341,5 +343,184 @@ class DrsResolutionServiceTest {
     verify(drsApi, never()).setHeader("X-Forwarded-For", ip);
     verify(drsApi, never()).setHeader("x-user-project", googleProject);
     verify(drsApi).setHeader(DrsResolutionService.TRANSACTION_ID_HEADER_NAME, TRANSACTION_ID);
+  }
+
+  @Test
+  void testTdrWithRequireUserProject_firstCallSucceeds() {
+    // First call succeeds, so no retry needed and x-user-project header not sent
+    var ip = "test.ip";
+    var googleProject = "test-google-project";
+    var tdrProvider = createTdrProviderWithRetryMode();
+
+    SignedUrlTestUtils.setupSignedUrlMocks(authService, googleStorageService, googleProject, url);
+    when(drsApi.getAccessURL(PATH, accessId)).thenReturn(new AccessURL().url(url.toString()));
+
+    var response =
+        drsResolutionService.fetchDrsObjectAccessUrl(
+            tdrProvider,
+            uriComponents,
+            accessId,
+            TypeEnum.GS,
+            List.of(BEARERAUTH),
+            new AuditLogEvent.Builder(),
+            ip,
+            googleProject,
+            TRANSACTION_ID);
+
+    assertThat("signed url is properly returned", response.getUrl(), equalTo(url.toString()));
+    verify(drsApi, never()).setHeader("x-user-project", googleProject);
+  }
+
+  @Test
+  void testTdrWithRequireUserProject_retrySucceeds() {
+    // Retry with x-user-project header after initial 400 "requireUserProject" error
+    var ip = "test.ip";
+    var googleProject = "test-google-project";
+    var tdrProvider = createTdrProviderWithRetryMode();
+    var retryApi = mock(DrsApi.class);
+
+    DrsApiFactory drsApiFactory = mock(DrsApiFactory.class);
+    when(drsApiFactory.getApiFromUriComponents(eq(uriComponents), any(DrsProvider.class)))
+        .thenReturn(drsApi)
+        .thenReturn(retryApi);
+
+    drsResolutionService =
+        new DrsResolutionService(drsApiFactory, authService, mock(AuditLogger.class));
+
+    SignedUrlTestUtils.setupSignedUrlMocks(authService, googleStorageService, googleProject, url);
+    when(drsApi.getAccessURL(PATH, accessId))
+        .thenThrow(
+            HttpClientErrorException.create(
+                org.springframework.http.HttpStatus.BAD_REQUEST,
+                "BadRequest",
+                org.springframework.http.HttpHeaders.EMPTY,
+                "Snapshot requires an x-user-project header".getBytes(),
+                null));
+    when(retryApi.getAccessURL(PATH, accessId)).thenReturn(new AccessURL().url(url.toString()));
+
+    var response =
+        drsResolutionService.fetchDrsObjectAccessUrl(
+            tdrProvider,
+            uriComponents,
+            accessId,
+            TypeEnum.GS,
+            List.of(BEARERAUTH),
+            new AuditLogEvent.Builder(),
+            ip,
+            googleProject,
+            TRANSACTION_ID);
+
+    assertThat(
+        "signed url is properly returned after retry", response.getUrl(), equalTo(url.toString()));
+    verify(drsApi, never()).setHeader("x-user-project", googleProject);
+    verify(retryApi).setHeader("x-user-project", googleProject);
+    verify(retryApi).setHeader("X-Forwarded-For", ip);
+    verify(retryApi).setHeader(DrsResolutionService.TRANSACTION_ID_HEADER_NAME, TRANSACTION_ID);
+  }
+
+  @Test
+  void testTdrWithRequireUserProject_noGoogleProject() {
+    // No retry without googleProject, even if error indicates it's needed
+    var ip = "test.ip";
+    String googleProject = null;
+    var tdrProvider = createTdrProviderWithRetryMode();
+
+    when(drsApi.getAccessURL(PATH, accessId))
+        .thenThrow(
+            HttpClientErrorException.create(
+                org.springframework.http.HttpStatus.BAD_REQUEST,
+                "BadRequest",
+                org.springframework.http.HttpHeaders.EMPTY,
+                "Snapshot requires an x-user-project header".getBytes(),
+                null));
+
+    assertThrows(
+        HttpClientErrorException.BadRequest.class,
+        () ->
+            drsResolutionService.fetchDrsObjectAccessUrl(
+                tdrProvider,
+                uriComponents,
+                accessId,
+                TypeEnum.GS,
+                List.of(BEARERAUTH),
+                new AuditLogEvent.Builder(),
+                ip,
+                googleProject,
+                TRANSACTION_ID));
+
+    verify(drsApi, never()).setHeader(eq("x-user-project"), any());
+  }
+
+  @Test
+  void testTdrWithRequireUserProject_unrelated400() {
+    // Unrelated 400 error should not trigger retry
+    var ip = "test.ip";
+    var googleProject = "test-google-project";
+    var tdrProvider = createTdrProviderWithRetryMode();
+
+    when(drsApi.getAccessURL(PATH, accessId))
+        .thenThrow(
+            HttpClientErrorException.create(
+                org.springframework.http.HttpStatus.BAD_REQUEST,
+                "BadRequest",
+                null,
+                "Some other error message".getBytes(),
+                null));
+
+    assertThrows(
+        HttpClientErrorException.BadRequest.class,
+        () ->
+            drsResolutionService.fetchDrsObjectAccessUrl(
+                tdrProvider,
+                uriComponents,
+                accessId,
+                TypeEnum.GS,
+                List.of(BEARERAUTH),
+                new AuditLogEvent.Builder(),
+                ip,
+                googleProject,
+                TRANSACTION_ID));
+
+    verify(drsApi, never()).setHeader(eq("x-user-project"), any());
+  }
+
+  @Test
+  void testNonTdrProviderAlwaysForwards() throws Exception {
+    // Non-TDR provider always sends x-user-project header on first call
+    var ip = "test.ip";
+    var googleProject = "test-google-project";
+
+    SignedUrlTestUtils.setupSignedUrlMocks(authService, googleStorageService, googleProject, url);
+    when(drsApi.getAccessURL(PATH, accessId)).thenReturn(new AccessURL().url(url.toString()));
+
+    var response =
+        drsResolutionService.fetchDrsObjectAccessUrl(
+            testDrsProvider, // This provider doesn't have requiresUserProjectOnRetry
+            uriComponents,
+            accessId,
+            TypeEnum.GS,
+            List.of(BEARERAUTH),
+            new AuditLogEvent.Builder(),
+            ip,
+            googleProject,
+            TRANSACTION_ID);
+
+    assertThat("signed url is properly returned", response.getUrl(), equalTo(url.toString()));
+    verify(drsApi).setHeader("x-user-project", googleProject);
+  }
+
+  private DrsProvider createTdrProviderWithRetryMode() {
+    return DrsProvider.create()
+        .setMetadataAuthType(DrsAuthEnum.current_request)
+        .setName("tdr")
+        .setHostRegex(".*")
+        .setAccessMethodConfigs(
+            new ArrayList<>(
+                List.of(
+                    ProviderAccessMethodConfig.create()
+                        .setType(AccessMethodConfigTypeEnum.gs)
+                        .setAuth(DrsAuthEnum.current_request)
+                        .setFetchAccessUrl(true)
+                        .setRequiresUserProjectOnRetry(true))));
   }
 }


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-3011

### Summary

This PR adds logic in DrsHub to send the `x-user-project` header to TDR only when it is required.

DrsHub first requests without the header. If TDR returns a 400 Bad Request indicating that a header is required, DrsHub retries the request with the `x-user-project` header included.