### PR TITLE
[CTM-382] Move x-user-project header to request body for resolve endpoint

### DIFF
--- a/common/openapi.yml
+++ b/common/openapi.yml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: drsHub
-  version: 2.0.0
+  version: 3.0.0
 paths:
   /api/v4/drs/resolve:
     post:

--- a/common/openapi.yml
+++ b/common/openapi.yml
@@ -204,6 +204,12 @@ components:
           type: array
           items:
             type: string
+        userProject:
+          description: >
+            For GCP-hosted files, the Google project to bill when accessing the signed URL (e.g. Terra billing project).
+            Only applies to GCP-hosted data.
+          type: string
+          nullable: true
 
     GetSignedUrlRequest:
       type: object

--- a/service/src/main/java/bio/terra/drshub/controllers/DrsHubApiController.java
+++ b/service/src/main/java/bio/terra/drshub/controllers/DrsHubApiController.java
@@ -33,13 +33,19 @@ public record DrsHubApiController(
   @Override
   @TrackCall
   public ResponseEntity<ResourceMetadata> resolveDrs(RequestObject body) {
+    var xUserProjectHeader = request.getHeader("x-user-project");
+    if (xUserProjectHeader != null && !xUserProjectHeader.isBlank()) {
+      throw new BadRequestException(
+          "The x-user-project header is no longer supported. Please send userProject in the request body instead.");
+    }
+
     var bearerToken = bearerTokenFactory.from(request);
     validateRequest(body);
 
     var userAgent = request.getHeader("user-agent");
     var forceAccessUrl = Objects.equals(request.getHeader("drshub-force-access-url"), "true");
     var ip = request.getHeader("X-Forwarded-For");
-    var googleProject = request.getHeader("x-user-project");
+    var googleProject = body.getUserProject();
     var serviceName = RequestUtils.serviceNameFromRequest(request);
 
     log.info(

--- a/service/src/test/java/bio/terra/drshub/controllers/DrsHubApiControllerTest.java
+++ b/service/src/test/java/bio/terra/drshub/controllers/DrsHubApiControllerTest.java
@@ -489,6 +489,46 @@ public class DrsHubApiControllerTest extends BaseTest {
   }
 
   @Test
+  void testAcceptsUserProjectInRequestBody() throws Exception {
+    var drsHost = TDR_TEST_HOST;
+    var drsObject = drsObjectWithId("some-object-id", "gs");
+    var expectedDrsUri = "drs://" + drsHost + "/some-object-id";
+    var requestBody =
+        objectMapper.writeValueAsString(
+            Map.of(
+                "url",
+                expectedDrsUri,
+                "fields",
+                List.of(Fields.CONTENT_TYPE),
+                "userProject",
+                "my-billing-project"));
+
+    mockDrsApiRestTemplate(drsHost, drsObject);
+    postDrsHubRequestRaw(TEST_ACCESS_TOKEN, requestBody).andExpect(status().isOk());
+  }
+
+  @Test
+  void testReturns400IfXUserProjectHeaderIsSent() throws Exception {
+    var cidProviderHost = getProviderHosts("kidsFirst");
+    var requestBody =
+        objectMapper.writeValueAsString(
+            Map.of(
+                "url",
+                String.format("drs://%s:%s", cidProviderHost.compactUriPrefix(), UUID.randomUUID()),
+                "fields",
+                List.of(Fields.CONTENT_TYPE)));
+
+    mvc.perform(
+            post("/api/v4/drs/resolve")
+                .header("authorization", "bearer " + TEST_ACCESS_TOKEN)
+                .header("x-user-project", "my-billing-project")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody))
+        .andExpect(status().isBadRequest())
+        .andExpect(content().string(org.hamcrest.Matchers.containsString("x-user-project header")));
+  }
+
+  @Test
   void testShouldReturnUnderlyingStatusIfDataObjectResolutionFails() throws Exception {
     var cidList = new ArrayList<>(config.getCompactIdHosts().keySet());
     var cid = cidList.get(new Random().nextInt(cidList.size()));


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CTM-382
See [this slack thread](https://manifoldai.slack.com/archives/C0AFWENAU81/p1773334817634759) for context.
https://github.com/DataBiosphere/terra-ui/pull/5491 is dependent on this PR. 

Note: This will not be merged until logs are reviewed and a decision is made.

Tests: 
Unit tests
Tested locally by connecting to a locally running terra-ui on branch rj/ctm-382-userProject-DRS
- In the case where the user is a reader, the endpoint was not called.
- In the case where the user is a writer/owner, the endpoint was successfully called with the userProject in the request body. The accessUrl returned contained that userProject. 