### PR TITLE
CTM-405: bump Spring Boot 3.5.8->3.5.11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
 	id 'idea'
 
 	id 'io.spring.dependency-management' version '1.1.7' apply false
-	id 'org.springframework.boot' version '3.5.8' apply false
+	id 'org.springframework.boot' version '3.5.9' apply false
 	id 'com.diffplug.spotless' version '8.0.0' apply false
 	// ^^ for some reason, can't use spotless in multiple subprojects without this ^^
 	id 'com.google.cloud.tools.jib' version '3.5.3' apply false

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
 	id 'idea'
 
 	id 'io.spring.dependency-management' version '1.1.7' apply false
-	id 'org.springframework.boot' version '3.5.9' apply false
+	id 'org.springframework.boot' version '3.5.11' apply false
 	id 'com.diffplug.spotless' version '8.0.0' apply false
 	// ^^ for some reason, can't use spotless in multiple subprojects without this ^^
 	id 'com.google.cloud.tools.jib' version '3.5.3' apply false


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/CTM-405

Bumps Spring Boot from 3.5.8 -> 3.5.11. This also bumps transitive dependency `org.apache.tomcat.embed:tomcat-embed-core` to 10.1.52, which satisfies CTM-405.