### PR TITLE
[CTM-412] CompileJava error

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Some architecture diagrams can be found in [LucidChart](https://lucid.app/docume
 ## Development
 
 ### Setup
-Install Java 17 SDK from your preferred provider. A common way to install and manage different JDK versions is to use [sdkman](https://sdkman.io/).
+Install Java 17 SDK (**17.0.2 or later**; 17.0.0 and 17.0.1 hit a compiler bug with records + Immutables and will fail with a typeSig ERROR during compileJava). A common way to install and manage different JDK versions is to use [sdkman](https://sdkman.io/).
 
 If developing in IntelliJ, you can configure the Project SDK to use Java 17.
 You'll also need to set the Gradle JVM, located at `Preferences | Build, Execution, Deployment | Build Tools | Gradle`.

--- a/build.gradle
+++ b/build.gradle
@@ -12,19 +12,6 @@ plugins {
 	id 'org.sonarqube' version '7.2.2.6593' apply false
 }
 
-// Fail fast on Java 17.0.0/17.0.1: compiler bug JDK-8273408 (typeSig ERROR) with records + Immutables.
-// Fixed in JDK 17.0.2. See https://bugs.openjdk.org/browse/JDK-8273408
-def versionStr = Runtime.version().toString()
-def parts = versionStr.split(/\./)
-def feature = parts[0].replaceAll(/[^0-9].*/, '').toInteger()
-def update = parts.length >= 3 ? parts[2].replaceAll(/[^0-9].*/, '').toInteger() : 0
-if (feature == 17 && update < 2) {
-	throw new GradleException(
-		"Java 17.0." + update + " is too old. This project uses records and Immutables, which trigger " +
-		"a compiler bug (typeSig ERROR) in Java 17.0.0 and 17.0.1. Please use Java 17.0.2 or later."
-	)
-}
-
 repositories { mavenCentral() }
 
 subprojects {

--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,19 @@ plugins {
 	id 'org.sonarqube' version '7.2.2.6593' apply false
 }
 
+// Fail fast on Java 17.0.0/17.0.1: compiler bug JDK-8273408 (typeSig ERROR) with records + Immutables.
+// Fixed in JDK 17.0.2. See https://bugs.openjdk.org/browse/JDK-8273408
+def versionStr = Runtime.version().toString()
+def parts = versionStr.split(/\./)
+def feature = parts[0].replaceAll(/[^0-9].*/, '').toInteger()
+def update = parts.length >= 3 ? parts[2].replaceAll(/[^0-9].*/, '').toInteger() : 0
+if (feature == 17 && update < 2) {
+	throw new GradleException(
+		"Java 17.0." + update + " is too old. This project uses records and Immutables, which trigger " +
+		"a compiler bug (typeSig ERROR) in Java 17.0.0 and 17.0.1. Please use Java 17.0.2 or later."
+	)
+}
+
 repositories { mavenCentral() }
 
 subprojects {


### PR DESCRIPTION
Ticket: 
https://broadworkbench.atlassian.net/browse/CTM-412

Addresses: 
https://github.com/immutables/immutables/issues/1331 
Compile bug in version 17.0.0 and 17.0.1 java - use version 17.0.2 instead

Changes:
Specify version in readme
Note: I did add an error in the build.gradle file when compiled with version 17.0.0 or 17.0.1, but then I removed it because this compile bug may not occur consistently so I didn't want to just add more failures. But I could add it back if we think providing that clearer error message would be helpful. (see first commit)