### PR TITLE
CTM-395: BDC auth now prefers passport, falls back to fence

### DIFF
--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -20,8 +20,9 @@ drshub:
       ecmProvider: fence
       accessMethodConfigs:
         - type: gs
-          auth: provider_access_token
+          auth: passport
           fetchAccessUrl: true
+          fallbackAuth: provider_access_token
     crdc:
       name: NCI Cancer Research / Proteomics Data Commons (CRDC / PDC)
       hostRegex: '.*\.datacommons\.io'


### PR DESCRIPTION
CTM-395

Change the config for BDC to try passport first, then fall back to fence.
