### PR TITLE
Revert "CTM-395: BDC auth now prefers passport, falls back to fence"

### DIFF
--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -20,9 +20,8 @@ drshub:
       ecmProvider: fence
       accessMethodConfigs:
         - type: gs
-          auth: passport
+          auth: provider_access_token
           fetchAccessUrl: true
-          fallbackAuth: provider_access_token
     crdc:
       name: NCI Cancer Research / Proteomics Data Commons (CRDC / PDC)
       hostRegex: '.*\.datacommons\.io'


### PR DESCRIPTION
Reverts DataBiosphere/terra-drs-hub#234