### PR TITLE
CTM-395: in dev only, BDC auth now prefers passport, falls back to fence

### DIFF
--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -197,6 +197,16 @@ drshub:
   compactIdHosts:
     "drs.anv0": jade.datarepo-dev.broadinstitute.org
     "dg.anv0": jade.datarepo-dev.broadinstitute.org
+  drsProviders:
+    bioDataCatalyst:
+      name: BioData Catalyst (BDC)
+      hostRegex: '.*\.biodatacatalyst\.nhlbi\.nih\.gov|wb-mock-drs-dev\.storage\.googleapis\.com'
+      ecmProvider: fence
+      accessMethodConfigs:
+        - type: gs
+          auth: passport
+          fetchAccessUrl: true
+          fallbackAuth: provider_access_token
 ---
 # staging
 spring.config.activate.on-profile: staging


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/CTM-395

This is a redo of #234, which I reverted.

This PR makes the same change, but makes it in the dev environment only. This change will therefore not release to staging or production.