### PR TITLE
DT-400: update to gradle 8.14.4

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.4-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/integration/build.gradle
+++ b/integration/build.gradle
@@ -3,7 +3,7 @@ plugins {
 	id 'application'
 	id 'io.freefair.lombok'
 	id 'com.diffplug.spotless'
-	id 'bio.terra.test-runner-plugin' version '0.1.3-SNAPSHOT'
+	id 'bio.terra.test-runner-plugin' version '0.2.2-SNAPSHOT'
 }
 
 repositories {

--- a/integration/build.gradle
+++ b/integration/build.gradle
@@ -8,7 +8,7 @@ plugins {
 
 repositories {
 	mavenCentral()
-	maven { url 'https://us-central1-maven.pkg.dev/dsp-artifact-registry/libs-snapshot/' }
+	maven { url = 'https://us-central1-maven.pkg.dev/dsp-artifact-registry/libs-snapshot/' }
 }
 
 dependencies {

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -18,8 +18,8 @@ plugins {
 
 repositories {
 	mavenCentral()
-	maven { url 'https://us-central1-maven.pkg.dev/dsp-artifact-registry/libs-snapshot/' }
-	maven { url 'https://us-central1-maven.pkg.dev/dsp-artifact-registry/libs-release/' }
+	maven { url = 'https://us-central1-maven.pkg.dev/dsp-artifact-registry/libs-snapshot/' }
+	maven { url = 'https://us-central1-maven.pkg.dev/dsp-artifact-registry/libs-release/' }
 }
 
 

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -82,3 +82,7 @@ sonar {
 	}
 }
 
+srcclr {
+	scope = "runtimeClasspath"
+}
+

--- a/settings.gradle
+++ b/settings.gradle
@@ -9,7 +9,7 @@ pluginManagement {
 		}
 		mavenCentral()
 		maven {
-			url 'https://us-central1-maven.pkg.dev/dsp-artifact-registry/libs-snapshot/'
+			url = 'https://us-central1-maven.pkg.dev/dsp-artifact-registry/libs-snapshot/'
 		}
 		gradlePluginPortal()
 	}


### PR DESCRIPTION
Updates gradle from 7.6.4 to 8.14.4. To make this change work, I also had to:
* Update test-runner plugin from 0.1.3 to 0.2.2, since the older version is incompatible with Gradle 8.
* Tweak some syntax to avoid deprecation warnings in the newer version of Gradle.
* Define the SourceClear scan scope, since SourceClear started to fail. See [other usages](https://github.com/search?q=org%3ADataBiosphere%20srcclr&type=code) for comparison.

Note: the latest version of gradle is 9.x, not 8.x. This PR only updates to 8.x because the `org.hidetake.swagger.generator` plugin used by DRSHub seems to be incompatible with 9.x, and swapping out that plugin is a nontrivial change. Getting up to Gradle 8 is worthwhile on its own, as it _should_ unblock other PRs like #233