### PR TITLE
[CTM-473] Include bearer token with passport auth when googleProject is set

### DIFF
--- a/service/src/main/java/bio/terra/drshub/services/DrsResolutionService.java
+++ b/service/src/main/java/bio/terra/drshub/services/DrsResolutionService.java
@@ -370,12 +370,10 @@ public class DrsResolutionService {
             // Find BEARERAUTH authorization in the list to get the properly configured token
             Optional<String> bearerTokenOpt =
                 drsHubAuthorizations.stream()
-                    .filter(
-                        a -> a.drsAuthType() == Authorizations.SupportedTypesEnum.BEARERAUTH)
+                    .filter(a -> a.drsAuthType() == Authorizations.SupportedTypesEnum.BEARERAUTH)
                     .findFirst()
                     .flatMap(a -> a.getAuthForAccessMethodType().apply(accessMethodType))
-                    .flatMap(
-                        list -> list.isEmpty() ? Optional.empty() : Optional.of(list.get(0)));
+                    .flatMap(list -> list.isEmpty() ? Optional.empty() : Optional.of(list.get(0)));
             if (bearerTokenOpt.isPresent()) {
               log.info(
                   "Setting bearer token for passport auth request to {}",

--- a/service/src/main/java/bio/terra/drshub/services/DrsResolutionService.java
+++ b/service/src/main/java/bio/terra/drshub/services/DrsResolutionService.java
@@ -293,7 +293,14 @@ public class DrsResolutionService {
       try {
         accessUrl =
             callAccessUrl(
-                drsApi, objectId, accessId, authorization, accessMethodType, uriComponents);
+                drsApi,
+                objectId,
+                accessId,
+                authorization,
+                accessMethodType,
+                uriComponents,
+                googleProject,
+                drsHubAuthorizations);
       } catch (HttpClientErrorException.BadRequest e) {
         if (retryMode && googleProject != null && isRequireUserProjectError(e)) {
           // Retry with a fresh client that includes x-user-project
@@ -302,7 +309,14 @@ public class DrsResolutionService {
           retryApi.setHeader("x-user-project", googleProject);
           accessUrl =
               callAccessUrl(
-                  retryApi, objectId, accessId, authorization, accessMethodType, uriComponents);
+                  retryApi,
+                  objectId,
+                  accessId,
+                  authorization,
+                  accessMethodType,
+                  uriComponents,
+                  googleProject,
+                  drsHubAuthorizations);
         } else {
           throw e;
         }
@@ -322,7 +336,9 @@ public class DrsResolutionService {
       String accessId,
       DrsHubAuthorization authorization,
       TypeEnum accessMethodType,
-      UriComponents uriComponents) {
+      UriComponents uriComponents,
+      String googleProject,
+      List<DrsHubAuthorization> drsHubAuthorizations) {
     Optional<List<String>> auth =
         authorization.getAuthForAccessMethodType().apply(accessMethodType);
 
@@ -344,6 +360,33 @@ public class DrsResolutionService {
       }
       case PASSPORTAUTH -> {
         try {
+          // If googleProject is set, also send bearer token alongside passports to enable
+          // signing the access url with the userProject set with the right access
+          if (googleProject != null) {
+            log.info(
+                "Google project {} specified for passport auth request to {}. Attempting to include bearer token.",
+                googleProject,
+                uriComponents.toUriString());
+            // Find BEARERAUTH authorization in the list to get the properly configured token
+            Optional<String> bearerTokenOpt =
+                drsHubAuthorizations.stream()
+                    .filter(
+                        a -> a.drsAuthType() == Authorizations.SupportedTypesEnum.BEARERAUTH)
+                    .findFirst()
+                    .flatMap(a -> a.getAuthForAccessMethodType().apply(accessMethodType))
+                    .flatMap(
+                        list -> list.isEmpty() ? Optional.empty() : Optional.of(list.get(0)));
+            if (bearerTokenOpt.isPresent()) {
+              log.info(
+                  "Setting bearer token for passport auth request to {}",
+                  uriComponents.toUriString());
+              drsApi.setBearerToken(bearerTokenOpt.get());
+            } else {
+              log.warn(
+                  "Google project specified but no bearer token found in authorizations for {}",
+                  uriComponents.toUriString());
+            }
+          }
           yield auth.map(a -> drsApi.postAccessURL(Map.of("passports", a), objectId, accessId))
               .orElse(null);
         } catch (RestClientException e) {

--- a/service/src/test/java/bio/terra/drshub/services/DrsResolutionServiceTest.java
+++ b/service/src/test/java/bio/terra/drshub/services/DrsResolutionServiceTest.java
@@ -523,4 +523,72 @@ class DrsResolutionServiceTest {
                         .setFetchAccessUrl(true)
                         .setRequiresUserProjectOnRetry(true))));
   }
+
+  private static Stream<Arguments> passportAuthWithGoogleProject() {
+    return Stream.of(
+        Arguments.of("test-project", true), // googleProject set, bearer token should be set
+        Arguments.of(null, false) // no googleProject, bearer token should not be set
+        );
+  }
+
+  @ParameterizedTest
+  @MethodSource
+  void passportAuthWithGoogleProject(String googleProject, boolean shouldSetBearerToken)
+      throws Exception {
+    var passportAuth =
+        new DrsHubAuthorization(SupportedTypesEnum.PASSPORTAUTH, (var e) -> Optional.of(PASSPORTS));
+    var bearerAuth =
+        new DrsHubAuthorization(
+            SupportedTypesEnum.BEARERAUTH, (var e) -> Optional.of(List.of(TOKEN_VALUE)));
+
+    when(drsApi.postAccessURL(Map.of("passports", PASSPORTS), PATH, accessId))
+        .thenReturn(new AccessURL().url("https://example.com"));
+
+    var response =
+        drsResolutionService.fetchDrsObjectAccessUrl(
+            testDrsProvider,
+            uriComponents,
+            accessId,
+            TypeEnum.GS,
+            List.of(passportAuth, bearerAuth),
+            new AuditLogEvent.Builder(),
+            null,
+            googleProject,
+            TRANSACTION_ID);
+
+    assertThat("access url returned", response.getUrl(), equalTo("https://example.com"));
+    verify(drsApi).postAccessURL(Map.of("passports", PASSPORTS), PATH, accessId);
+
+    if (shouldSetBearerToken) {
+      verify(drsApi).setBearerToken(TOKEN_VALUE);
+    } else {
+      verify(drsApi, never()).setBearerToken(any());
+    }
+  }
+
+  @Test
+  void passportAuthWithGoogleProject_noBearerAuthInList() throws Exception {
+    var googleProject = "test-project";
+    var passportAuth =
+        new DrsHubAuthorization(SupportedTypesEnum.PASSPORTAUTH, (var e) -> Optional.of(PASSPORTS));
+
+    when(drsApi.postAccessURL(Map.of("passports", PASSPORTS), PATH, accessId))
+        .thenReturn(new AccessURL().url("https://example.com"));
+
+    var response =
+        drsResolutionService.fetchDrsObjectAccessUrl(
+            testDrsProvider,
+            uriComponents,
+            accessId,
+            TypeEnum.GS,
+            List.of(passportAuth),
+            new AuditLogEvent.Builder(),
+            null,
+            googleProject,
+            TRANSACTION_ID);
+
+    assertThat("access url returned", response.getUrl(), equalTo("https://example.com"));
+    verify(drsApi).postAccessURL(Map.of("passports", PASSPORTS), PATH, accessId);
+    verify(drsApi, never()).setBearerToken(any());
+  }
 }


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/CTM-473

## Summary
When the DRS resolve endpoint uses passport auth and a `googleProject` parameter is provided, also send the bearer token alongside the passports. This enables signing the access URL with the userProject set with the correct access permissions.

## Implementation
- Searches the authorization list for a `BEARERAUTH` entry (from the fallback auth configuration) to get the properly configured token (either `provider_access_token` or `current_request`)
- Only includes the bearer token when `googleProject` is not null
- Added comprehensive logging to track when bearer tokens are included and warn if expected but not found

## Testing
- Added parameterized unit tests covering:
  - Bearer token is set when googleProject is provided
  - Bearer token is not set when googleProject is null  
  - No error when BEARERAUTH not in authorization list