### PR TITLE
[CTM-473] (fix) For passport auth, pass through the user's bearer token for signing the url

### DIFF
--- a/service/src/main/java/bio/terra/drshub/services/DrsResolutionService.java
+++ b/service/src/main/java/bio/terra/drshub/services/DrsResolutionService.java
@@ -168,6 +168,7 @@ public class DrsResolutionService {
           forceAccessUrl,
           ip,
           googleProject,
+          bearerToken,
           transactionId);
     }
 
@@ -189,6 +190,7 @@ public class DrsResolutionService {
       boolean forceAccessUrl,
       String ip,
       String googleProject,
+      BearerToken bearerToken,
       String transactionId) {
 
     getDrsFileName(drsResponse).ifPresent(drsMetadataBuilder::fileName);
@@ -208,6 +210,7 @@ public class DrsResolutionService {
                 auditEventBuilder,
                 ip,
                 googleProject,
+                bearerToken,
                 transactionId);
         drsMetadataBuilder.accessUrl(accessUrl);
       } catch (RuntimeException e) {
@@ -274,6 +277,7 @@ public class DrsResolutionService {
       AuditLogEvent.Builder auditLogEventBuilder,
       String ip,
       String googleProject,
+      BearerToken bearerToken,
       String transactionId) {
 
     var drsApi = drsApiFactory.getApiFromUriComponents(uriComponents, drsProvider);
@@ -300,7 +304,7 @@ public class DrsResolutionService {
                 accessMethodType,
                 uriComponents,
                 googleProject,
-                drsHubAuthorizations);
+                bearerToken);
       } catch (HttpClientErrorException.BadRequest e) {
         if (retryMode && googleProject != null && isRequireUserProjectError(e)) {
           // Retry with a fresh client that includes x-user-project
@@ -316,7 +320,7 @@ public class DrsResolutionService {
                   accessMethodType,
                   uriComponents,
                   googleProject,
-                  drsHubAuthorizations);
+                  bearerToken);
         } else {
           throw e;
         }
@@ -338,7 +342,7 @@ public class DrsResolutionService {
       TypeEnum accessMethodType,
       UriComponents uriComponents,
       String googleProject,
-      List<DrsHubAuthorization> drsHubAuthorizations) {
+      BearerToken bearerToken) {
     Optional<List<String>> auth =
         authorization.getAuthForAccessMethodType().apply(accessMethodType);
 
@@ -362,28 +366,12 @@ public class DrsResolutionService {
         try {
           // If googleProject is set, also send bearer token alongside passports to enable
           // signing the access url with the userProject set with the right access
-          if (googleProject != null) {
+          if (googleProject != null && bearerToken != null && bearerToken.getToken() != null) {
             log.info(
-                "Google project {} specified for passport auth request to {}. Attempting to include bearer token.",
+                "Google project {} specified for passport auth request to {}. Setting user's bearer token.",
                 googleProject,
                 uriComponents.toUriString());
-            // Find BEARERAUTH authorization in the list to get the properly configured token
-            Optional<String> bearerTokenOpt =
-                drsHubAuthorizations.stream()
-                    .filter(a -> a.drsAuthType() == Authorizations.SupportedTypesEnum.BEARERAUTH)
-                    .findFirst()
-                    .flatMap(a -> a.getAuthForAccessMethodType().apply(accessMethodType))
-                    .flatMap(list -> list.isEmpty() ? Optional.empty() : Optional.of(list.get(0)));
-            if (bearerTokenOpt.isPresent()) {
-              log.info(
-                  "Setting bearer token for passport auth request to {}",
-                  uriComponents.toUriString());
-              drsApi.setBearerToken(bearerTokenOpt.get());
-            } else {
-              log.warn(
-                  "Google project specified but no bearer token found in authorizations for {}",
-                  uriComponents.toUriString());
-            }
+            drsApi.setBearerToken(bearerToken.getToken());
           }
           yield auth.map(a -> drsApi.postAccessURL(Map.of("passports", a), objectId, accessId))
               .orElse(null);

--- a/service/src/test/java/bio/terra/drshub/services/DrsResolutionServiceTest.java
+++ b/service/src/test/java/bio/terra/drshub/services/DrsResolutionServiceTest.java
@@ -602,4 +602,43 @@ class DrsResolutionServiceTest {
     // With the fix, we now use the user's bearer token directly when googleProject is set
     verify(drsApi).setBearerToken(TOKEN_VALUE);
   }
+
+  @Test
+  void fetchDrsObjectAccessUrl_passportAuthWithGoogleProject_usesUserToken() throws Exception {
+    // Test the full fetchDrsObjectAccessUrl flow to ensure user's bearer token is set
+    var googleProject = "test-google-project";
+    var ip = "test.ip";
+    var passportAuth =
+        new DrsHubAuthorization(SupportedTypesEnum.PASSPORTAUTH, (var e) -> Optional.of(PASSPORTS));
+
+    when(drsApi.postAccessURL(Map.of("passports", PASSPORTS), PATH, accessId))
+        .thenReturn(new AccessURL().url("https://signed-url.example.com/data"));
+
+    var response =
+        drsResolutionService.fetchDrsObjectAccessUrl(
+            testDrsProvider,
+            uriComponents,
+            accessId,
+            TypeEnum.GS,
+            List.of(passportAuth),
+            new AuditLogEvent.Builder(),
+            ip,
+            googleProject,
+            TOKEN,
+            TRANSACTION_ID);
+
+    assertThat(
+        "signed url returned with passport auth",
+        response.getUrl(),
+        equalTo("https://signed-url.example.com/data"));
+
+    // Verify standard headers are set
+    verify(drsApi).setHeader("X-Forwarded-For", ip);
+    verify(drsApi).setHeader("x-user-project", googleProject);
+    verify(drsApi).setHeader(DrsResolutionService.TRANSACTION_ID_HEADER_NAME, TRANSACTION_ID);
+
+    // Verify user's bearer token is set before passport auth call
+    verify(drsApi).setBearerToken(TOKEN_VALUE);
+    verify(drsApi).postAccessURL(Map.of("passports", PASSPORTS), PATH, accessId);
+  }
 }

--- a/service/src/test/java/bio/terra/drshub/services/DrsResolutionServiceTest.java
+++ b/service/src/test/java/bio/terra/drshub/services/DrsResolutionServiceTest.java
@@ -294,6 +294,7 @@ class DrsResolutionServiceTest {
             new AuditLogEvent.Builder(),
             ip,
             googleProject,
+            TOKEN,
             TRANSACTION_ID);
     assertThat(
         "google signed url is properly returned", response.getUrl(), equalTo(url.toString()));
@@ -316,6 +317,7 @@ class DrsResolutionServiceTest {
             new AuditLogEvent.Builder(),
             ip,
             googleProject,
+            TOKEN,
             TRANSACTION_ID);
     assertThat("signed url is properly returned", response.getUrl(), equalTo(url.toString()));
     verify(drsApi).setHeader("X-Forwarded-For", ip);
@@ -338,6 +340,7 @@ class DrsResolutionServiceTest {
             new AuditLogEvent.Builder(),
             ip,
             googleProject,
+            TOKEN,
             TRANSACTION_ID);
     assertThat("signed url is properly returned", response.getUrl(), equalTo(url.toString()));
     verify(drsApi, never()).setHeader("X-Forwarded-For", ip);
@@ -365,6 +368,7 @@ class DrsResolutionServiceTest {
             new AuditLogEvent.Builder(),
             ip,
             googleProject,
+            TOKEN,
             TRANSACTION_ID);
 
     assertThat("signed url is properly returned", response.getUrl(), equalTo(url.toString()));
@@ -408,6 +412,7 @@ class DrsResolutionServiceTest {
             new AuditLogEvent.Builder(),
             ip,
             googleProject,
+            TOKEN,
             TRANSACTION_ID);
 
     assertThat(
@@ -446,6 +451,7 @@ class DrsResolutionServiceTest {
                 new AuditLogEvent.Builder(),
                 ip,
                 googleProject,
+                TOKEN,
                 TRANSACTION_ID));
 
     verify(drsApi, never()).setHeader(eq("x-user-project"), any());
@@ -479,6 +485,7 @@ class DrsResolutionServiceTest {
                 new AuditLogEvent.Builder(),
                 ip,
                 googleProject,
+                TOKEN,
                 TRANSACTION_ID));
 
     verify(drsApi, never()).setHeader(eq("x-user-project"), any());
@@ -503,6 +510,7 @@ class DrsResolutionServiceTest {
             new AuditLogEvent.Builder(),
             ip,
             googleProject,
+            TOKEN,
             TRANSACTION_ID);
 
     assertThat("signed url is properly returned", response.getUrl(), equalTo(url.toString()));
@@ -554,6 +562,7 @@ class DrsResolutionServiceTest {
             new AuditLogEvent.Builder(),
             null,
             googleProject,
+            TOKEN,
             TRANSACTION_ID);
 
     assertThat("access url returned", response.getUrl(), equalTo("https://example.com"));
@@ -585,10 +594,12 @@ class DrsResolutionServiceTest {
             new AuditLogEvent.Builder(),
             null,
             googleProject,
+            TOKEN,
             TRANSACTION_ID);
 
     assertThat("access url returned", response.getUrl(), equalTo("https://example.com"));
     verify(drsApi).postAccessURL(Map.of("passports", PASSPORTS), PATH, accessId);
-    verify(drsApi, never()).setBearerToken(any());
+    // With the fix, we now use the user's bearer token directly when googleProject is set
+    verify(drsApi).setBearerToken(TOKEN_VALUE);
   }
 }


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/CTM-473
Follow on to: https://github.com/DataBiosphere/jade-data-repo/pull/2101
## Problem
Theory: we're sending the DCF Fence provider token instead of the user's SAM token when using passport auth with `googleProject` set. SAM expects the user's Google-authenticated token for signing GCS URLs with requester-pays billing.

## Solution
Use `bearerToken.getToken()` (user's current request token) directly instead of searching the authorization list for a BEARERAUTH entry (which returns the DCF Fence provider token).

## Changes
- Pass `BearerToken` parameter through to `callAccessUrl`
- In PASSPORTAUTH case: use user's bearer token directly when `googleProject` is set
- Update tests to pass TOKEN parameter and verify correct behavior