### PR TITLE
[CTM-388] Update DRShub spec to 1.3

### DIFF
--- a/service/generators.gradle
+++ b/service/generators.gradle
@@ -28,7 +28,7 @@ swaggerSources {
 	}
 
 	ga4gh {
-		inputFile = file('src/main/resources/vendor/data-repository-service-1.2.0.yaml')
+		inputFile = file('src/main/resources/vendor/data-repository-service-1.3.0.yaml')
 		code(makeClientCodeClosure('io.github.ga4gh.drs'))
 	}
 

--- a/service/src/main/resources/vendor/data-repository-service-1.3.0.yaml
+++ b/service/src/main/resources/vendor/data-repository-service-1.3.0.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Data Repository Service
-  version: 1.2.0
+  version: 1.3.0
   x-logo:
     url: >-
       https://www.ga4gh.org/wp-content/themes/ga4gh-theme/gfx/GA-logo-horizontal-tag-RGB.svg
@@ -990,7 +990,7 @@ paths:
         Returns object metadata, and a list of access methods that can be used
         to fetch object bytes.
 
-        Method is a POST to accomodate a JWT GA4GH Passport sent in the formData
+        Method is a POST to accommodate a JWT GA4GH Passport sent in the formData
         in order to authorize access.
       operationId: PostObject
       security:
@@ -1057,7 +1057,7 @@ paths:
         contains an `access_id` (e.g., for servers that use signed URLs for
         fetching object bytes).
 
-        Method is a POST to accomodate a JWT GA4GH Passport sent in the formData
+        Method is a POST to accommodate a JWT GA4GH Passport sent in the formData
         in order to authorize access.
       operationId: PostAccessURL
       security:


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/CTM-388

The bundled spec file already contained all substantive 1.3.0 changes (the Authorizations schema, OPTIONS /objects/{object_id} endpoint, authorizations field on AccessMethod, etc.), and the service code was already implemented against that content.  Thus this PR only needs to update the name of `data-repository-service-1.2.0.yaml` and declared version.