### PR TITLE
[CTM-472] use TDR client instead of ga4gh client for passport+requester-pays

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -45,6 +45,7 @@ dependencies {
 	}
 	implementation 'org.broadinstitute.dsde.workbench:sam-client_2.13:v0.0.332'
 	implementation 'bio.terra:externalcreds-client-resttemplate:1.83.0-SNAPSHOT'
+	implementation 'bio.terra:datarepo-client:2.382.0-SNAPSHOT'
 	implementation 'org.codehaus.janino:janino:3.1.12' // Provides if/else xml parsing for logback config
 
 	// google

--- a/service/src/main/java/bio/terra/drshub/config/DrsHubConfigInterface.java
+++ b/service/src/main/java/bio/terra/drshub/config/DrsHubConfigInterface.java
@@ -15,6 +15,8 @@ public interface DrsHubConfigInterface {
 
   String getExternalcredsUrl();
 
+  String getTdrUrl();
+
   Map<String, String> getCompactIdHosts();
 
   Map<String, DrsProvider> getDrsProviders();

--- a/service/src/main/java/bio/terra/drshub/services/DrsResolutionService.java
+++ b/service/src/main/java/bio/terra/drshub/services/DrsResolutionService.java
@@ -384,7 +384,6 @@ public class DrsResolutionService {
                 "Google project {} specified for passport auth request to {}. Using TDR client with bearer token.",
                 googleProject,
                 uriComponents.toUriString());
-            var tdrBaseUrl = "https://" + uriComponents.getHost();
             yield auth.map(
                     a ->
                         callDataRepoPostAccessUrl(
@@ -393,8 +392,7 @@ public class DrsResolutionService {
                             a,
                             objectId,
                             accessId,
-                            googleProject,
-                            tdrBaseUrl))
+                            googleProject))
                 .orElse(null);
           }
           yield auth.map(a -> drsApi.postAccessURL(Map.of("passports", a), objectId, accessId))
@@ -416,12 +414,11 @@ public class DrsResolutionService {
       List<String> passportStrings,
       String objectId,
       String accessId,
-      String xUserProject,
-      String tdrBaseUrl) {
+      String xUserProject) {
     DRSPassportRequestModel body = new DRSPassportRequestModel();
     body.setPassports(passportStrings);
 
-    DataRepositoryServiceApi drsApi = tdrApiFactory.getApi(accessToken, tdrBaseUrl);
+    DataRepositoryServiceApi drsApi = tdrApiFactory.getApi(accessToken);
     DRSAccessURL drsAccessURL;
     try {
       drsAccessURL = drsApi.postAccessURL(body, objectId, accessId, xUserProject);

--- a/service/src/main/java/bio/terra/drshub/services/DrsResolutionService.java
+++ b/service/src/main/java/bio/terra/drshub/services/DrsResolutionService.java
@@ -6,7 +6,6 @@ import static org.apache.commons.lang3.ObjectUtils.isEmpty;
 import bio.terra.common.exception.BadRequestException;
 import bio.terra.common.iam.BearerToken;
 import bio.terra.datarepo.api.DataRepositoryServiceApi;
-import bio.terra.datarepo.client.ApiClient;
 import bio.terra.datarepo.client.ApiException;
 import bio.terra.datarepo.model.DRSAccessURL;
 import bio.terra.datarepo.model.DRSPassportRequestModel;
@@ -42,7 +41,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.util.UriComponents;
 
@@ -53,14 +55,19 @@ public class DrsResolutionService {
   private final DrsApiFactory drsApiFactory;
   private final AuthService authService;
   private final AuditLogger auditLogger;
+  private final TdrApiFactory tdrApiFactory;
   public static final String TRANSACTION_ID_HEADER_NAME = "X-Transaction-Id";
 
   @Autowired
   public DrsResolutionService(
-      DrsApiFactory drsApiFactory, AuthService authService, AuditLogger auditLogger) {
+      DrsApiFactory drsApiFactory,
+      AuthService authService,
+      AuditLogger auditLogger,
+      TdrApiFactory tdrApiFactory) {
     this.drsApiFactory = drsApiFactory;
     this.authService = authService;
     this.auditLogger = auditLogger;
+    this.tdrApiFactory = tdrApiFactory;
   }
 
   /**
@@ -305,7 +312,8 @@ public class DrsResolutionService {
                 accessMethodType,
                 uriComponents,
                 googleProject,
-                drsHubAuthorizations);
+                drsHubAuthorizations,
+                tdrApiFactory);
       } catch (HttpClientErrorException.BadRequest e) {
         if (retryMode && googleProject != null && isRequireUserProjectError(e)) {
           // Retry with a fresh client that includes x-user-project
@@ -321,7 +329,8 @@ public class DrsResolutionService {
                   accessMethodType,
                   uriComponents,
                   googleProject,
-                  drsHubAuthorizations);
+                  drsHubAuthorizations,
+                  tdrApiFactory);
         } else {
           throw e;
         }
@@ -343,7 +352,8 @@ public class DrsResolutionService {
       TypeEnum accessMethodType,
       UriComponents uriComponents,
       String googleProject,
-      List<DrsHubAuthorization> drsHubAuthorizations) {
+      List<DrsHubAuthorization> drsHubAuthorizations,
+      TdrApiFactory tdrApiFactory) {
     Optional<List<String>> auth =
         authorization.getAuthForAccessMethodType().apply(accessMethodType);
 
@@ -385,7 +395,7 @@ public class DrsResolutionService {
                   uriComponents.toUriString());
               // For this specific case, call TDR using the TDR client instead of the DRS client.
               // The TDR client supports passing the bearer token in the request.
-              yield auth.map(a -> callDataRepoPostAccessUrl(bearerTokenOpt.get(), a, objectId, accessId, googleProject)).orElse(null);
+              yield auth.map(a -> callDataRepoPostAccessUrl(tdrApiFactory, bearerTokenOpt.get(), a, objectId, accessId, googleProject, "https://" + uriComponents.getHost())).orElse(null);
             } else {
               log.warn(
                   "Google project specified but no bearer token found in authorizations for {}",
@@ -406,24 +416,22 @@ public class DrsResolutionService {
   }
 
   private static AccessURL callDataRepoPostAccessUrl(
-      String accessToken, List<String> passportStrings, String objectId, String accessId, String xUserProject
+      TdrApiFactory tdrApiFactory, String accessToken, List<String> passportStrings, String objectId, String accessId, String xUserProject, String tdrBaseUrl
   ) {
-    // translate the ga4gh client model to the TDR client model for the request
     DRSPassportRequestModel body = new DRSPassportRequestModel();
     body.setPassports(passportStrings);
 
-    // invoke TDR
-    // TODO: don't build the data repo client inline; it should probably have its own dedicated
-    //     class with http client reuse and all the trimmings
-    ApiClient dataRepoClient = new ApiClient();
-    dataRepoClient.setAccessToken(accessToken);
-    DataRepositoryServiceApi drsApi = new DataRepositoryServiceApi(dataRepoClient);
+    DataRepositoryServiceApi drsApi = tdrApiFactory.getApi(accessToken, tdrBaseUrl);
     DRSAccessURL drsAccessURL;
     try {
       drsAccessURL = drsApi.postAccessURL(body, objectId, accessId, xUserProject);
     } catch (ApiException e) {
-      // TODO: better exception handling
-      throw new RuntimeException(e);
+      var status = HttpStatusCode.valueOf(e.getCode());
+      var responseBody = e.getResponseBody() != null ? e.getResponseBody().getBytes(StandardCharsets.UTF_8) : new byte[0];
+      if (status.is4xxClientError()) {
+        throw HttpClientErrorException.create(status, e.getMessage(), HttpHeaders.EMPTY, responseBody, StandardCharsets.UTF_8);
+      }
+      throw HttpServerErrorException.create(status, e.getMessage(), HttpHeaders.EMPTY, responseBody, StandardCharsets.UTF_8);
     }
 
     // translate the ga4gh client model to the TDR client model for the response

--- a/service/src/main/java/bio/terra/drshub/services/DrsResolutionService.java
+++ b/service/src/main/java/bio/terra/drshub/services/DrsResolutionService.java
@@ -5,6 +5,11 @@ import static org.apache.commons.lang3.ObjectUtils.isEmpty;
 
 import bio.terra.common.exception.BadRequestException;
 import bio.terra.common.iam.BearerToken;
+import bio.terra.datarepo.api.DataRepositoryServiceApi;
+import bio.terra.datarepo.client.ApiClient;
+import bio.terra.datarepo.client.ApiException;
+import bio.terra.datarepo.model.DRSAccessURL;
+import bio.terra.datarepo.model.DRSPassportRequestModel;
 import bio.terra.drshub.config.DrsProvider;
 import bio.terra.drshub.config.DrsProviderInterface;
 import bio.terra.drshub.generated.model.RequestObject.CloudPlatformEnum;
@@ -378,7 +383,9 @@ public class DrsResolutionService {
               log.info(
                   "Setting bearer token for passport auth request to {}",
                   uriComponents.toUriString());
-              drsApi.setBearerToken(bearerTokenOpt.get());
+              // For this specific case, call TDR using the TDR client instead of the DRS client.
+              // The TDR client supports passing the bearer token in the request.
+              yield auth.map(a -> callDataRepoPostAccessUrl(bearerTokenOpt.get(), a, objectId, accessId, googleProject)).orElse(null);
             } else {
               log.warn(
                   "Google project specified but no bearer token found in authorizations for {}",
@@ -397,6 +404,36 @@ public class DrsResolutionService {
       }
     };
   }
+
+  private static AccessURL callDataRepoPostAccessUrl(
+      String accessToken, List<String> passportStrings, String objectId, String accessId, String xUserProject
+  ) {
+    // translate the ga4gh client model to the TDR client model for the request
+    DRSPassportRequestModel body = new DRSPassportRequestModel();
+    body.setPassports(passportStrings);
+
+    // invoke TDR
+    // TODO: don't build the data repo client inline; it should probably have its own dedicated
+    //     class with http client reuse and all the trimmings
+    ApiClient dataRepoClient = new ApiClient();
+    dataRepoClient.setAccessToken(accessToken);
+    DataRepositoryServiceApi drsApi = new DataRepositoryServiceApi(dataRepoClient);
+    DRSAccessURL drsAccessURL;
+    try {
+      drsAccessURL = drsApi.postAccessURL(body, objectId, accessId, xUserProject);
+    } catch (ApiException e) {
+      // TODO: better exception handling
+      throw new RuntimeException(e);
+    }
+
+    // translate the ga4gh client model to the TDR client model for the response
+    AccessURL accessURL = new AccessURL();
+    accessURL.setUrl(drsAccessURL.getUrl());
+    accessURL.setHeaders(drsAccessURL.getHeaders());
+
+    return accessURL;
+  }
+
 
   private static boolean isRequireUserProjectError(HttpClientErrorException.BadRequest e) {
     return e.getResponseBodyAsString().contains("Snapshot requires an x-user-project header");

--- a/service/src/main/java/bio/terra/drshub/services/DrsResolutionService.java
+++ b/service/src/main/java/bio/terra/drshub/services/DrsResolutionService.java
@@ -316,7 +316,6 @@ public class DrsResolutionService {
                 accessMethodType,
                 uriComponents,
                 googleProject,
-                drsHubAuthorizations,
                 tdrApiFactory,
                 bearerToken);
       } catch (HttpClientErrorException.BadRequest e) {
@@ -334,7 +333,6 @@ public class DrsResolutionService {
                   accessMethodType,
                   uriComponents,
                   googleProject,
-                  drsHubAuthorizations,
                   tdrApiFactory,
                   bearerToken);
         } else {
@@ -358,7 +356,6 @@ public class DrsResolutionService {
       TypeEnum accessMethodType,
       UriComponents uriComponents,
       String googleProject,
-      List<DrsHubAuthorization> drsHubAuthorizations,
       TdrApiFactory tdrApiFactory,
       BearerToken bearerToken) {
     Optional<List<String>> auth =
@@ -389,25 +386,6 @@ public class DrsResolutionService {
                 "Google project {} specified for passport auth request to {}. Setting user's bearer token.",
                 googleProject,
                 uriComponents.toUriString());
-            // Find BEARERAUTH authorization in the list to get the properly configured token
-            Optional<String> bearerTokenOpt =
-                drsHubAuthorizations.stream()
-                    .filter(a -> a.drsAuthType() == Authorizations.SupportedTypesEnum.BEARERAUTH)
-                    .findFirst()
-                    .flatMap(a -> a.getAuthForAccessMethodType().apply(accessMethodType))
-                    .flatMap(list -> list.isEmpty() ? Optional.empty() : Optional.of(list.get(0)));
-            if (bearerTokenOpt.isPresent()) {
-              log.info(
-                  "Setting bearer token for passport auth request to {}",
-                  uriComponents.toUriString());
-              // For this specific case, call TDR using the TDR client instead of the DRS client.
-              // The TDR client supports passing the bearer token in the request.
-              yield auth.map(a -> callDataRepoPostAccessUrl(tdrApiFactory, bearerTokenOpt.get(), a, objectId, accessId, googleProject, "https://" + uriComponents.getHost())).orElse(null);
-            } else {
-              log.warn(
-                  "Google project specified but no bearer token found in authorizations for {}",
-                  uriComponents.toUriString());
-            }
             drsApi.setBearerToken(bearerToken.getToken());
           }
           yield auth.map(a -> drsApi.postAccessURL(Map.of("passports", a), objectId, accessId))

--- a/service/src/main/java/bio/terra/drshub/services/DrsResolutionService.java
+++ b/service/src/main/java/bio/terra/drshub/services/DrsResolutionService.java
@@ -39,10 +39,10 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.scheduling.annotation.Async;
-import org.springframework.stereotype.Service;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatusCode;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.client.RestClientException;
@@ -385,8 +385,7 @@ public class DrsResolutionService {
                 googleProject,
                 uriComponents.toUriString());
             var tdrBaseUrl = "https://" + uriComponents.getHost();
-            yield auth
-                .map(
+            yield auth.map(
                     a ->
                         callDataRepoPostAccessUrl(
                             tdrApiFactory,
@@ -412,8 +411,13 @@ public class DrsResolutionService {
   }
 
   private static AccessURL callDataRepoPostAccessUrl(
-      TdrApiFactory tdrApiFactory, String accessToken, List<String> passportStrings, String objectId, String accessId, String xUserProject, String tdrBaseUrl
-  ) {
+      TdrApiFactory tdrApiFactory,
+      String accessToken,
+      List<String> passportStrings,
+      String objectId,
+      String accessId,
+      String xUserProject,
+      String tdrBaseUrl) {
     DRSPassportRequestModel body = new DRSPassportRequestModel();
     body.setPassports(passportStrings);
 
@@ -423,11 +427,16 @@ public class DrsResolutionService {
       drsAccessURL = drsApi.postAccessURL(body, objectId, accessId, xUserProject);
     } catch (ApiException e) {
       var status = HttpStatusCode.valueOf(e.getCode());
-      var responseBody = e.getResponseBody() != null ? e.getResponseBody().getBytes(StandardCharsets.UTF_8) : new byte[0];
+      var responseBody =
+          e.getResponseBody() != null
+              ? e.getResponseBody().getBytes(StandardCharsets.UTF_8)
+              : new byte[0];
       if (status.is4xxClientError()) {
-        throw HttpClientErrorException.create(status, e.getMessage(), HttpHeaders.EMPTY, responseBody, StandardCharsets.UTF_8);
+        throw HttpClientErrorException.create(
+            status, e.getMessage(), HttpHeaders.EMPTY, responseBody, StandardCharsets.UTF_8);
       }
-      throw HttpServerErrorException.create(status, e.getMessage(), HttpHeaders.EMPTY, responseBody, StandardCharsets.UTF_8);
+      throw HttpServerErrorException.create(
+          status, e.getMessage(), HttpHeaders.EMPTY, responseBody, StandardCharsets.UTF_8);
     }
 
     // translate the ga4gh client model to the TDR client model for the response
@@ -437,7 +446,6 @@ public class DrsResolutionService {
 
     return accessURL;
   }
-
 
   private static boolean isRequireUserProjectError(HttpClientErrorException.BadRequest e) {
     return e.getResponseBodyAsString().contains("Snapshot requires an x-user-project header");

--- a/service/src/main/java/bio/terra/drshub/services/DrsResolutionService.java
+++ b/service/src/main/java/bio/terra/drshub/services/DrsResolutionService.java
@@ -379,14 +379,24 @@ public class DrsResolutionService {
       }
       case PASSPORTAUTH -> {
         try {
-          // If googleProject is set, also send bearer token alongside passports to enable
-          // signing the access url with the userProject set with the right access
           if (googleProject != null && bearerToken != null && bearerToken.getToken() != null) {
             log.info(
-                "Google project {} specified for passport auth request to {}. Setting user's bearer token.",
+                "Google project {} specified for passport auth request to {}. Using TDR client with bearer token.",
                 googleProject,
                 uriComponents.toUriString());
-            drsApi.setBearerToken(bearerToken.getToken());
+            var tdrBaseUrl = "https://" + uriComponents.getHost();
+            yield auth
+                .map(
+                    a ->
+                        callDataRepoPostAccessUrl(
+                            tdrApiFactory,
+                            bearerToken.getToken(),
+                            a,
+                            objectId,
+                            accessId,
+                            googleProject,
+                            tdrBaseUrl))
+                .orElse(null);
           }
           yield auth.map(a -> drsApi.postAccessURL(Map.of("passports", a), objectId, accessId))
               .orElse(null);

--- a/service/src/main/java/bio/terra/drshub/services/TdrApiFactory.java
+++ b/service/src/main/java/bio/terra/drshub/services/TdrApiFactory.java
@@ -2,14 +2,15 @@ package bio.terra.drshub.services;
 
 import bio.terra.datarepo.api.DataRepositoryServiceApi;
 import bio.terra.datarepo.client.ApiClient;
+import bio.terra.drshub.config.DrsHubConfig;
 import org.springframework.stereotype.Service;
 
 @Service
-public record TdrApiFactory() {
+public record TdrApiFactory(DrsHubConfig drsHubConfig) {
 
-  public DataRepositoryServiceApi getApi(String accessToken, String baseUrl) {
+  public DataRepositoryServiceApi getApi(String accessToken) {
     var apiClient = new ApiClient();
-    apiClient.setBasePath(baseUrl);
+    apiClient.setBasePath(drsHubConfig.getTdrUrl());
     apiClient.setAccessToken(accessToken);
     return new DataRepositoryServiceApi(apiClient);
   }

--- a/service/src/main/java/bio/terra/drshub/services/TdrApiFactory.java
+++ b/service/src/main/java/bio/terra/drshub/services/TdrApiFactory.java
@@ -1,0 +1,16 @@
+package bio.terra.drshub.services;
+
+import bio.terra.datarepo.api.DataRepositoryServiceApi;
+import bio.terra.datarepo.client.ApiClient;
+import org.springframework.stereotype.Service;
+
+@Service
+public record TdrApiFactory() {
+
+  public DataRepositoryServiceApi getApi(String accessToken, String baseUrl) {
+    var apiClient = new ApiClient();
+    apiClient.setBasePath(baseUrl);
+    apiClient.setAccessToken(accessToken);
+    return new DataRepositoryServiceApi(apiClient);
+  }
+}

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -4,6 +4,7 @@ drshub:
   bardUrl: https://terra-bard-${deploy_env}.appspot.com
   samUrl: https://sam.dsde-${deploy_env}.broadinstitute.org
   externalcredsUrl: https://externalcreds.dsde-${deploy_env}.broadinstitute.org
+  tdrUrl: ${TDR_URL:https://jade.datarepo-dev.broadinstitute.org}
 
   drsProviders:
     anvil:

--- a/service/src/test/java/bio/terra/drshub/controllers/VerifyPactDrsHubApiController.java
+++ b/service/src/test/java/bio/terra/drshub/controllers/VerifyPactDrsHubApiController.java
@@ -25,6 +25,7 @@ import bio.terra.drshub.services.AuthService;
 import bio.terra.drshub.services.DrsApiFactory;
 import bio.terra.drshub.services.DrsProviderService;
 import bio.terra.drshub.services.DrsResolutionService;
+import bio.terra.drshub.services.TdrApiFactory;
 import bio.terra.drshub.services.TrackingService;
 import bio.terra.drshub.tracking.UserLoggingMetrics;
 import bio.terra.drshub.util.AsyncUtils;
@@ -65,6 +66,7 @@ class VerifyPactsDrsHubApiController {
   @MockBean private AuthService authService;
   @MockBean private DrsApi drsApi;
   @MockBean private DrsApiFactory drsApiFactory;
+  @MockBean private TdrApiFactory tdrApiFactory;
   @MockBean private AuditLogger auditLogger;
   @MockBean private TrackingService trackingService;
   @SpyBean private DrsResolutionService drsResolutionService;

--- a/service/src/test/java/bio/terra/drshub/services/DrsResolutionServiceTest.java
+++ b/service/src/test/java/bio/terra/drshub/services/DrsResolutionServiceTest.java
@@ -12,6 +12,10 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import bio.terra.common.iam.BearerToken;
+import bio.terra.datarepo.api.DataRepositoryServiceApi;
+import bio.terra.datarepo.client.ApiException;
+import bio.terra.datarepo.model.DRSAccessURL;
+import bio.terra.datarepo.model.DRSPassportRequestModel;
 import bio.terra.drshub.config.DrsProvider;
 import bio.terra.drshub.config.ProviderAccessMethodConfig;
 import bio.terra.drshub.logging.AuditLogEvent;
@@ -59,6 +63,8 @@ class DrsResolutionServiceTest {
   @Mock private UriComponents uriComponents;
   @Mock private AuthService authService;
   @Mock private GoogleStorageService googleStorageService;
+  @Mock private TdrApiFactory tdrApiFactory;
+  @Mock private DataRepositoryServiceApi tdrApi;
 
   private static final String PATH = "path";
 
@@ -100,7 +106,7 @@ class DrsResolutionServiceTest {
     DrsApiFactory drsApiFactory = mock(DrsApiFactory.class);
 
     drsResolutionService =
-        new DrsResolutionService(drsApiFactory, authService, mock(AuditLogger.class));
+        new DrsResolutionService(drsApiFactory, authService, mock(AuditLogger.class), tdrApiFactory);
 
     when(uriComponents.getHost()).thenReturn("host.com");
     when(uriComponents.getPath()).thenReturn(PATH);
@@ -385,7 +391,7 @@ class DrsResolutionServiceTest {
         .thenReturn(retryApi);
 
     drsResolutionService =
-        new DrsResolutionService(drsApiFactory, authService, mock(AuditLogger.class));
+        new DrsResolutionService(drsApiFactory, authService, mock(AuditLogger.class), tdrApiFactory);
 
     SignedUrlTestUtils.setupSignedUrlMocks(authService, googleStorageService, googleProject, url);
     when(drsApi.getAccessURL(PATH, accessId))
@@ -524,17 +530,70 @@ class DrsResolutionServiceTest {
                         .setRequiresUserProjectOnRetry(true))));
   }
 
-  private static Stream<Arguments> passportAuthWithGoogleProject() {
-    return Stream.of(
-        Arguments.of("test-project", true), // googleProject set, bearer token should be set
-        Arguments.of(null, false) // no googleProject, bearer token should not be set
-        );
+  @Test
+  void passportAuthWithGoogleProject_usesTdrClient() throws Exception {
+    var googleProject = "test-project";
+    var passportAuth =
+        new DrsHubAuthorization(SupportedTypesEnum.PASSPORTAUTH, (var e) -> Optional.of(PASSPORTS));
+    var bearerAuth =
+        new DrsHubAuthorization(
+            SupportedTypesEnum.BEARERAUTH, (var e) -> Optional.of(List.of(TOKEN_VALUE)));
+
+    when(tdrApiFactory.getApi(TOKEN_VALUE, "https://host.com")).thenReturn(tdrApi);
+    when(tdrApi.postAccessURL(any(DRSPassportRequestModel.class), eq(PATH), eq(accessId), eq(googleProject)))
+        .thenReturn(new DRSAccessURL().url("https://example.com"));
+
+    var response =
+        drsResolutionService.fetchDrsObjectAccessUrl(
+            testDrsProvider,
+            uriComponents,
+            accessId,
+            TypeEnum.GS,
+            List.of(passportAuth, bearerAuth),
+            new AuditLogEvent.Builder(),
+            null,
+            googleProject,
+            TRANSACTION_ID);
+
+    assertThat("access url returned", response.getUrl(), equalTo("https://example.com"));
+    verify(tdrApiFactory).getApi(TOKEN_VALUE, "https://host.com");
+    verify(tdrApi).postAccessURL(any(DRSPassportRequestModel.class), eq(PATH), eq(accessId), eq(googleProject));
+    verify(drsApi, never()).postAccessURL(any(), any(), any());
+    verify(drsApi, never()).setBearerToken(any());
   }
 
-  @ParameterizedTest
-  @MethodSource
-  void passportAuthWithGoogleProject(String googleProject, boolean shouldSetBearerToken)
-      throws Exception {
+  @Test
+  void passportAuthWithGoogleProject_baseUrlConstructedFromHost() throws Exception {
+    var googleProject = "test-project";
+    var differentHost = "jade.datarepo-dev.broadinstitute.org";
+    when(uriComponents.getHost()).thenReturn(differentHost);
+
+    var passportAuth =
+        new DrsHubAuthorization(SupportedTypesEnum.PASSPORTAUTH, (var e) -> Optional.of(PASSPORTS));
+    var bearerAuth =
+        new DrsHubAuthorization(
+            SupportedTypesEnum.BEARERAUTH, (var e) -> Optional.of(List.of(TOKEN_VALUE)));
+
+    when(tdrApiFactory.getApi(TOKEN_VALUE, "https://" + differentHost)).thenReturn(tdrApi);
+    when(tdrApi.postAccessURL(any(DRSPassportRequestModel.class), any(), any(), any()))
+        .thenReturn(new DRSAccessURL().url("https://example.com"));
+
+    drsResolutionService.fetchDrsObjectAccessUrl(
+        testDrsProvider,
+        uriComponents,
+        accessId,
+        TypeEnum.GS,
+        List.of(passportAuth, bearerAuth),
+        new AuditLogEvent.Builder(),
+        null,
+        googleProject,
+        TRANSACTION_ID);
+
+    verify(tdrApiFactory).getApi(TOKEN_VALUE, "https://" + differentHost);
+  }
+
+  @Test
+  void passportAuthWithGoogleProject_noGoogleProject() throws Exception {
     var passportAuth =
         new DrsHubAuthorization(SupportedTypesEnum.PASSPORTAUTH, (var e) -> Optional.of(PASSPORTS));
     var bearerAuth =
@@ -553,17 +612,13 @@ class DrsResolutionServiceTest {
             List.of(passportAuth, bearerAuth),
             new AuditLogEvent.Builder(),
             null,
-            googleProject,
+            null,
             TRANSACTION_ID);
 
     assertThat("access url returned", response.getUrl(), equalTo("https://example.com"));
     verify(drsApi).postAccessURL(Map.of("passports", PASSPORTS), PATH, accessId);
-
-    if (shouldSetBearerToken) {
-      verify(drsApi).setBearerToken(TOKEN_VALUE);
-    } else {
-      verify(drsApi, never()).setBearerToken(any());
-    }
+    verify(drsApi, never()).setBearerToken(any());
+    verifyNoInteractions(tdrApiFactory);
   }
 
   @Test

--- a/service/src/test/java/bio/terra/drshub/services/DrsResolutionServiceTest.java
+++ b/service/src/test/java/bio/terra/drshub/services/DrsResolutionServiceTest.java
@@ -548,7 +548,7 @@ class DrsResolutionServiceTest {
         new DrsHubAuthorization(
             SupportedTypesEnum.BEARERAUTH, (var e) -> Optional.of(List.of(TOKEN_VALUE)));
 
-    when(tdrApiFactory.getApi(TOKEN_VALUE, "https://host.com")).thenReturn(tdrApi);
+    when(tdrApiFactory.getApi(TOKEN_VALUE)).thenReturn(tdrApi);
     when(tdrApi.postAccessURL(
             any(DRSPassportRequestModel.class), eq(PATH), eq(accessId), eq(googleProject)))
         .thenReturn(new DRSAccessURL().url("https://example.com"));
@@ -567,7 +567,7 @@ class DrsResolutionServiceTest {
             TRANSACTION_ID);
 
     assertThat("access url returned", response.getUrl(), equalTo("https://example.com"));
-    verify(tdrApiFactory).getApi(TOKEN_VALUE, "https://host.com");
+    verify(tdrApiFactory).getApi(TOKEN_VALUE);
     verify(tdrApi)
         .postAccessURL(
             any(DRSPassportRequestModel.class), eq(PATH), eq(accessId), eq(googleProject));
@@ -576,18 +576,15 @@ class DrsResolutionServiceTest {
   }
 
   @Test
-  void passportAuthWithGoogleProject_baseUrlConstructedFromHost() throws Exception {
+  void passportAuthWithGoogleProject_usesTdrFactory() throws Exception {
     var googleProject = "test-project";
-    var differentHost = "jade.datarepo-dev.broadinstitute.org";
-    when(uriComponents.getHost()).thenReturn(differentHost);
-
     var passportAuth =
         new DrsHubAuthorization(SupportedTypesEnum.PASSPORTAUTH, (var e) -> Optional.of(PASSPORTS));
     var bearerAuth =
         new DrsHubAuthorization(
             SupportedTypesEnum.BEARERAUTH, (var e) -> Optional.of(List.of(TOKEN_VALUE)));
 
-    when(tdrApiFactory.getApi(TOKEN_VALUE, "https://" + differentHost)).thenReturn(tdrApi);
+    when(tdrApiFactory.getApi(TOKEN_VALUE)).thenReturn(tdrApi);
     when(tdrApi.postAccessURL(any(DRSPassportRequestModel.class), any(), any(), any()))
         .thenReturn(new DRSAccessURL().url("https://example.com"));
 
@@ -603,7 +600,7 @@ class DrsResolutionServiceTest {
         TOKEN,
         TRANSACTION_ID);
 
-    verify(tdrApiFactory).getApi(TOKEN_VALUE, "https://" + differentHost);
+    verify(tdrApiFactory).getApi(TOKEN_VALUE);
   }
 
   @Test
@@ -642,7 +639,7 @@ class DrsResolutionServiceTest {
     var passportAuth =
         new DrsHubAuthorization(SupportedTypesEnum.PASSPORTAUTH, (var e) -> Optional.of(PASSPORTS));
 
-    when(tdrApiFactory.getApi(TOKEN_VALUE, "https://host.com")).thenReturn(tdrApi);
+    when(tdrApiFactory.getApi(TOKEN_VALUE)).thenReturn(tdrApi);
     when(tdrApi.postAccessURL(
             any(DRSPassportRequestModel.class), eq(PATH), eq(accessId), eq(googleProject)))
         .thenReturn(new DRSAccessURL().url("https://example.com"));
@@ -661,7 +658,7 @@ class DrsResolutionServiceTest {
             TRANSACTION_ID);
 
     assertThat("access url returned", response.getUrl(), equalTo("https://example.com"));
-    verify(tdrApiFactory).getApi(TOKEN_VALUE, "https://host.com");
+    verify(tdrApiFactory).getApi(TOKEN_VALUE);
     verify(tdrApi)
         .postAccessURL(
             any(DRSPassportRequestModel.class), eq(PATH), eq(accessId), eq(googleProject));
@@ -676,7 +673,7 @@ class DrsResolutionServiceTest {
     var passportAuth =
         new DrsHubAuthorization(SupportedTypesEnum.PASSPORTAUTH, (var e) -> Optional.of(PASSPORTS));
 
-    when(tdrApiFactory.getApi(TOKEN_VALUE, "https://host.com")).thenReturn(tdrApi);
+    when(tdrApiFactory.getApi(TOKEN_VALUE)).thenReturn(tdrApi);
     when(tdrApi.postAccessURL(
             any(DRSPassportRequestModel.class), eq(PATH), eq(accessId), eq(googleProject)))
         .thenReturn(new DRSAccessURL().url("https://signed-url.example.com/data"));
@@ -702,7 +699,7 @@ class DrsResolutionServiceTest {
     verify(drsApi).setHeader("X-Forwarded-For", ip);
     verify(drsApi).setHeader("x-user-project", googleProject);
     verify(drsApi).setHeader(DrsResolutionService.TRANSACTION_ID_HEADER_NAME, TRANSACTION_ID);
-    verify(tdrApiFactory).getApi(TOKEN_VALUE, "https://host.com");
+    verify(tdrApiFactory).getApi(TOKEN_VALUE);
     verify(tdrApi)
         .postAccessURL(
             any(DRSPassportRequestModel.class), eq(PATH), eq(accessId), eq(googleProject));

--- a/service/src/test/java/bio/terra/drshub/services/DrsResolutionServiceTest.java
+++ b/service/src/test/java/bio/terra/drshub/services/DrsResolutionServiceTest.java
@@ -561,6 +561,7 @@ class DrsResolutionServiceTest {
             new AuditLogEvent.Builder(),
             null,
             googleProject,
+            TOKEN,
             TRANSACTION_ID);
 
     assertThat("access url returned", response.getUrl(), equalTo("https://example.com"));
@@ -595,6 +596,7 @@ class DrsResolutionServiceTest {
         new AuditLogEvent.Builder(),
         null,
         googleProject,
+        TOKEN,
         TRANSACTION_ID);
 
     verify(tdrApiFactory).getApi(TOKEN_VALUE, "https://" + differentHost);
@@ -621,7 +623,6 @@ class DrsResolutionServiceTest {
             new AuditLogEvent.Builder(),
             null,
             null,
-            googleProject,
             TOKEN,
             TRANSACTION_ID);
 

--- a/service/src/test/java/bio/terra/drshub/services/DrsResolutionServiceTest.java
+++ b/service/src/test/java/bio/terra/drshub/services/DrsResolutionServiceTest.java
@@ -13,7 +13,6 @@ import static org.mockito.Mockito.when;
 
 import bio.terra.common.iam.BearerToken;
 import bio.terra.datarepo.api.DataRepositoryServiceApi;
-import bio.terra.datarepo.client.ApiException;
 import bio.terra.datarepo.model.DRSAccessURL;
 import bio.terra.datarepo.model.DRSPassportRequestModel;
 import bio.terra.drshub.config.DrsProvider;
@@ -106,7 +105,8 @@ class DrsResolutionServiceTest {
     DrsApiFactory drsApiFactory = mock(DrsApiFactory.class);
 
     drsResolutionService =
-        new DrsResolutionService(drsApiFactory, authService, mock(AuditLogger.class), tdrApiFactory);
+        new DrsResolutionService(
+            drsApiFactory, authService, mock(AuditLogger.class), tdrApiFactory);
 
     when(uriComponents.getHost()).thenReturn("host.com");
     when(uriComponents.getPath()).thenReturn(PATH);
@@ -395,7 +395,8 @@ class DrsResolutionServiceTest {
         .thenReturn(retryApi);
 
     drsResolutionService =
-        new DrsResolutionService(drsApiFactory, authService, mock(AuditLogger.class), tdrApiFactory);
+        new DrsResolutionService(
+            drsApiFactory, authService, mock(AuditLogger.class), tdrApiFactory);
 
     SignedUrlTestUtils.setupSignedUrlMocks(authService, googleStorageService, googleProject, url);
     when(drsApi.getAccessURL(PATH, accessId))
@@ -548,7 +549,8 @@ class DrsResolutionServiceTest {
             SupportedTypesEnum.BEARERAUTH, (var e) -> Optional.of(List.of(TOKEN_VALUE)));
 
     when(tdrApiFactory.getApi(TOKEN_VALUE, "https://host.com")).thenReturn(tdrApi);
-    when(tdrApi.postAccessURL(any(DRSPassportRequestModel.class), eq(PATH), eq(accessId), eq(googleProject)))
+    when(tdrApi.postAccessURL(
+            any(DRSPassportRequestModel.class), eq(PATH), eq(accessId), eq(googleProject)))
         .thenReturn(new DRSAccessURL().url("https://example.com"));
 
     var response =
@@ -566,7 +568,9 @@ class DrsResolutionServiceTest {
 
     assertThat("access url returned", response.getUrl(), equalTo("https://example.com"));
     verify(tdrApiFactory).getApi(TOKEN_VALUE, "https://host.com");
-    verify(tdrApi).postAccessURL(any(DRSPassportRequestModel.class), eq(PATH), eq(accessId), eq(googleProject));
+    verify(tdrApi)
+        .postAccessURL(
+            any(DRSPassportRequestModel.class), eq(PATH), eq(accessId), eq(googleProject));
     verify(drsApi, never()).postAccessURL(any(), any(), any());
     verify(drsApi, never()).setBearerToken(any());
   }
@@ -638,8 +642,10 @@ class DrsResolutionServiceTest {
     var passportAuth =
         new DrsHubAuthorization(SupportedTypesEnum.PASSPORTAUTH, (var e) -> Optional.of(PASSPORTS));
 
-    when(drsApi.postAccessURL(Map.of("passports", PASSPORTS), PATH, accessId))
-        .thenReturn(new AccessURL().url("https://example.com"));
+    when(tdrApiFactory.getApi(TOKEN_VALUE, "https://host.com")).thenReturn(tdrApi);
+    when(tdrApi.postAccessURL(
+            any(DRSPassportRequestModel.class), eq(PATH), eq(accessId), eq(googleProject)))
+        .thenReturn(new DRSAccessURL().url("https://example.com"));
 
     var response =
         drsResolutionService.fetchDrsObjectAccessUrl(
@@ -655,21 +661,25 @@ class DrsResolutionServiceTest {
             TRANSACTION_ID);
 
     assertThat("access url returned", response.getUrl(), equalTo("https://example.com"));
-    verify(drsApi).postAccessURL(Map.of("passports", PASSPORTS), PATH, accessId);
-    // With the fix, we now use the user's bearer token directly when googleProject is set
-    verify(drsApi).setBearerToken(TOKEN_VALUE);
+    verify(tdrApiFactory).getApi(TOKEN_VALUE, "https://host.com");
+    verify(tdrApi)
+        .postAccessURL(
+            any(DRSPassportRequestModel.class), eq(PATH), eq(accessId), eq(googleProject));
+    verify(drsApi, never()).postAccessURL(any(), any(), any());
+    verify(drsApi, never()).setBearerToken(any());
   }
 
   @Test
   void fetchDrsObjectAccessUrl_passportAuthWithGoogleProject_usesUserToken() throws Exception {
-    // Test the full fetchDrsObjectAccessUrl flow to ensure user's bearer token is set
     var googleProject = "test-google-project";
     var ip = "test.ip";
     var passportAuth =
         new DrsHubAuthorization(SupportedTypesEnum.PASSPORTAUTH, (var e) -> Optional.of(PASSPORTS));
 
-    when(drsApi.postAccessURL(Map.of("passports", PASSPORTS), PATH, accessId))
-        .thenReturn(new AccessURL().url("https://signed-url.example.com/data"));
+    when(tdrApiFactory.getApi(TOKEN_VALUE, "https://host.com")).thenReturn(tdrApi);
+    when(tdrApi.postAccessURL(
+            any(DRSPassportRequestModel.class), eq(PATH), eq(accessId), eq(googleProject)))
+        .thenReturn(new DRSAccessURL().url("https://signed-url.example.com/data"));
 
     var response =
         drsResolutionService.fetchDrsObjectAccessUrl(
@@ -689,13 +699,14 @@ class DrsResolutionServiceTest {
         response.getUrl(),
         equalTo("https://signed-url.example.com/data"));
 
-    // Verify standard headers are set
     verify(drsApi).setHeader("X-Forwarded-For", ip);
     verify(drsApi).setHeader("x-user-project", googleProject);
     verify(drsApi).setHeader(DrsResolutionService.TRANSACTION_ID_HEADER_NAME, TRANSACTION_ID);
-
-    // Verify user's bearer token is set before passport auth call
-    verify(drsApi).setBearerToken(TOKEN_VALUE);
-    verify(drsApi).postAccessURL(Map.of("passports", PASSPORTS), PATH, accessId);
+    verify(tdrApiFactory).getApi(TOKEN_VALUE, "https://host.com");
+    verify(tdrApi)
+        .postAccessURL(
+            any(DRSPassportRequestModel.class), eq(PATH), eq(accessId), eq(googleProject));
+    verify(drsApi, never()).postAccessURL(any(), any(), any());
+    verify(drsApi, never()).setBearerToken(any());
   }
 }


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/CTM-472
Use the TDR client instead of the ga4gh drs-spec client to invoke TDR when a request comes in with both a passport and a bill-to project for requester pays.