### PR TITLE
CTM-473: use TDR client library to call TDR's PostAccessURL

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -45,6 +45,7 @@ dependencies {
 	}
 	implementation 'org.broadinstitute.dsde.workbench:sam-client_2.13:v0.0.332'
 	implementation 'bio.terra:externalcreds-client-resttemplate:1.83.0-SNAPSHOT'
+	implementation 'bio.terra:datarepo-client:2.382.0-SNAPSHOT'
 	implementation 'org.codehaus.janino:janino:3.1.12' // Provides if/else xml parsing for logback config
 
 	// google

--- a/service/src/main/java/bio/terra/drshub/config/DrsHubConfigInterface.java
+++ b/service/src/main/java/bio/terra/drshub/config/DrsHubConfigInterface.java
@@ -15,6 +15,8 @@ public interface DrsHubConfigInterface {
 
   String getExternalcredsUrl();
 
+  String getTdrUrl();
+
   Map<String, String> getCompactIdHosts();
 
   Map<String, DrsProvider> getDrsProviders();

--- a/service/src/main/java/bio/terra/drshub/services/DrsResolutionService.java
+++ b/service/src/main/java/bio/terra/drshub/services/DrsResolutionService.java
@@ -423,10 +423,11 @@ public class DrsResolutionService {
     String petToken;
 
     try {
+      log.info("Retrieving access token for user from sam");
       petToken =
           samGoogleApi.getArbitraryPetServiceAccountToken(List.of("openid", "email", "profile"));
       log.info(
-          "Retrieving access token for pet token {} with length {}",
+          "Access token retrieved for pet: token substring {} with length {}",
           petToken.substring(0, 5),
           petToken.length());
     } catch (org.broadinstitute.dsde.workbench.client.sam.ApiException e) {

--- a/service/src/main/java/bio/terra/drshub/services/DrsResolutionService.java
+++ b/service/src/main/java/bio/terra/drshub/services/DrsResolutionService.java
@@ -417,28 +417,29 @@ public class DrsResolutionService {
     //    to use the Terra-specific TDR client library instead of the GA4GH DRS-spec client library,
     //    because the GA4GH client does not pass on the bearer token, and TDR needs that.
 
-    // invoke Sam to get a pet token
-    org.broadinstitute.dsde.workbench.client.sam.api.GoogleApi samGoogleApi =
-        samApiFactory.getGoogleApi(accessToken);
-    String petToken;
-
-    try {
-      log.info("Retrieving access token for user from sam");
-      petToken =
-          samGoogleApi.getArbitraryPetServiceAccountToken(List.of("openid", "email", "profile"));
-      log.info(
-          "Access token retrieved for pet: token substring {} with length {}",
-          petToken.substring(0, 5),
-          petToken.length());
-    } catch (org.broadinstitute.dsde.workbench.client.sam.ApiException e) {
-      // TODO: more precise and helpful error handling
-      throw new RuntimeException(e);
-    }
-    if (StringUtils.isBlank(petToken)) {
-      // TODO: more precise and helpful error handling
-      throw new RuntimeException("Pet token is blank!");
-    }
-    //    String petToken = accessToken;
+    //    // invoke Sam to get a pet token
+    //    org.broadinstitute.dsde.workbench.client.sam.api.GoogleApi samGoogleApi =
+    //        samApiFactory.getGoogleApi(accessToken);
+    //    String petToken;
+    //
+    //    try {
+    //      log.info("Retrieving access token for user from sam");
+    //      petToken =
+    //          samGoogleApi.getArbitraryPetServiceAccountToken(List.of("openid", "email",
+    // "profile"));
+    //      log.info(
+    //          "Access token retrieved for pet: token substring {} with length {}",
+    //          petToken.substring(0, 5),
+    //          petToken.length());
+    //    } catch (org.broadinstitute.dsde.workbench.client.sam.ApiException e) {
+    //      // TODO: more precise and helpful error handling
+    //      throw new RuntimeException(e);
+    //    }
+    //    if (StringUtils.isBlank(petToken)) {
+    //      // TODO: more precise and helpful error handling
+    //      throw new RuntimeException("Pet token is blank!");
+    //    }
+    String petToken = accessToken;
 
     String petTokenSample = StringUtils.substring(Optional.ofNullable(petToken).orElse(""), 0, 25);
 

--- a/service/src/main/java/bio/terra/drshub/services/DrsResolutionService.java
+++ b/service/src/main/java/bio/terra/drshub/services/DrsResolutionService.java
@@ -55,7 +55,6 @@ public class DrsResolutionService {
   private final AuthService authService;
   private final AuditLogger auditLogger;
   private final TdrApiFactory tdrApiFactory;
-  private final SamApiFactory samApiFactory;
   public static final String TRANSACTION_ID_HEADER_NAME = "X-Transaction-Id";
 
   @Autowired
@@ -63,13 +62,11 @@ public class DrsResolutionService {
       DrsApiFactory drsApiFactory,
       AuthService authService,
       AuditLogger auditLogger,
-      TdrApiFactory tdrApiFactory,
-      SamApiFactory samApiFactory) {
+      TdrApiFactory tdrApiFactory) {
     this.drsApiFactory = drsApiFactory;
     this.authService = authService;
     this.auditLogger = auditLogger;
     this.tdrApiFactory = tdrApiFactory;
-    this.samApiFactory = samApiFactory;
   }
 
   /**
@@ -378,6 +375,8 @@ public class DrsResolutionService {
       }
       case PASSPORTAUTH -> {
         try {
+          // If googleProject is set, also send bearer token alongside passports to enable
+          // signing the access url with the userProject set with the right access
           if (googleProject != null && bearerToken != null && bearerToken.getToken() != null) {
             log.info(
                 "Google project {} specified for passport auth request to {}. Using TDR client with bearer token.",
@@ -385,7 +384,7 @@ public class DrsResolutionService {
                 uriComponents.toUriString());
             yield auth.map(
                     a ->
-                        callDataRepoViaPetToken(
+                        callDataRepoPostAccessUrl(
                             bearerToken.getToken(), a, objectId, accessId, googleProject))
                 .orElse(null);
           }
@@ -402,16 +401,17 @@ public class DrsResolutionService {
     };
   }
 
-  private AccessURL callDataRepoViaPetToken(
+  private AccessURL callDataRepoPostAccessUrl(
       String accessToken,
       List<String> passportStrings,
       String objectId,
       String accessId,
       String xUserProject) {
-    // invoke TDR with the pet token to resolve the DRS URI
+    // translate the ga4gh client model to the TDR client model for the request
     DRSPassportRequestModel body = new DRSPassportRequestModel();
     body.setPassports(passportStrings);
 
+    // invoke TDR using the TDR client library to resolve the DRS URI
     DataRepositoryServiceApi drsApi = tdrApiFactory.getApi(accessToken);
     DRSAccessURL drsAccessURL;
     try {
@@ -430,7 +430,7 @@ public class DrsResolutionService {
           status, e.getMessage(), HttpHeaders.EMPTY, responseBody, StandardCharsets.UTF_8);
     }
 
-    // translate the ga4gh client model to the TDR client model for the response
+    // translate the TDR client model to the ga4gh client model for the response
     AccessURL accessURL = new AccessURL();
     accessURL.setUrl(drsAccessURL.getUrl());
     accessURL.setHeaders(drsAccessURL.getHeaders());

--- a/service/src/main/java/bio/terra/drshub/services/DrsResolutionService.java
+++ b/service/src/main/java/bio/terra/drshub/services/DrsResolutionService.java
@@ -418,26 +418,28 @@ public class DrsResolutionService {
     //    because the GA4GH client does not pass on the bearer token, and TDR needs that.
 
     // invoke Sam to get a pet token
-    org.broadinstitute.dsde.workbench.client.sam.api.GoogleApi samGoogleApi =
-        samApiFactory.getGoogleApi(accessToken);
-    String petToken;
-
-    try {
-      log.info("Retrieving access token for user from sam");
-      petToken =
-          samGoogleApi.getArbitraryPetServiceAccountToken(List.of("openid", "email", "profile"));
-      log.info(
-          "Access token retrieved for pet: token substring {} with length {}",
-          petToken.substring(0, 5),
-          petToken.length());
-    } catch (org.broadinstitute.dsde.workbench.client.sam.ApiException e) {
-      // TODO: more precise and helpful error handling
-      throw new RuntimeException(e);
-    }
-    if (StringUtils.isBlank(petToken)) {
-      // TODO: more precise and helpful error handling
-      throw new RuntimeException("Pet token is blank!");
-    }
+    //    org.broadinstitute.dsde.workbench.client.sam.api.GoogleApi samGoogleApi =
+    //        samApiFactory.getGoogleApi(accessToken);
+    //    String petToken;
+    //
+    //    try {
+    //      log.info("Retrieving access token for user from sam");
+    //      petToken =
+    //          samGoogleApi.getArbitraryPetServiceAccountToken(List.of("openid", "email",
+    // "profile"));
+    //      log.info(
+    //          "Access token retrieved for pet: token substring {} with length {}",
+    //          petToken.substring(0, 5),
+    //          petToken.length());
+    //    } catch (org.broadinstitute.dsde.workbench.client.sam.ApiException e) {
+    //      // TODO: more precise and helpful error handling
+    //      throw new RuntimeException(e);
+    //    }
+    //    if (StringUtils.isBlank(petToken)) {
+    //      // TODO: more precise and helpful error handling
+    //      throw new RuntimeException("Pet token is blank!");
+    //    }
+    String petToken = accessToken;
 
     // invoke TDR with the pet token to resolve the DRS URI
     DRSPassportRequestModel body = new DRSPassportRequestModel();

--- a/service/src/main/java/bio/terra/drshub/services/DrsResolutionService.java
+++ b/service/src/main/java/bio/terra/drshub/services/DrsResolutionService.java
@@ -1,6 +1,5 @@
 package bio.terra.drshub.services;
 
-import static io.github.ga4gh.drs.model.Authorizations.SupportedTypesEnum.BEARERAUTH;
 import static org.apache.commons.lang3.ObjectUtils.isEmpty;
 
 import bio.terra.common.exception.BadRequestException;
@@ -38,6 +37,7 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatusCode;
@@ -386,7 +386,7 @@ public class DrsResolutionService {
                 uriComponents.toUriString());
             yield auth.map(
                     a ->
-                        callDataRepoPostAccessUrl(
+                        callDataRepoViaPetToken(
                             tdrApiFactory,
                             bearerToken.getToken(),
                             a,
@@ -408,17 +408,47 @@ public class DrsResolutionService {
     };
   }
 
-  private static AccessURL callDataRepoPostAccessUrl(
+  private static AccessURL callDataRepoViaPetToken(
       TdrApiFactory tdrApiFactory,
       String accessToken,
       List<String> passportStrings,
       String objectId,
       String accessId,
       String xUserProject) {
+
+    // 1. Invoke Sam to get a token for the user's pet. This trades the b2c-minted `accessToken` for
+    //    a Google-minted pet token. We need a Google-minted token to send to TDR, because TDR
+    //    verifies the token via Google's tokeninfo endpoint
+    // 2. Invoke TDR's `PostAccessURL` api to resolve the DRS URI to an access url. Here, we have
+    //    to use the Terra-specific TDR client library instead of the GA4GH DRS-spec client library,
+    //    because the GA4GH client does not pass on the bearer token, and TDR needs that.
+
+    // invoke Sam to get a pet token
+    // TODO: set up a factory or other more-robust means to construct the Sam client
+    org.broadinstitute.dsde.workbench.client.sam.ApiClient samApiClient =
+        new org.broadinstitute.dsde.workbench.client.sam.ApiClient();
+    samApiClient.setAccessToken(accessToken);
+    org.broadinstitute.dsde.workbench.client.sam.api.GoogleApi samGoogleApi =
+        new org.broadinstitute.dsde.workbench.client.sam.api.GoogleApi(samApiClient);
+    String petToken;
+
+    try {
+      petToken =
+          samGoogleApi.getArbitraryPetServiceAccountToken(List.of("openid", "email", "profile"));
+    } catch (org.broadinstitute.dsde.workbench.client.sam.ApiException e) {
+      // TODO: more precise and helpful error handling
+      throw new RuntimeException(e);
+    }
+    if (StringUtils.isBlank(petToken)) {
+      // TODO: more precise and helpful error handling
+      throw new RuntimeException("Pet token is blank!");
+    }
+
+    // invoke TDR with the pet token to resolve the DRS URI
     DRSPassportRequestModel body = new DRSPassportRequestModel();
     body.setPassports(passportStrings);
 
-    DataRepositoryServiceApi drsApi = tdrApiFactory.getApi(accessToken);
+    DataRepositoryServiceApi drsApi = tdrApiFactory.getApi(petToken);
     DRSAccessURL drsAccessURL;
     try {
       drsAccessURL = drsApi.postAccessURL(body, objectId, accessId, xUserProject);

--- a/service/src/main/java/bio/terra/drshub/services/DrsResolutionService.java
+++ b/service/src/main/java/bio/terra/drshub/services/DrsResolutionService.java
@@ -449,9 +449,6 @@ public class DrsResolutionService {
     body.setPassports(passportStrings);
 
     DataRepositoryServiceApi drsApi = tdrApiFactory.getApi(petToken);
-    drsApi.setHeadersOverrides(
-        Map.of(
-            "OIDC_CLAIM_email", "fakey.mcfakerson@fake.com", "OIDC_CLAIM_user_id", "1234567890"));
     DRSAccessURL drsAccessURL;
     try {
       drsAccessURL = drsApi.postAccessURL(body, objectId, accessId, xUserProject);

--- a/service/src/main/java/bio/terra/drshub/services/DrsResolutionService.java
+++ b/service/src/main/java/bio/terra/drshub/services/DrsResolutionService.java
@@ -449,6 +449,9 @@ public class DrsResolutionService {
     body.setPassports(passportStrings);
 
     DataRepositoryServiceApi drsApi = tdrApiFactory.getApi(petToken);
+    drsApi.setHeadersOverrides(
+        Map.of(
+            "OIDC_CLAIM_email", "fakey.mcfakerson@fake.com", "OIDC_CLAIM_user_id", "1234567890"));
     DRSAccessURL drsAccessURL;
     try {
       drsAccessURL = drsApi.postAccessURL(body, objectId, accessId, xUserProject);

--- a/service/src/main/java/bio/terra/drshub/services/DrsResolutionService.java
+++ b/service/src/main/java/bio/terra/drshub/services/DrsResolutionService.java
@@ -418,28 +418,31 @@ public class DrsResolutionService {
     //    because the GA4GH client does not pass on the bearer token, and TDR needs that.
 
     // invoke Sam to get a pet token
-    //    org.broadinstitute.dsde.workbench.client.sam.api.GoogleApi samGoogleApi =
-    //        samApiFactory.getGoogleApi(accessToken);
-    //    String petToken;
-    //
-    //    try {
-    //      log.info("Retrieving access token for user from sam");
-    //      petToken =
-    //          samGoogleApi.getArbitraryPetServiceAccountToken(List.of("openid", "email",
-    // "profile"));
-    //      log.info(
-    //          "Access token retrieved for pet: token substring {} with length {}",
-    //          petToken.substring(0, 5),
-    //          petToken.length());
-    //    } catch (org.broadinstitute.dsde.workbench.client.sam.ApiException e) {
-    //      // TODO: more precise and helpful error handling
-    //      throw new RuntimeException(e);
-    //    }
-    //    if (StringUtils.isBlank(petToken)) {
-    //      // TODO: more precise and helpful error handling
-    //      throw new RuntimeException("Pet token is blank!");
-    //    }
-    String petToken = accessToken;
+    org.broadinstitute.dsde.workbench.client.sam.api.GoogleApi samGoogleApi =
+        samApiFactory.getGoogleApi(accessToken);
+    String petToken;
+
+    try {
+      log.info("Retrieving access token for user from sam");
+      petToken =
+          samGoogleApi.getArbitraryPetServiceAccountToken(List.of("openid", "email", "profile"));
+      log.info(
+          "Access token retrieved for pet: token substring {} with length {}",
+          petToken.substring(0, 5),
+          petToken.length());
+    } catch (org.broadinstitute.dsde.workbench.client.sam.ApiException e) {
+      // TODO: more precise and helpful error handling
+      throw new RuntimeException(e);
+    }
+    if (StringUtils.isBlank(petToken)) {
+      // TODO: more precise and helpful error handling
+      throw new RuntimeException("Pet token is blank!");
+    }
+    //    String petToken = accessToken;
+
+    String petTokenSample = StringUtils.substring(Optional.ofNullable(petToken).orElse(""), 0, 25);
+
+    log.info("sending token from DRSHub to TDR: {}", petTokenSample);
 
     // invoke TDR with the pet token to resolve the DRS URI
     DRSPassportRequestModel body = new DRSPassportRequestModel();

--- a/service/src/main/java/bio/terra/drshub/services/DrsResolutionService.java
+++ b/service/src/main/java/bio/terra/drshub/services/DrsResolutionService.java
@@ -56,6 +56,7 @@ public class DrsResolutionService {
   private final AuthService authService;
   private final AuditLogger auditLogger;
   private final TdrApiFactory tdrApiFactory;
+  private final SamApiFactory samApiFactory;
   public static final String TRANSACTION_ID_HEADER_NAME = "X-Transaction-Id";
 
   @Autowired
@@ -63,11 +64,13 @@ public class DrsResolutionService {
       DrsApiFactory drsApiFactory,
       AuthService authService,
       AuditLogger auditLogger,
-      TdrApiFactory tdrApiFactory) {
+      TdrApiFactory tdrApiFactory,
+      SamApiFactory samApiFactory) {
     this.drsApiFactory = drsApiFactory;
     this.authService = authService;
     this.auditLogger = auditLogger;
     this.tdrApiFactory = tdrApiFactory;
+    this.samApiFactory = samApiFactory;
   }
 
   /**
@@ -316,7 +319,6 @@ public class DrsResolutionService {
                 accessMethodType,
                 uriComponents,
                 googleProject,
-                tdrApiFactory,
                 bearerToken);
       } catch (HttpClientErrorException.BadRequest e) {
         if (retryMode && googleProject != null && isRequireUserProjectError(e)) {
@@ -333,7 +335,6 @@ public class DrsResolutionService {
                   accessMethodType,
                   uriComponents,
                   googleProject,
-                  tdrApiFactory,
                   bearerToken);
         } else {
           throw e;
@@ -348,7 +349,7 @@ public class DrsResolutionService {
     return null;
   }
 
-  private static AccessURL callAccessUrl(
+  private AccessURL callAccessUrl(
       DrsApi drsApi,
       String objectId,
       String accessId,
@@ -356,7 +357,6 @@ public class DrsResolutionService {
       TypeEnum accessMethodType,
       UriComponents uriComponents,
       String googleProject,
-      TdrApiFactory tdrApiFactory,
       BearerToken bearerToken) {
     Optional<List<String>> auth =
         authorization.getAuthForAccessMethodType().apply(accessMethodType);
@@ -387,12 +387,7 @@ public class DrsResolutionService {
             yield auth.map(
                     a ->
                         callDataRepoViaPetToken(
-                            tdrApiFactory,
-                            bearerToken.getToken(),
-                            a,
-                            objectId,
-                            accessId,
-                            googleProject))
+                            bearerToken.getToken(), a, objectId, accessId, googleProject))
                 .orElse(null);
           }
           yield auth.map(a -> drsApi.postAccessURL(Map.of("passports", a), objectId, accessId))
@@ -408,8 +403,7 @@ public class DrsResolutionService {
     };
   }
 
-  private static AccessURL callDataRepoViaPetToken(
-      TdrApiFactory tdrApiFactory,
+  private AccessURL callDataRepoViaPetToken(
       String accessToken,
       List<String> passportStrings,
       String objectId,
@@ -424,17 +418,17 @@ public class DrsResolutionService {
     //    because the GA4GH client does not pass on the bearer token, and TDR needs that.
 
     // invoke Sam to get a pet token
-    // TODO: set up a factory or other more-robust means to construct the Sam client
-    org.broadinstitute.dsde.workbench.client.sam.ApiClient samApiClient =
-        new org.broadinstitute.dsde.workbench.client.sam.ApiClient();
-    samApiClient.setAccessToken(accessToken);
     org.broadinstitute.dsde.workbench.client.sam.api.GoogleApi samGoogleApi =
-        new org.broadinstitute.dsde.workbench.client.sam.api.GoogleApi(samApiClient);
+        samApiFactory.getGoogleApi(accessToken);
     String petToken;
 
     try {
       petToken =
           samGoogleApi.getArbitraryPetServiceAccountToken(List.of("openid", "email", "profile"));
+      log.info(
+          "Retrieving access token for pet token {} with length {}",
+          petToken.substring(0, 5),
+          petToken.length());
     } catch (org.broadinstitute.dsde.workbench.client.sam.ApiException e) {
       // TODO: more precise and helpful error handling
       throw new RuntimeException(e);

--- a/service/src/main/java/bio/terra/drshub/services/DrsResolutionService.java
+++ b/service/src/main/java/bio/terra/drshub/services/DrsResolutionService.java
@@ -37,7 +37,6 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatusCode;
@@ -409,47 +408,11 @@ public class DrsResolutionService {
       String objectId,
       String accessId,
       String xUserProject) {
-
-    // 1. Invoke Sam to get a token for the user's pet. This trades the b2c-minted `accessToken` for
-    //    a Google-minted pet token. We need a Google-minted token to send to TDR, because TDR
-    //    verifies the token via Google's tokeninfo endpoint
-    // 2. Invoke TDR's `PostAccessURL` api to resolve the DRS URI to an access url. Here, we have
-    //    to use the Terra-specific TDR client library instead of the GA4GH DRS-spec client library,
-    //    because the GA4GH client does not pass on the bearer token, and TDR needs that.
-
-    //    // invoke Sam to get a pet token
-    //    org.broadinstitute.dsde.workbench.client.sam.api.GoogleApi samGoogleApi =
-    //        samApiFactory.getGoogleApi(accessToken);
-    //    String petToken;
-    //
-    //    try {
-    //      log.info("Retrieving access token for user from sam");
-    //      petToken =
-    //          samGoogleApi.getArbitraryPetServiceAccountToken(List.of("openid", "email",
-    // "profile"));
-    //      log.info(
-    //          "Access token retrieved for pet: token substring {} with length {}",
-    //          petToken.substring(0, 5),
-    //          petToken.length());
-    //    } catch (org.broadinstitute.dsde.workbench.client.sam.ApiException e) {
-    //      // TODO: more precise and helpful error handling
-    //      throw new RuntimeException(e);
-    //    }
-    //    if (StringUtils.isBlank(petToken)) {
-    //      // TODO: more precise and helpful error handling
-    //      throw new RuntimeException("Pet token is blank!");
-    //    }
-    String petToken = accessToken;
-
-    String petTokenSample = StringUtils.substring(Optional.ofNullable(petToken).orElse(""), 0, 25);
-
-    log.info("sending token from DRSHub to TDR: {}", petTokenSample);
-
     // invoke TDR with the pet token to resolve the DRS URI
     DRSPassportRequestModel body = new DRSPassportRequestModel();
     body.setPassports(passportStrings);
 
-    DataRepositoryServiceApi drsApi = tdrApiFactory.getApi(petToken);
+    DataRepositoryServiceApi drsApi = tdrApiFactory.getApi(accessToken);
     DRSAccessURL drsAccessURL;
     try {
       drsAccessURL = drsApi.postAccessURL(body, objectId, accessId, xUserProject);

--- a/service/src/main/java/bio/terra/drshub/services/DrsResolutionService.java
+++ b/service/src/main/java/bio/terra/drshub/services/DrsResolutionService.java
@@ -5,6 +5,10 @@ import static org.apache.commons.lang3.ObjectUtils.isEmpty;
 
 import bio.terra.common.exception.BadRequestException;
 import bio.terra.common.iam.BearerToken;
+import bio.terra.datarepo.api.DataRepositoryServiceApi;
+import bio.terra.datarepo.client.ApiException;
+import bio.terra.datarepo.model.DRSAccessURL;
+import bio.terra.datarepo.model.DRSPassportRequestModel;
 import bio.terra.drshub.config.DrsProvider;
 import bio.terra.drshub.config.DrsProviderInterface;
 import bio.terra.drshub.generated.model.RequestObject.CloudPlatformEnum;
@@ -35,9 +39,12 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.util.UriComponents;
 
@@ -48,14 +55,19 @@ public class DrsResolutionService {
   private final DrsApiFactory drsApiFactory;
   private final AuthService authService;
   private final AuditLogger auditLogger;
+  private final TdrApiFactory tdrApiFactory;
   public static final String TRANSACTION_ID_HEADER_NAME = "X-Transaction-Id";
 
   @Autowired
   public DrsResolutionService(
-      DrsApiFactory drsApiFactory, AuthService authService, AuditLogger auditLogger) {
+      DrsApiFactory drsApiFactory,
+      AuthService authService,
+      AuditLogger auditLogger,
+      TdrApiFactory tdrApiFactory) {
     this.drsApiFactory = drsApiFactory;
     this.authService = authService;
     this.auditLogger = auditLogger;
+    this.tdrApiFactory = tdrApiFactory;
   }
 
   /**
@@ -304,6 +316,7 @@ public class DrsResolutionService {
                 accessMethodType,
                 uriComponents,
                 googleProject,
+                tdrApiFactory,
                 bearerToken);
       } catch (HttpClientErrorException.BadRequest e) {
         if (retryMode && googleProject != null && isRequireUserProjectError(e)) {
@@ -320,6 +333,7 @@ public class DrsResolutionService {
                   accessMethodType,
                   uriComponents,
                   googleProject,
+                  tdrApiFactory,
                   bearerToken);
         } else {
           throw e;
@@ -342,6 +356,7 @@ public class DrsResolutionService {
       TypeEnum accessMethodType,
       UriComponents uriComponents,
       String googleProject,
+      TdrApiFactory tdrApiFactory,
       BearerToken bearerToken) {
     Optional<List<String>> auth =
         authorization.getAuthForAccessMethodType().apply(accessMethodType);
@@ -364,14 +379,21 @@ public class DrsResolutionService {
       }
       case PASSPORTAUTH -> {
         try {
-          // If googleProject is set, also send bearer token alongside passports to enable
-          // signing the access url with the userProject set with the right access
           if (googleProject != null && bearerToken != null && bearerToken.getToken() != null) {
             log.info(
-                "Google project {} specified for passport auth request to {}. Setting user's bearer token.",
+                "Google project {} specified for passport auth request to {}. Using TDR client with bearer token.",
                 googleProject,
                 uriComponents.toUriString());
-            drsApi.setBearerToken(bearerToken.getToken());
+            yield auth.map(
+                    a ->
+                        callDataRepoPostAccessUrl(
+                            tdrApiFactory,
+                            bearerToken.getToken(),
+                            a,
+                            objectId,
+                            accessId,
+                            googleProject))
+                .orElse(null);
           }
           yield auth.map(a -> drsApi.postAccessURL(Map.of("passports", a), objectId, accessId))
               .orElse(null);
@@ -384,6 +406,42 @@ public class DrsResolutionService {
         }
       }
     };
+  }
+
+  private static AccessURL callDataRepoPostAccessUrl(
+      TdrApiFactory tdrApiFactory,
+      String accessToken,
+      List<String> passportStrings,
+      String objectId,
+      String accessId,
+      String xUserProject) {
+    DRSPassportRequestModel body = new DRSPassportRequestModel();
+    body.setPassports(passportStrings);
+
+    DataRepositoryServiceApi drsApi = tdrApiFactory.getApi(accessToken);
+    DRSAccessURL drsAccessURL;
+    try {
+      drsAccessURL = drsApi.postAccessURL(body, objectId, accessId, xUserProject);
+    } catch (ApiException e) {
+      var status = HttpStatusCode.valueOf(e.getCode());
+      var responseBody =
+          e.getResponseBody() != null
+              ? e.getResponseBody().getBytes(StandardCharsets.UTF_8)
+              : new byte[0];
+      if (status.is4xxClientError()) {
+        throw HttpClientErrorException.create(
+            status, e.getMessage(), HttpHeaders.EMPTY, responseBody, StandardCharsets.UTF_8);
+      }
+      throw HttpServerErrorException.create(
+          status, e.getMessage(), HttpHeaders.EMPTY, responseBody, StandardCharsets.UTF_8);
+    }
+
+    // translate the ga4gh client model to the TDR client model for the response
+    AccessURL accessURL = new AccessURL();
+    accessURL.setUrl(drsAccessURL.getUrl());
+    accessURL.setHeaders(drsAccessURL.getHeaders());
+
+    return accessURL;
   }
 
   private static boolean isRequireUserProjectError(HttpClientErrorException.BadRequest e) {

--- a/service/src/main/java/bio/terra/drshub/services/SamApiFactory.java
+++ b/service/src/main/java/bio/terra/drshub/services/SamApiFactory.java
@@ -3,6 +3,7 @@ package bio.terra.drshub.services;
 import bio.terra.common.iam.BearerToken;
 import bio.terra.drshub.config.DrsHubConfig;
 import bio.terra.sam.api.SamApi;
+import org.broadinstitute.dsde.workbench.client.sam.api.GoogleApi;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -14,5 +15,12 @@ public record SamApiFactory(DrsHubConfig drsHubConfig) {
     samApi.getApiClient().setAccessToken(bearerToken.getToken());
 
     return samApi;
+  }
+
+  public GoogleApi getGoogleApi(String accessToken) {
+    var apiClient = new org.broadinstitute.dsde.workbench.client.sam.ApiClient();
+    apiClient.setBasePath(drsHubConfig.getSamUrl());
+    apiClient.setAccessToken(accessToken);
+    return new GoogleApi(apiClient);
   }
 }

--- a/service/src/main/java/bio/terra/drshub/services/SamApiFactory.java
+++ b/service/src/main/java/bio/terra/drshub/services/SamApiFactory.java
@@ -3,7 +3,6 @@ package bio.terra.drshub.services;
 import bio.terra.common.iam.BearerToken;
 import bio.terra.drshub.config.DrsHubConfig;
 import bio.terra.sam.api.SamApi;
-import org.broadinstitute.dsde.workbench.client.sam.api.GoogleApi;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -15,12 +14,5 @@ public record SamApiFactory(DrsHubConfig drsHubConfig) {
     samApi.getApiClient().setAccessToken(bearerToken.getToken());
 
     return samApi;
-  }
-
-  public GoogleApi getGoogleApi(String accessToken) {
-    var apiClient = new org.broadinstitute.dsde.workbench.client.sam.ApiClient();
-    apiClient.setBasePath(drsHubConfig.getSamUrl());
-    apiClient.setAccessToken(accessToken);
-    return new GoogleApi(apiClient);
   }
 }

--- a/service/src/main/java/bio/terra/drshub/services/TdrApiFactory.java
+++ b/service/src/main/java/bio/terra/drshub/services/TdrApiFactory.java
@@ -1,0 +1,17 @@
+package bio.terra.drshub.services;
+
+import bio.terra.datarepo.api.DataRepositoryServiceApi;
+import bio.terra.datarepo.client.ApiClient;
+import bio.terra.drshub.config.DrsHubConfig;
+import org.springframework.stereotype.Service;
+
+@Service
+public record TdrApiFactory(DrsHubConfig drsHubConfig) {
+
+  public DataRepositoryServiceApi getApi(String accessToken) {
+    var apiClient = new ApiClient();
+    apiClient.setBasePath(drsHubConfig.getTdrUrl());
+    apiClient.setAccessToken(accessToken);
+    return new DataRepositoryServiceApi(apiClient);
+  }
+}

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -4,6 +4,7 @@ drshub:
   bardUrl: https://terra-bard-${deploy_env}.appspot.com
   samUrl: https://sam.dsde-${deploy_env}.broadinstitute.org
   externalcredsUrl: https://externalcreds.dsde-${deploy_env}.broadinstitute.org
+  tdrUrl: ${TDR_URL:https://jade.datarepo-dev.broadinstitute.org}
 
   drsProviders:
     anvil:

--- a/service/src/test/java/bio/terra/drshub/controllers/VerifyPactDrsHubApiController.java
+++ b/service/src/test/java/bio/terra/drshub/controllers/VerifyPactDrsHubApiController.java
@@ -25,6 +25,7 @@ import bio.terra.drshub.services.AuthService;
 import bio.terra.drshub.services.DrsApiFactory;
 import bio.terra.drshub.services.DrsProviderService;
 import bio.terra.drshub.services.DrsResolutionService;
+import bio.terra.drshub.services.TdrApiFactory;
 import bio.terra.drshub.services.TrackingService;
 import bio.terra.drshub.tracking.UserLoggingMetrics;
 import bio.terra.drshub.util.AsyncUtils;
@@ -65,6 +66,7 @@ class VerifyPactsDrsHubApiController {
   @MockBean private AuthService authService;
   @MockBean private DrsApi drsApi;
   @MockBean private DrsApiFactory drsApiFactory;
+  @MockBean private TdrApiFactory tdrApiFactory;
   @MockBean private AuditLogger auditLogger;
   @MockBean private TrackingService trackingService;
   @SpyBean private DrsResolutionService drsResolutionService;

--- a/service/src/test/java/bio/terra/drshub/services/DrsResolutionServiceTest.java
+++ b/service/src/test/java/bio/terra/drshub/services/DrsResolutionServiceTest.java
@@ -103,11 +103,10 @@ class DrsResolutionServiceTest {
   @BeforeEach
   void before() throws Exception {
     DrsApiFactory drsApiFactory = mock(DrsApiFactory.class);
-    SamApiFactory samApiFactory = mock(SamApiFactory.class);
 
     drsResolutionService =
         new DrsResolutionService(
-            drsApiFactory, authService, mock(AuditLogger.class), tdrApiFactory, samApiFactory);
+            drsApiFactory, authService, mock(AuditLogger.class), tdrApiFactory);
 
     when(uriComponents.getHost()).thenReturn("host.com");
     when(uriComponents.getPath()).thenReturn(PATH);
@@ -391,14 +390,13 @@ class DrsResolutionServiceTest {
     var retryApi = mock(DrsApi.class);
 
     DrsApiFactory drsApiFactory = mock(DrsApiFactory.class);
-    SamApiFactory samApiFactory = mock(SamApiFactory.class);
     when(drsApiFactory.getApiFromUriComponents(eq(uriComponents), any(DrsProvider.class)))
         .thenReturn(drsApi)
         .thenReturn(retryApi);
 
     drsResolutionService =
         new DrsResolutionService(
-            drsApiFactory, authService, mock(AuditLogger.class), tdrApiFactory, samApiFactory);
+            drsApiFactory, authService, mock(AuditLogger.class), tdrApiFactory);
 
     SignedUrlTestUtils.setupSignedUrlMocks(authService, googleStorageService, googleProject, url);
     when(drsApi.getAccessURL(PATH, accessId))

--- a/service/src/test/java/bio/terra/drshub/services/DrsResolutionServiceTest.java
+++ b/service/src/test/java/bio/terra/drshub/services/DrsResolutionServiceTest.java
@@ -12,6 +12,9 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import bio.terra.common.iam.BearerToken;
+import bio.terra.datarepo.api.DataRepositoryServiceApi;
+import bio.terra.datarepo.model.DRSAccessURL;
+import bio.terra.datarepo.model.DRSPassportRequestModel;
 import bio.terra.drshub.config.DrsProvider;
 import bio.terra.drshub.config.ProviderAccessMethodConfig;
 import bio.terra.drshub.logging.AuditLogEvent;
@@ -59,6 +62,8 @@ class DrsResolutionServiceTest {
   @Mock private UriComponents uriComponents;
   @Mock private AuthService authService;
   @Mock private GoogleStorageService googleStorageService;
+  @Mock private TdrApiFactory tdrApiFactory;
+  @Mock private DataRepositoryServiceApi tdrApi;
 
   private static final String PATH = "path";
 
@@ -100,7 +105,8 @@ class DrsResolutionServiceTest {
     DrsApiFactory drsApiFactory = mock(DrsApiFactory.class);
 
     drsResolutionService =
-        new DrsResolutionService(drsApiFactory, authService, mock(AuditLogger.class));
+        new DrsResolutionService(
+            drsApiFactory, authService, mock(AuditLogger.class), tdrApiFactory);
 
     when(uriComponents.getHost()).thenReturn("host.com");
     when(uriComponents.getPath()).thenReturn(PATH);
@@ -389,7 +395,8 @@ class DrsResolutionServiceTest {
         .thenReturn(retryApi);
 
     drsResolutionService =
-        new DrsResolutionService(drsApiFactory, authService, mock(AuditLogger.class));
+        new DrsResolutionService(
+            drsApiFactory, authService, mock(AuditLogger.class), tdrApiFactory);
 
     SignedUrlTestUtils.setupSignedUrlMocks(authService, googleStorageService, googleProject, url);
     when(drsApi.getAccessURL(PATH, accessId))
@@ -532,17 +539,72 @@ class DrsResolutionServiceTest {
                         .setRequiresUserProjectOnRetry(true))));
   }
 
-  private static Stream<Arguments> passportAuthWithGoogleProject() {
-    return Stream.of(
-        Arguments.of("test-project", true), // googleProject set, bearer token should be set
-        Arguments.of(null, false) // no googleProject, bearer token should not be set
-        );
+  @Test
+  void passportAuthWithGoogleProject_usesTdrClient() throws Exception {
+    var googleProject = "test-project";
+    var passportAuth =
+        new DrsHubAuthorization(SupportedTypesEnum.PASSPORTAUTH, (var e) -> Optional.of(PASSPORTS));
+    var bearerAuth =
+        new DrsHubAuthorization(
+            SupportedTypesEnum.BEARERAUTH, (var e) -> Optional.of(List.of(TOKEN_VALUE)));
+
+    when(tdrApiFactory.getApi(TOKEN_VALUE)).thenReturn(tdrApi);
+    when(tdrApi.postAccessURL(
+            any(DRSPassportRequestModel.class), eq(PATH), eq(accessId), eq(googleProject)))
+        .thenReturn(new DRSAccessURL().url("https://example.com"));
+
+    var response =
+        drsResolutionService.fetchDrsObjectAccessUrl(
+            testDrsProvider,
+            uriComponents,
+            accessId,
+            TypeEnum.GS,
+            List.of(passportAuth, bearerAuth),
+            new AuditLogEvent.Builder(),
+            null,
+            googleProject,
+            TOKEN,
+            TRANSACTION_ID);
+
+    assertThat("access url returned", response.getUrl(), equalTo("https://example.com"));
+    verify(tdrApiFactory).getApi(TOKEN_VALUE);
+    verify(tdrApi)
+        .postAccessURL(
+            any(DRSPassportRequestModel.class), eq(PATH), eq(accessId), eq(googleProject));
+    verify(drsApi, never()).postAccessURL(any(), any(), any());
+    verify(drsApi, never()).setBearerToken(any());
   }
 
-  @ParameterizedTest
-  @MethodSource
-  void passportAuthWithGoogleProject(String googleProject, boolean shouldSetBearerToken)
-      throws Exception {
+  @Test
+  void passportAuthWithGoogleProject_usesTdrFactory() throws Exception {
+    var googleProject = "test-project";
+    var passportAuth =
+        new DrsHubAuthorization(SupportedTypesEnum.PASSPORTAUTH, (var e) -> Optional.of(PASSPORTS));
+    var bearerAuth =
+        new DrsHubAuthorization(
+            SupportedTypesEnum.BEARERAUTH, (var e) -> Optional.of(List.of(TOKEN_VALUE)));
+
+    when(tdrApiFactory.getApi(TOKEN_VALUE)).thenReturn(tdrApi);
+    when(tdrApi.postAccessURL(any(DRSPassportRequestModel.class), any(), any(), any()))
+        .thenReturn(new DRSAccessURL().url("https://example.com"));
+
+    drsResolutionService.fetchDrsObjectAccessUrl(
+        testDrsProvider,
+        uriComponents,
+        accessId,
+        TypeEnum.GS,
+        List.of(passportAuth, bearerAuth),
+        new AuditLogEvent.Builder(),
+        null,
+        googleProject,
+        TOKEN,
+        TRANSACTION_ID);
+
+    verify(tdrApiFactory).getApi(TOKEN_VALUE);
+  }
+
+  @Test
+  void passportAuthWithGoogleProject_noGoogleProject() throws Exception {
     var passportAuth =
         new DrsHubAuthorization(SupportedTypesEnum.PASSPORTAUTH, (var e) -> Optional.of(PASSPORTS));
     var bearerAuth =
@@ -561,18 +623,14 @@ class DrsResolutionServiceTest {
             List.of(passportAuth, bearerAuth),
             new AuditLogEvent.Builder(),
             null,
-            googleProject,
+            null,
             TOKEN,
             TRANSACTION_ID);
 
     assertThat("access url returned", response.getUrl(), equalTo("https://example.com"));
     verify(drsApi).postAccessURL(Map.of("passports", PASSPORTS), PATH, accessId);
-
-    if (shouldSetBearerToken) {
-      verify(drsApi).setBearerToken(TOKEN_VALUE);
-    } else {
-      verify(drsApi, never()).setBearerToken(any());
-    }
+    verify(drsApi, never()).setBearerToken(any());
+    verifyNoInteractions(tdrApiFactory);
   }
 
   @Test
@@ -581,8 +639,10 @@ class DrsResolutionServiceTest {
     var passportAuth =
         new DrsHubAuthorization(SupportedTypesEnum.PASSPORTAUTH, (var e) -> Optional.of(PASSPORTS));
 
-    when(drsApi.postAccessURL(Map.of("passports", PASSPORTS), PATH, accessId))
-        .thenReturn(new AccessURL().url("https://example.com"));
+    when(tdrApiFactory.getApi(TOKEN_VALUE)).thenReturn(tdrApi);
+    when(tdrApi.postAccessURL(
+            any(DRSPassportRequestModel.class), eq(PATH), eq(accessId), eq(googleProject)))
+        .thenReturn(new DRSAccessURL().url("https://example.com"));
 
     var response =
         drsResolutionService.fetchDrsObjectAccessUrl(
@@ -598,21 +658,25 @@ class DrsResolutionServiceTest {
             TRANSACTION_ID);
 
     assertThat("access url returned", response.getUrl(), equalTo("https://example.com"));
-    verify(drsApi).postAccessURL(Map.of("passports", PASSPORTS), PATH, accessId);
-    // With the fix, we now use the user's bearer token directly when googleProject is set
-    verify(drsApi).setBearerToken(TOKEN_VALUE);
+    verify(tdrApiFactory).getApi(TOKEN_VALUE);
+    verify(tdrApi)
+        .postAccessURL(
+            any(DRSPassportRequestModel.class), eq(PATH), eq(accessId), eq(googleProject));
+    verify(drsApi, never()).postAccessURL(any(), any(), any());
+    verify(drsApi, never()).setBearerToken(any());
   }
 
   @Test
   void fetchDrsObjectAccessUrl_passportAuthWithGoogleProject_usesUserToken() throws Exception {
-    // Test the full fetchDrsObjectAccessUrl flow to ensure user's bearer token is set
     var googleProject = "test-google-project";
     var ip = "test.ip";
     var passportAuth =
         new DrsHubAuthorization(SupportedTypesEnum.PASSPORTAUTH, (var e) -> Optional.of(PASSPORTS));
 
-    when(drsApi.postAccessURL(Map.of("passports", PASSPORTS), PATH, accessId))
-        .thenReturn(new AccessURL().url("https://signed-url.example.com/data"));
+    when(tdrApiFactory.getApi(TOKEN_VALUE)).thenReturn(tdrApi);
+    when(tdrApi.postAccessURL(
+            any(DRSPassportRequestModel.class), eq(PATH), eq(accessId), eq(googleProject)))
+        .thenReturn(new DRSAccessURL().url("https://signed-url.example.com/data"));
 
     var response =
         drsResolutionService.fetchDrsObjectAccessUrl(
@@ -632,13 +696,14 @@ class DrsResolutionServiceTest {
         response.getUrl(),
         equalTo("https://signed-url.example.com/data"));
 
-    // Verify standard headers are set
     verify(drsApi).setHeader("X-Forwarded-For", ip);
     verify(drsApi).setHeader("x-user-project", googleProject);
     verify(drsApi).setHeader(DrsResolutionService.TRANSACTION_ID_HEADER_NAME, TRANSACTION_ID);
-
-    // Verify user's bearer token is set before passport auth call
-    verify(drsApi).setBearerToken(TOKEN_VALUE);
-    verify(drsApi).postAccessURL(Map.of("passports", PASSPORTS), PATH, accessId);
+    verify(tdrApiFactory).getApi(TOKEN_VALUE);
+    verify(tdrApi)
+        .postAccessURL(
+            any(DRSPassportRequestModel.class), eq(PATH), eq(accessId), eq(googleProject));
+    verify(drsApi, never()).postAccessURL(any(), any(), any());
+    verify(drsApi, never()).setBearerToken(any());
   }
 }

--- a/service/src/test/java/bio/terra/drshub/services/DrsResolutionServiceTest.java
+++ b/service/src/test/java/bio/terra/drshub/services/DrsResolutionServiceTest.java
@@ -103,10 +103,11 @@ class DrsResolutionServiceTest {
   @BeforeEach
   void before() throws Exception {
     DrsApiFactory drsApiFactory = mock(DrsApiFactory.class);
+    SamApiFactory samApiFactory = mock(SamApiFactory.class);
 
     drsResolutionService =
         new DrsResolutionService(
-            drsApiFactory, authService, mock(AuditLogger.class), tdrApiFactory);
+            drsApiFactory, authService, mock(AuditLogger.class), tdrApiFactory, samApiFactory);
 
     when(uriComponents.getHost()).thenReturn("host.com");
     when(uriComponents.getPath()).thenReturn(PATH);
@@ -390,13 +391,14 @@ class DrsResolutionServiceTest {
     var retryApi = mock(DrsApi.class);
 
     DrsApiFactory drsApiFactory = mock(DrsApiFactory.class);
+    SamApiFactory samApiFactory = mock(SamApiFactory.class);
     when(drsApiFactory.getApiFromUriComponents(eq(uriComponents), any(DrsProvider.class)))
         .thenReturn(drsApi)
         .thenReturn(retryApi);
 
     drsResolutionService =
         new DrsResolutionService(
-            drsApiFactory, authService, mock(AuditLogger.class), tdrApiFactory);
+            drsApiFactory, authService, mock(AuditLogger.class), tdrApiFactory, samApiFactory);
 
     SignedUrlTestUtils.setupSignedUrlMocks(authService, googleStorageService, googleProject, url);
     when(drsApi.getAccessURL(PATH, accessId))


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/CTM-473

https://github.com/DataBiosphere/terra-drs-hub/pull/247 and https://github.com/DataBiosphere/jade-data-repo/pull/2105 work together to support the (DRS resolution + passport + user-specified project for requester-pays) use case.

At a high level, these two PRs:
* In DRSHub, switch from using the GA4GH-standard DRS client library to the Terra-specific TDR client library for the TDR endpoint request in this specific use case. This allows passing the user's `Authorization: Bearer` token in the request.
* In TDR, add business logic to extract the bearer token from the request. We need this business logic because the TDR `/ga4gh/...` endpoint in question is missing some request headers that are only set by the oidc-proxy for requests under the `/api/...` prefix.

---

In this PR:
* Re-implement https://github.com/DataBiosphere/terra-drs-hub/pull/244 (by reverting https://github.com/DataBiosphere/terra-drs-hub/pull/245) to use Terra's TDR client instead of the GA4GH client when invoking PostAccessURL in TDR.
