### PR TITLE
[CTM-472] Fix BDC DRS resolve returning accessUrl: null when userProject is present

### DIFF
--- a/service/src/main/java/bio/terra/drshub/config/ProviderAccessMethodConfigInterface.java
+++ b/service/src/main/java/bio/terra/drshub/config/ProviderAccessMethodConfigInterface.java
@@ -27,4 +27,15 @@ public interface ProviderAccessMethodConfigInterface {
   default boolean requiresUserProjectOnRetry() {
     return false;
   }
+
+  /**
+   * When true, passport-auth access-URL requests that include a googleProject are routed through
+   * the TDR client (which forwards x-user-project to sign the URL against the caller's billing
+   * project). Only TDR supports this mechanism; non-TDR providers (e.g. BDC/Gen3) must use the
+   * standard passport POST path regardless of whether a googleProject is present.
+   */
+  @Default
+  default boolean supportsUserProject() {
+    return false;
+  }
 }

--- a/service/src/main/java/bio/terra/drshub/services/DrsResolutionService.java
+++ b/service/src/main/java/bio/terra/drshub/services/DrsResolutionService.java
@@ -296,6 +296,8 @@ public class DrsResolutionService {
     var accessMethodConfig = drsProvider.getAccessMethodByType(accessMethodType);
     boolean retryMode =
         accessMethodConfig != null && accessMethodConfig.requiresUserProjectOnRetry();
+    boolean supportsUserProject =
+        accessMethodConfig != null && accessMethodConfig.supportsUserProject();
 
     // Set x-user-project immediately for providers that always want it
     if (!retryMode && googleProject != null) {
@@ -316,7 +318,7 @@ public class DrsResolutionService {
                 uriComponents,
                 googleProject,
                 bearerToken,
-                retryMode);
+                supportsUserProject);
       } catch (HttpClientErrorException.BadRequest e) {
         if (retryMode && googleProject != null && isRequireUserProjectError(e)) {
           // Retry with a fresh client that includes x-user-project
@@ -333,7 +335,7 @@ public class DrsResolutionService {
                   uriComponents,
                   googleProject,
                   bearerToken,
-                  retryMode);
+                  supportsUserProject);
         } else {
           throw e;
         }
@@ -356,7 +358,7 @@ public class DrsResolutionService {
       UriComponents uriComponents,
       String googleProject,
       BearerToken bearerToken,
-      boolean requiresUserProjectOnRetry) {
+      boolean supportsUserProject) {
     Optional<List<String>> auth =
         authorization.getAuthForAccessMethodType().apply(accessMethodType);
 
@@ -382,7 +384,7 @@ public class DrsResolutionService {
           // passports to enable signing the access url with the userProject set with the right
           // access. Non-TDR providers (e.g. BDC) do not use x-user-project and must not be routed
           // to TDR.
-          if (requiresUserProjectOnRetry
+          if (supportsUserProject
               && googleProject != null
               && bearerToken != null
               && bearerToken.getToken() != null) {

--- a/service/src/main/java/bio/terra/drshub/services/DrsResolutionService.java
+++ b/service/src/main/java/bio/terra/drshub/services/DrsResolutionService.java
@@ -315,7 +315,8 @@ public class DrsResolutionService {
                 accessMethodType,
                 uriComponents,
                 googleProject,
-                bearerToken);
+                bearerToken,
+                retryMode);
       } catch (HttpClientErrorException.BadRequest e) {
         if (retryMode && googleProject != null && isRequireUserProjectError(e)) {
           // Retry with a fresh client that includes x-user-project
@@ -331,7 +332,8 @@ public class DrsResolutionService {
                   accessMethodType,
                   uriComponents,
                   googleProject,
-                  bearerToken);
+                  bearerToken,
+                  retryMode);
         } else {
           throw e;
         }
@@ -353,7 +355,8 @@ public class DrsResolutionService {
       TypeEnum accessMethodType,
       UriComponents uriComponents,
       String googleProject,
-      BearerToken bearerToken) {
+      BearerToken bearerToken,
+      boolean requiresUserProjectOnRetry) {
     Optional<List<String>> auth =
         authorization.getAuthForAccessMethodType().apply(accessMethodType);
 
@@ -375,9 +378,14 @@ public class DrsResolutionService {
       }
       case PASSPORTAUTH -> {
         try {
-          // If googleProject is set, also send bearer token alongside passports to enable
-          // signing the access url with the userProject set with the right access
-          if (googleProject != null && bearerToken != null && bearerToken.getToken() != null) {
+          // If googleProject is set and this is a TDR provider, also send bearer token alongside
+          // passports to enable signing the access url with the userProject set with the right
+          // access. Non-TDR providers (e.g. BDC) do not use x-user-project and must not be routed
+          // to TDR.
+          if (requiresUserProjectOnRetry
+              && googleProject != null
+              && bearerToken != null
+              && bearerToken.getToken() != null) {
             log.info(
                 "Google project {} specified for passport auth request to {}. Using TDR client with bearer token.",
                 googleProject,

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -52,6 +52,7 @@ drshub:
           auth: current_request
           fetchAccessUrl: true
           requiresUserProjectOnRetry: true
+          supportsUserProject: true
         - type: https
           auth: current_request
           fetchAccessUrl: true # Used for Azure

--- a/service/src/test/java/bio/terra/drshub/services/DrsResolutionServiceTest.java
+++ b/service/src/test/java/bio/terra/drshub/services/DrsResolutionServiceTest.java
@@ -541,6 +541,7 @@ class DrsResolutionServiceTest {
 
   @Test
   void passportAuthWithGoogleProject_usesTdrClient() throws Exception {
+    var tdrProvider = createTdrProviderWithRetryMode();
     var googleProject = "test-project";
     var passportAuth =
         new DrsHubAuthorization(SupportedTypesEnum.PASSPORTAUTH, (var e) -> Optional.of(PASSPORTS));
@@ -555,7 +556,7 @@ class DrsResolutionServiceTest {
 
     var response =
         drsResolutionService.fetchDrsObjectAccessUrl(
-            testDrsProvider,
+            tdrProvider,
             uriComponents,
             accessId,
             TypeEnum.GS,
@@ -577,6 +578,7 @@ class DrsResolutionServiceTest {
 
   @Test
   void passportAuthWithGoogleProject_usesTdrFactory() throws Exception {
+    var tdrProvider = createTdrProviderWithRetryMode();
     var googleProject = "test-project";
     var passportAuth =
         new DrsHubAuthorization(SupportedTypesEnum.PASSPORTAUTH, (var e) -> Optional.of(PASSPORTS));
@@ -589,7 +591,7 @@ class DrsResolutionServiceTest {
         .thenReturn(new DRSAccessURL().url("https://example.com"));
 
     drsResolutionService.fetchDrsObjectAccessUrl(
-        testDrsProvider,
+        tdrProvider,
         uriComponents,
         accessId,
         TypeEnum.GS,
@@ -635,6 +637,7 @@ class DrsResolutionServiceTest {
 
   @Test
   void passportAuthWithGoogleProject_noBearerAuthInList() throws Exception {
+    var tdrProvider = createTdrProviderWithRetryMode();
     var googleProject = "test-project";
     var passportAuth =
         new DrsHubAuthorization(SupportedTypesEnum.PASSPORTAUTH, (var e) -> Optional.of(PASSPORTS));
@@ -646,7 +649,7 @@ class DrsResolutionServiceTest {
 
     var response =
         drsResolutionService.fetchDrsObjectAccessUrl(
-            testDrsProvider,
+            tdrProvider,
             uriComponents,
             accessId,
             TypeEnum.GS,
@@ -668,6 +671,7 @@ class DrsResolutionServiceTest {
 
   @Test
   void fetchDrsObjectAccessUrl_passportAuthWithGoogleProject_usesUserToken() throws Exception {
+    var tdrProvider = createTdrProviderWithRetryMode();
     var googleProject = "test-google-project";
     var ip = "test.ip";
     var passportAuth =
@@ -680,7 +684,7 @@ class DrsResolutionServiceTest {
 
     var response =
         drsResolutionService.fetchDrsObjectAccessUrl(
-            testDrsProvider,
+            tdrProvider,
             uriComponents,
             accessId,
             TypeEnum.GS,
@@ -697,7 +701,6 @@ class DrsResolutionServiceTest {
         equalTo("https://signed-url.example.com/data"));
 
     verify(drsApi).setHeader("X-Forwarded-For", ip);
-    verify(drsApi).setHeader("x-user-project", googleProject);
     verify(drsApi).setHeader(DrsResolutionService.TRANSACTION_ID_HEADER_NAME, TRANSACTION_ID);
     verify(tdrApiFactory).getApi(TOKEN_VALUE);
     verify(tdrApi)
@@ -705,5 +708,41 @@ class DrsResolutionServiceTest {
             any(DRSPassportRequestModel.class), eq(PATH), eq(accessId), eq(googleProject));
     verify(drsApi, never()).postAccessURL(any(), any(), any());
     verify(drsApi, never()).setBearerToken(any());
+  }
+
+  @Test
+  void passportAuth_nonTdrProvider_withGoogleProject_usesPassportPath() throws Exception {
+    // BDC (requiresUserProjectOnRetry=false) with a googleProject must use the standard passport
+    // path, not the TDR client. Before the fix, the presence of googleProject alone was enough to
+    // route any passport-auth provider to TDR.
+    var googleProject = "terra-dev-billing-project";
+    var passportAuth =
+        new DrsHubAuthorization(SupportedTypesEnum.PASSPORTAUTH, (var e) -> Optional.of(PASSPORTS));
+    var bearerAuth =
+        new DrsHubAuthorization(
+            SupportedTypesEnum.BEARERAUTH, (var e) -> Optional.of(List.of(TOKEN_VALUE)));
+
+    when(drsApi.postAccessURL(Map.of("passports", PASSPORTS), PATH, accessId))
+        .thenReturn(new AccessURL().url("https://fence.example.com/signed-url"));
+
+    var response =
+        drsResolutionService.fetchDrsObjectAccessUrl(
+            testDrsProvider, // requiresUserProjectOnRetry=false (BDC-like)
+            uriComponents,
+            accessId,
+            TypeEnum.GS,
+            List.of(passportAuth, bearerAuth),
+            new AuditLogEvent.Builder(),
+            null,
+            googleProject,
+            TOKEN,
+            TRANSACTION_ID);
+
+    assertThat(
+        "signed url returned via passport path",
+        response.getUrl(),
+        equalTo("https://fence.example.com/signed-url"));
+    verify(drsApi).postAccessURL(Map.of("passports", PASSPORTS), PATH, accessId);
+    verifyNoInteractions(tdrApiFactory);
   }
 }

--- a/service/src/test/java/bio/terra/drshub/services/DrsResolutionServiceTest.java
+++ b/service/src/test/java/bio/terra/drshub/services/DrsResolutionServiceTest.java
@@ -536,7 +536,8 @@ class DrsResolutionServiceTest {
                         .setType(AccessMethodConfigTypeEnum.gs)
                         .setAuth(DrsAuthEnum.current_request)
                         .setFetchAccessUrl(true)
-                        .setRequiresUserProjectOnRetry(true))));
+                        .setRequiresUserProjectOnRetry(true)
+                        .setSupportsUserProject(true))));
   }
 
   @Test


### PR DESCRIPTION
## Description

Fixes a bug where DRSHub returns `accessUrl: null` for BDC/Gen3 DRS URIs when the resolve request includes a `userProject`.

The `PASSPORTAUTH` branch in `callAccessUrl` was routing any passport-auth provider to the TDR client whenever `googleProject != null`. BDC doesn't use `x-user-project` and must not be routed to TDR — doing so caused TDR to return 400 for the unknown DRS ID, the Fence fallback to 401, and DRSHub to silently return `accessUrl: null`.

**Fix:** add a `supportsUserProject` flag to `ProviderAccessMethodConfig` (default `false`), set it `true` for TDR's `gs` method, and gate the TDR-client branch on it. Non-TDR providers now always use the standard passport POST path regardless of `googleProject`.

## Changes

- `ProviderAccessMethodConfigInterface` — new `supportsUserProject` flag (default `false`)
- `application.yml` — `supportsUserProject: true` on TDR's `gs` access method
- `DrsResolutionService` — gate TDR-client PASSPORTAUTH branch on `supportsUserProject`
- `DrsResolutionServiceTest` — fix 4 TDR tests to use TDR provider config; add BDC regression test

## Test plan

- [x] Unit tests pass (`DrsResolutionServiceTest`)
- [x] Confirmed that manual POST `/api/v4/drs/resolve` call w/ TDR URL still works
- [ ] Manual: POST `/api/v4/drs/resolve` for a BDC DRS URI with `userProject` returns a valid signed URL on dev tier - ⚠️ Note: I have not tested because I do not have a passport with access to a BDC consent code.

## References

CTM-472 / CTM-537

🤖 Generated with [Claude Code](https://claude.com/claude-code)