### PR TITLE
CTM-613: Disambiguate cloud provider for TDR https-typed access methods

### DIFF
--- a/service/src/main/java/bio/terra/drshub/config/DrsProviderInterface.java
+++ b/service/src/main/java/bio/terra/drshub/config/DrsProviderInterface.java
@@ -57,13 +57,14 @@ public interface DrsProviderInterface {
   /**
    * Like {@link #getAccessMethodByType}, but corrects for TDR returning its GCP passport signed-URL
    * access method typed {@code https} (the same type it uses for Azure) rather than {@code gs}.
-   * Only TDR prefixes GCP access ids with {@code gcp-}, so an access id with that prefix is
-   * resolved against the provider's {@code gs} config instead, regardless of the type DRS reported.
-   * See CTM-613.
+   * Only TDR prefixes Azure access ids with {@code az-}; any other {@code https} access id is
+   * treated as GCP and resolved against the provider's {@code gs} config instead, regardless of the
+   * type DRS reported. See CTM-613.
    */
   default ProviderAccessMethodConfig getAccessMethodByTypeAndAccessId(
       AccessMethod.TypeEnum accessMethodType, String accessId) {
-    if (accessId != null && accessId.startsWith("gcp-")) {
+    boolean isAzure = accessId != null && accessId.startsWith("az-");
+    if (accessMethodType == AccessMethod.TypeEnum.HTTPS && !isAzure) {
       var gcpConfig = getAccessMethodByType(AccessMethod.TypeEnum.GS);
       if (gcpConfig != null) {
         return gcpConfig;

--- a/service/src/main/java/bio/terra/drshub/config/DrsProviderInterface.java
+++ b/service/src/main/java/bio/terra/drshub/config/DrsProviderInterface.java
@@ -64,8 +64,8 @@ public interface DrsProviderInterface {
    */
   default ProviderAccessMethodConfig getAccessMethodByTypeAndAccessId(
       AccessMethod.TypeEnum accessMethodType, String accessId) {
-    boolean isGcpPassport = accessId != null && accessId.startsWith("gcp-");
-    if (accessMethodType == AccessMethod.TypeEnum.HTTPS && isGcpPassport) {
+    boolean isGcp = accessId != null && accessId.startsWith("gcp-");
+    if (accessMethodType == AccessMethod.TypeEnum.HTTPS && isGcp) {
       var gcpConfig = getAccessMethodByType(AccessMethod.TypeEnum.GS);
       if (gcpConfig != null) {
         return gcpConfig;

--- a/service/src/main/java/bio/terra/drshub/config/DrsProviderInterface.java
+++ b/service/src/main/java/bio/terra/drshub/config/DrsProviderInterface.java
@@ -54,6 +54,24 @@ public interface DrsProviderInterface {
         .orElse(null);
   }
 
+  /**
+   * Like {@link #getAccessMethodByType}, but corrects for TDR returning its GCP passport signed-URL
+   * access method typed {@code https} (the same type it uses for Azure) rather than {@code gs}.
+   * Only TDR prefixes GCP access ids with {@code gcp-}, so an access id with that prefix is
+   * resolved against the provider's {@code gs} config instead, regardless of the type DRS reported.
+   * See CTM-613.
+   */
+  default ProviderAccessMethodConfig getAccessMethodByTypeAndAccessId(
+      AccessMethod.TypeEnum accessMethodType, String accessId) {
+    if (accessId != null && accessId.startsWith("gcp-")) {
+      var gcpConfig = getAccessMethodByType(AccessMethod.TypeEnum.GS);
+      if (gcpConfig != null) {
+        return gcpConfig;
+      }
+    }
+    return getAccessMethodByType(accessMethodType);
+  }
+
   default List<AccessMethodConfigTypeEnum> getAccessMethodConfigTypes() {
     return getAccessMethodConfigs().stream().map(ProviderAccessMethodConfig::getType).toList();
   }

--- a/service/src/main/java/bio/terra/drshub/config/DrsProviderInterface.java
+++ b/service/src/main/java/bio/terra/drshub/config/DrsProviderInterface.java
@@ -57,14 +57,15 @@ public interface DrsProviderInterface {
   /**
    * Like {@link #getAccessMethodByType}, but corrects for TDR returning its GCP passport signed-URL
    * access method typed {@code https} (the same type it uses for Azure) rather than {@code gs}.
-   * Only TDR prefixes Azure access ids with {@code az-}; any other {@code https} access id is
-   * treated as GCP and resolved against the provider's {@code gs} config instead, regardless of the
-   * type DRS reported. See CTM-613.
+   * Only TDR prefixes GCP passport access ids with {@code gcp-}; an access id with that prefix is
+   * resolved against the provider's {@code gs} config instead, regardless of the type DRS reported.
+   * Scoped to {@code https} so it can't affect other providers' non-{@code https} access methods
+   * (e.g. an {@code s3} config on a provider that also has a {@code gs} config). See CTM-613.
    */
   default ProviderAccessMethodConfig getAccessMethodByTypeAndAccessId(
       AccessMethod.TypeEnum accessMethodType, String accessId) {
-    boolean isAzure = accessId != null && accessId.startsWith("az-");
-    if (accessMethodType == AccessMethod.TypeEnum.HTTPS && !isAzure) {
+    boolean isGcpPassport = accessId != null && accessId.startsWith("gcp-");
+    if (accessMethodType == AccessMethod.TypeEnum.HTTPS && isGcpPassport) {
       var gcpConfig = getAccessMethodByType(AccessMethod.TypeEnum.GS);
       if (gcpConfig != null) {
         return gcpConfig;

--- a/service/src/main/java/bio/terra/drshub/config/DrsProviderInterface.java
+++ b/service/src/main/java/bio/terra/drshub/config/DrsProviderInterface.java
@@ -57,14 +57,13 @@ public interface DrsProviderInterface {
   /**
    * Like {@link #getAccessMethodByType}, but corrects for TDR returning its GCP passport signed-URL
    * access method typed {@code https} (the same type it uses for Azure) rather than {@code gs}.
-   * Only TDR prefixes Azure access ids with {@code az-}; any other {@code https} access id is
-   * treated as GCP and resolved against the provider's {@code gs} config instead, regardless of the
-   * type DRS reported. See CTM-613.
+   * Only TDR prefixes GCP access ids with {@code gcp-}, so an access id with that prefix is
+   * resolved against the provider's {@code gs} config instead, regardless of the type DRS reported.
+   * See CTM-613.
    */
   default ProviderAccessMethodConfig getAccessMethodByTypeAndAccessId(
       AccessMethod.TypeEnum accessMethodType, String accessId) {
-    boolean isAzure = accessId != null && accessId.startsWith("az-");
-    if (accessMethodType == AccessMethod.TypeEnum.HTTPS && !isAzure) {
+    if (accessId != null && accessId.startsWith("gcp-")) {
       var gcpConfig = getAccessMethodByType(AccessMethod.TypeEnum.GS);
       if (gcpConfig != null) {
         return gcpConfig;

--- a/service/src/main/java/bio/terra/drshub/services/DrsResolutionService.java
+++ b/service/src/main/java/bio/terra/drshub/services/DrsResolutionService.java
@@ -293,7 +293,8 @@ public class DrsResolutionService {
 
     var drsApi = drsApiFactory.getApiFromUriComponents(uriComponents, drsProvider);
     var objectId = getObjectId(uriComponents);
-    var accessMethodConfig = drsProvider.getAccessMethodByType(accessMethodType);
+    var accessMethodConfig =
+        drsProvider.getAccessMethodByTypeAndAccessId(accessMethodType, accessId);
     boolean retryMode =
         accessMethodConfig != null && accessMethodConfig.requiresUserProjectOnRetry();
     boolean supportsUserProject =
@@ -342,7 +343,7 @@ public class DrsResolutionService {
       }
       if (accessUrl != null) {
         auditLogEventBuilder.authType(
-            drsProvider.getAccessMethodByType(accessMethodType).getAuth());
+            drsProvider.getAccessMethodByTypeAndAccessId(accessMethodType, accessId).getAuth());
         return accessUrl;
       }
     }

--- a/service/src/test/java/bio/terra/drshub/services/DrsResolutionServiceTest.java
+++ b/service/src/test/java/bio/terra/drshub/services/DrsResolutionServiceTest.java
@@ -746,4 +746,101 @@ class DrsResolutionServiceTest {
     verify(drsApi).postAccessURL(Map.of("passports", PASSPORTS), PATH, accessId);
     verifyNoInteractions(tdrApiFactory);
   }
+
+  private DrsProvider createFullTdrProvider() {
+    // Mirrors application.yml's terraDataRepo config: gs supports user-project routing, https
+    // (shared by Azure and TDR's GCP-passport signed-URL method) does not by type alone.
+    return DrsProvider.create()
+        .setMetadataAuthType(DrsAuthEnum.current_request)
+        .setName("tdr")
+        .setHostRegex(".*")
+        .setAccessMethodConfigs(
+            new ArrayList<>(
+                List.of(
+                    ProviderAccessMethodConfig.create()
+                        .setType(AccessMethodConfigTypeEnum.gs)
+                        .setAuth(DrsAuthEnum.current_request)
+                        .setFetchAccessUrl(true)
+                        .setRequiresUserProjectOnRetry(true)
+                        .setSupportsUserProject(true),
+                    ProviderAccessMethodConfig.create()
+                        .setType(AccessMethodConfigTypeEnum.https)
+                        .setAuth(DrsAuthEnum.current_request)
+                        .setFetchAccessUrl(true))));
+  }
+
+  @Test
+  void passportAuth_tdrGcpPassportHttps_usesTdrClient() throws Exception {
+    // CTM-613 regression: TDR returns its GCP passport signed-URL access method typed `https`
+    // (same type as Azure), distinguishable only by the `gcp-` access-id prefix. Before the fix,
+    // this fell through to TDR's https config (supportsUserProject=false) and used the no-bearer
+    // passport path, which TDR 401s on, ultimately surfacing as a 500.
+    var tdrProvider = createFullTdrProvider();
+    var gcpAccessId = "gcp-passport-us-central1*snapshot";
+    var googleProject = "test-project";
+    var passportAuth =
+        new DrsHubAuthorization(SupportedTypesEnum.PASSPORTAUTH, (var e) -> Optional.of(PASSPORTS));
+
+    when(tdrApiFactory.getApi(TOKEN_VALUE)).thenReturn(tdrApi);
+    when(tdrApi.postAccessURL(
+            any(DRSPassportRequestModel.class), eq(PATH), eq(gcpAccessId), eq(googleProject)))
+        .thenReturn(new DRSAccessURL().url("https://signed-url.example.com/data"));
+
+    var response =
+        drsResolutionService.fetchDrsObjectAccessUrl(
+            tdrProvider,
+            uriComponents,
+            gcpAccessId,
+            TypeEnum.HTTPS,
+            List.of(passportAuth),
+            new AuditLogEvent.Builder(),
+            null,
+            googleProject,
+            TOKEN,
+            TRANSACTION_ID);
+
+    assertThat(
+        "signed url returned via TDR client",
+        response.getUrl(),
+        equalTo("https://signed-url.example.com/data"));
+    verify(tdrApiFactory).getApi(TOKEN_VALUE);
+    verify(tdrApi)
+        .postAccessURL(
+            any(DRSPassportRequestModel.class), eq(PATH), eq(gcpAccessId), eq(googleProject));
+    verify(drsApi, never()).postAccessURL(any(), any(), any());
+  }
+
+  @Test
+  void passportAuth_tdrAzureHttps_usesPassportPath() throws Exception {
+    // Azure's TDR access method is also typed `https` but is not gcp-prefixed; it must keep using
+    // the standard passport path (no bearer/x-user-project), matching pre-fix Azure behavior.
+    var tdrProvider = createFullTdrProvider();
+    var azureAccessId = "az-passport-eastus*snapshot";
+    var googleProject = "test-project";
+    var passportAuth =
+        new DrsHubAuthorization(SupportedTypesEnum.PASSPORTAUTH, (var e) -> Optional.of(PASSPORTS));
+
+    when(drsApi.postAccessURL(Map.of("passports", PASSPORTS), PATH, azureAccessId))
+        .thenReturn(new AccessURL().url("https://azure.example.com/signed-url"));
+
+    var response =
+        drsResolutionService.fetchDrsObjectAccessUrl(
+            tdrProvider,
+            uriComponents,
+            azureAccessId,
+            TypeEnum.HTTPS,
+            List.of(passportAuth),
+            new AuditLogEvent.Builder(),
+            null,
+            googleProject,
+            TOKEN,
+            TRANSACTION_ID);
+
+    assertThat(
+        "signed url returned via passport path",
+        response.getUrl(),
+        equalTo("https://azure.example.com/signed-url"));
+    verify(drsApi).postAccessURL(Map.of("passports", PASSPORTS), PATH, azureAccessId);
+    verifyNoInteractions(tdrApiFactory);
+  }
 }


### PR DESCRIPTION
# NOTE
I decided against this approach because I worried about unintended consequences. It's odd to me to use the "GS" access method when it really should be the "HTTPS" access method just to match the other GCP properties. It seems like this could get us in a wonky state.
____

## Summary
- Fixes [CTM-613](https://broadworkbench.atlassian.net/browse/CTM-613): resolving a TDR requester-pays DRS object via passport auth returned HTTP 500, because TDR's GCP passport signed-URL access method is typed `https` (same as Azure's), so the `supportsUserProject` gate added in #255 — keyed on `type` — never matched it, DRSHub sent the passport POST without a bearer token, TDR 401'd, and the bearer-GET fallback 500'd.
- Adds `DrsProviderInterface.getAccessMethodByTypeAndAccessId`, which resolves the provider's access-method config using the `az-` access-id prefix instead of `type` alone: for an `https`-typed access method, anything *not* `az-`-prefixed is treated as GCP and resolved against the provider's `gs` config. Non-`https` types (`gs`, `s3`, ...) are unaffected — the check only kicks in for the ambiguous `https` case, so it can't misroute other providers' `s3`/`gs` access methods.
- This is the DRSHub-side, access-id-prefix interim fix discussed on the ticket; it's self-contained and doesn't depend on any TDR-side change (e.g. adopting a `cloud` field).

## Why this approach
DRSHub already resolves the similiar ambiguity the same way in `AccessMethodUtils.getAccessMethodForCloud` — when a caller requests the Azure cloud platform, it matches on the `az-` access-id prefix rather than `type`, because a signed URL is `https` for every cloud and can't be told apart by `type` alone:
```java
if (cloudPlatform.equals(CloudPlatformEnum.AZURE)) {
  // Note: Only the Terra Data Repo drs provider prefixes Azure access ids with "az"
  filter = m -> m.getAccessId() != null && m.getAccessId().startsWith("az");
}
```

[CTM-613]: https://broadworkbench.atlassian.net/browse/CTM-613?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
