### PR TITLE
[DRAFT] CTM-613: DRSHub — consume the DRS 1.5 cloud field for per-cloud config selection

### DIFF
--- a/service/src/main/java/bio/terra/drshub/config/DrsProviderInterface.java
+++ b/service/src/main/java/bio/terra/drshub/config/DrsProviderInterface.java
@@ -54,6 +54,29 @@ public interface DrsProviderInterface {
         .orElse(null);
   }
 
+  /**
+   * Select the access-method config for a resolved access method by its DRS `type` AND DRS 1.5
+   * `cloud`. Matching on `type` alone is insufficient: a signed URL is `https` for every cloud, so a
+   * GCS passport access method (typed `https`) would otherwise match the Azure `https` config and
+   * lose requester-pays user-project support (the HTTP 500). When the access method carries no
+   * `cloud` (providers not yet emitting DRS 1.5), or no cloud-annotated config matches, fall back to
+   * the legacy type-only match so behavior is unchanged.
+   */
+  default ProviderAccessMethodConfig getAccessMethodConfig(
+      AccessMethod.TypeEnum accessMethodType, @Nullable String cloud) {
+    if (cloud != null) {
+      Optional<ProviderAccessMethodConfig> byTypeAndCloud =
+          getAccessMethodConfigs().stream()
+              .filter(c -> c.getType().getReturnedEquivalent() == accessMethodType)
+              .filter(c -> c.getCloud().map(cloud::equalsIgnoreCase).orElse(false))
+              .findFirst();
+      if (byTypeAndCloud.isPresent()) {
+        return byTypeAndCloud.get();
+      }
+    }
+    return getAccessMethodByType(accessMethodType);
+  }
+
   default List<AccessMethodConfigTypeEnum> getAccessMethodConfigTypes() {
     return getAccessMethodConfigs().stream().map(ProviderAccessMethodConfig::getType).toList();
   }

--- a/service/src/main/java/bio/terra/drshub/config/ProviderAccessMethodConfigInterface.java
+++ b/service/src/main/java/bio/terra/drshub/config/ProviderAccessMethodConfigInterface.java
@@ -11,6 +11,15 @@ import org.immutables.value.Value.Default;
 public interface ProviderAccessMethodConfigInterface {
   AccessMethodConfigTypeEnum getType();
 
+  /**
+   * DRS 1.5 `cloud` (CSP) this config applies to (`gcp` / `azure` / `aws`). When set, DrsHub matches
+   * this config to an access method by `type` AND `cloud`, so a GCS signed-URL method (typed
+   * `https`, like Azure) is not mis-matched to the Azure `https` config and keeps its requester-pays
+   * user-project support. Optional for backward compatibility: configs without `cloud` are matched
+   * by `type` alone (legacy behavior).
+   */
+  Optional<String> getCloud();
+
   DrsAuthEnum getAuth();
 
   boolean isFetchAccessUrl();

--- a/service/src/main/java/bio/terra/drshub/services/DrsResolutionService.java
+++ b/service/src/main/java/bio/terra/drshub/services/DrsResolutionService.java
@@ -209,6 +209,10 @@ public class DrsResolutionService {
 
     if (drsProvider.shouldFetchAccessUrl(accessMethodType, requestedFields, forceAccessUrl)) {
       var accessId = accessMethod.map(AccessMethod::getAccessId).orElseThrow();
+      // DRS 1.5 `cloud` of the selected access method (null for providers not yet emitting it), used
+      // to select the per-cloud config so a GCS signed-URL method typed `https` is not matched to
+      // the Azure `https` config.
+      var accessMethodCloud = accessMethod.map(AccessMethod::getCloud).orElse(null);
       try {
         log.info("Requesting URL for {}", uriComponents.toUriString());
         var accessUrl =
@@ -217,6 +221,7 @@ public class DrsResolutionService {
                 uriComponents,
                 accessId,
                 accessMethodType,
+                accessMethodCloud,
                 authorizations,
                 auditEventBuilder,
                 ip,
@@ -284,6 +289,7 @@ public class DrsResolutionService {
       UriComponents uriComponents,
       String accessId,
       TypeEnum accessMethodType,
+      String accessMethodCloud,
       List<DrsHubAuthorization> drsHubAuthorizations,
       AuditLogEvent.Builder auditLogEventBuilder,
       String ip,
@@ -293,7 +299,11 @@ public class DrsResolutionService {
 
     var drsApi = drsApiFactory.getApiFromUriComponents(uriComponents, drsProvider);
     var objectId = getObjectId(uriComponents);
-    var accessMethodConfig = drsProvider.getAccessMethodByType(accessMethodType);
+    // Select the config by `type` + DRS 1.5 `cloud` so a GCS signed-URL method (typed `https`, like
+    // Azure) is matched to the GCS config -- not the Azure `https` config -- keeping its
+    // requester-pays user-project support. Falls back to type-only when `cloud` is absent.
+    var accessMethodConfig =
+        drsProvider.getAccessMethodConfig(accessMethodType, accessMethodCloud);
     boolean retryMode =
         accessMethodConfig != null && accessMethodConfig.requiresUserProjectOnRetry();
     boolean supportsUserProject =
@@ -342,7 +352,7 @@ public class DrsResolutionService {
       }
       if (accessUrl != null) {
         auditLogEventBuilder.authType(
-            drsProvider.getAccessMethodByType(accessMethodType).getAuth());
+            drsProvider.getAccessMethodConfig(accessMethodType, accessMethodCloud).getAuth());
         return accessUrl;
       }
     }

--- a/service/src/main/java/bio/terra/drshub/util/AccessMethodUtils.java
+++ b/service/src/main/java/bio/terra/drshub/util/AccessMethodUtils.java
@@ -34,6 +34,19 @@ public class AccessMethodUtils {
 
   public static Optional<AccessMethod> getAccessMethodForCloud(
       List<AccessMethod> accessMethods, CloudPlatformEnum cloudPlatform) {
+    // Prefer the DRS 1.5 `cloud` field when the provider emits it: it names the CSP directly, where
+    // `type` cannot (a signed URL is `https` for every cloud). Fall back to the legacy heuristics
+    // (`type == gs` for GCS, `az` access-id prefix for Azure) for providers not yet emitting
+    // `cloud`.
+    String targetCloud = toDrsCloud(cloudPlatform);
+    Optional<AccessMethod> byCloud =
+        accessMethods.stream()
+            .filter(m -> m.getCloud() != null && m.getCloud().equalsIgnoreCase(targetCloud))
+            .findFirst();
+    if (byCloud.isPresent()) {
+      return byCloud;
+    }
+
     Predicate<AccessMethod> filter;
     if (cloudPlatform.equals(CloudPlatformEnum.AZURE)) {
       // Note: Only the Terra Data Repo drs provider prefixes Azure access ids with "az"
@@ -42,6 +55,18 @@ public class AccessMethodUtils {
       filter = m -> m.getType().toString().equals(cloudPlatform.toString());
     }
     return accessMethods.stream().filter(filter).findFirst();
+  }
+
+  /**
+   * DRS 1.5 `cloud` (CSP) value for a DrsHub request cloud platform. DrsHub's request vocabulary
+   * uses the storage-type-ish `gs` for Google, whereas the DRS `cloud` field uses `gcp`.
+   */
+  private static String toDrsCloud(CloudPlatformEnum cloudPlatform) {
+    return switch (cloudPlatform) {
+      case GS -> "gcp";
+      case AZURE -> "azure";
+      case S3 -> "aws";
+    };
   }
 
   public static List<AccessMethod> getAccessMethods(

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -53,10 +53,24 @@ drshub:
           fetchAccessUrl: true
           requiresUserProjectOnRetry: true
           supportsUserProject: true
+          cloud: gcp
         - type: https
           auth: current_request
           fetchAccessUrl: true # Used for Azure
           requiresUserProjectOnRetry: false  # Azure doesn't have requester-pays
+          cloud: azure
+        # GCS signed-URL / passport access method: TDR types it `https` (a signed URL is https for
+        # every cloud). It needs its own gcp-cloud config so `type` + `cloud` selection matches here
+        # -- not the Azure `https` config above -- preserving requester-pays user-project support
+        # (the fix for the HTTP 500). Listed after Azure so the legacy type-only
+        # getAccessMethodByType(https) fallback still resolves to Azure (unchanged) when `cloud` is
+        # absent, e.g. before TDR emits it.
+        - type: https
+          auth: current_request
+          fetchAccessUrl: true
+          requiresUserProjectOnRetry: true
+          supportsUserProject: true
+          cloud: gcp
     sage:
       name: Sage Bionetworks
       hostRegex: 'repo-dev\.dev\.sagebase\.org|repo-prod\.prod\.sagebase\.org'

--- a/service/src/main/resources/vendor/data-repository-service-1.3.0.yaml
+++ b/service/src/main/resources/vendor/data-repository-service-1.3.0.yaml
@@ -1381,6 +1381,14 @@ components:
             Name of the region in the cloud service provider that the object
             belongs to.
           example: us-east-1
+        cloud:
+          type: string
+          description: >-
+            Name of the cloud service provider (CSP) that hosts the object, per DRS 1.5.
+            Disambiguates access methods that share a `type` (notably `https`, the signed-URL
+            protocol on every cloud) so DrsHub can select the correct per-cloud config.
+            Suggested values: `aws`, `gcp`, `azure`. Optional and additive.
+          example: gcp
         authorizations:
           allOf:
             - $ref: '#/components/schemas/Authorizations'


### PR DESCRIPTION
> **Status: DRAFT for discussion** (invited by Shelby). This is not yet mergeable — it needs a generated-client regen and tests, and it has not been build-verified locally (see **Draft caveats**). It is opened to make the `cloud`-field approach concrete and estimable.

## Why — the problem
Terra-internal DRS resolution goes through DRSHub, and DRSHub selects the per-access-method **config** by DRS `type` alone. But `type: https` is the protocol for a **signed URL**, which *every* cloud uses — so `type` cannot tell DRSHub *which cloud* an access method belongs to.

TDR returns its **GCS passport** access method typed `https` (a signed URL is `https` for every cloud), so DRSHub matches it to the **Azure** `https` config, where `supportsUserProject` is false. For a RAS-passport **requester-pays** GCS object, DRSHub then omits the caller bearer + `x-user-project` on the passport `POST …/access`, TDR replies **401**, and DRSHub falls through to a bearer `GET` on the `gcp-passport-*` access id → **HTTP 500**.

This blocks RAS-passport DRS access for AnVIL researchers working in Terra (**CTM-613**). It is a regression from **CTM-472 / PR #255**, which added the `supportsUserProject` gate but set it only on TDR's `gs` config — and TDR's passport access method is typed `https`, not `gs`.

`type` is a *protocol*; the *cloud* needs its own field. DRS 1.5 added exactly that: **`cloud`** (`aws` / `gcp` / `azure`).

## What this PR does
Consumes the DRS 1.5 `cloud` field so DRSHub selects the config by **`type` + `cloud`**:

- **`service/src/main/resources/vendor/data-repository-service-1.3.0.yaml`** — add an optional `cloud` property to `AccessMethod`. (DRSHub owns this vendored DRS spec, so this is a local edit; the `io.github.ga4gh.drs` model must be **regenerated**.)
- **`ProviderAccessMethodConfig` + `application.yml`** — add an optional `cloud` to the config; annotate the `terraDataRepo` configs (`gs` → `gcp`, the existing `https` → `azure`) and add an explicit **`https` + `gcp`** config for the GCS signed-URL / passport method. It is listed *after* the Azure `https` config so the legacy type-only `getAccessMethodByType(https)` fallback still resolves to Azure when `cloud` is absent.
- **`DrsProviderInterface.getAccessMethodConfig(type, cloud)`** — select by `type` + `cloud`, falling back to the legacy type-only match when `cloud` is absent or unmatched (backward-compatible for providers not yet emitting DRS 1.5).
- **`DrsResolutionService`** — thread the selected access method's `cloud` to the config lookup.
- **`AccessMethodUtils.getAccessMethodForCloud`** — prefer the `cloud` field, retiring the `type == gs` / `az`-prefix heuristics (with fallback).

**Companion PR** (TDR emits `cloud`): https://github.com/DataBiosphere/jade-data-repo/pull/2120

## Scope — what this fixes, and what completes it
- ✅ **Requester-pays** passport access via DRSHub (CTM-613): the GCS passport method now selects the `gcp` config → DRSHub sends the bearer + `x-user-project` via the TDR client → **200 + signed URL**.
- ➡️ **Non-requester-pays** passport access via DRSHub is **not** resolved by this PR alone. In the non-rp path DRSHub sends no user project and gates the caller's bearer on `googleProject != null` (`DrsResolutionService.callAccessUrl`), so the passport `POST …/access` reaches TDR with **no `Authorization` header** → the same 401 → 500. That leg is completed by the companion TDR change **CTM-611** (TDR `/access` accepting passport-only), after which DRSHub's bearer-less non-rp POST succeeds. The two changes are complementary; neither is redundant.

## Backward compatibility & rollout
- **Additive.** `cloud` is optional; when absent, selection falls back to today's type-only behavior. Safe to deploy in either order relative to TDR emitting `cloud` — DRSHub falls back until it appears.
- **Azure unchanged** — its `https` method still resolves to the `azure` config (no user project).

## Draft caveats (not yet done)
- **Client regen required.** The vendored-spec change means `io.github.ga4gh.drs.model.AccessMethod.getCloud()` does not exist until the generator runs; this will not compile until then.
- **No tests yet.**
- **Not build-verified locally.** Two interactions to confirm on a real build: (1) the immutables/Spring binding of the new optional `cloud` config property, and (2) the new `https` + `gcp` config's `requiresUserProjectOnRetry` behavior.

## References
- Jira **CTM-613** — the DRSHub HTTP 500 this resolves (requester-pays leg).
- Jira **CTM-611** — companion TDR passport-only `/access` fix; completes the non-requester-pays leg.
- **CTM-472 / PR #255** — the change this refines (its `supportsUserProject` gate). Its review also hit the `type: https` ambiguity: a `provider == TDR` gate was rejected because Azure is `https` too — `type` + `cloud` is the missing signal.
