### PR TITLE
CTM-613: prefer DRS 1.5 cloud field in getAccessMethodForCloud

### DIFF
--- a/service/src/main/java/bio/terra/drshub/util/AccessMethodUtils.java
+++ b/service/src/main/java/bio/terra/drshub/util/AccessMethodUtils.java
@@ -34,6 +34,19 @@ public class AccessMethodUtils {
 
   public static Optional<AccessMethod> getAccessMethodForCloud(
       List<AccessMethod> accessMethods, CloudPlatformEnum cloudPlatform) {
+    // Prefer the DRS 1.5 `cloud` field when the provider emits it: it names the CSP directly,
+    // where `type` cannot (a signed URL is `https` for every cloud). Fall back to the legacy
+    // heuristics (`type == gs` for GCS, `az` access-id prefix for Azure) for providers not yet
+    // emitting `cloud`.
+    String targetCloud = toDrsCloud(cloudPlatform);
+    Optional<AccessMethod> byCloud =
+        accessMethods.stream()
+            .filter(m -> m.getCloud() != null && m.getCloud().equalsIgnoreCase(targetCloud))
+            .findFirst();
+    if (byCloud.isPresent()) {
+      return byCloud;
+    }
+
     Predicate<AccessMethod> filter;
     if (cloudPlatform.equals(CloudPlatformEnum.AZURE)) {
       // Note: Only the Terra Data Repo drs provider prefixes Azure access ids with "az"
@@ -42,6 +55,18 @@ public class AccessMethodUtils {
       filter = m -> m.getType().toString().equals(cloudPlatform.toString());
     }
     return accessMethods.stream().filter(filter).findFirst();
+  }
+
+  /**
+   * DRS 1.5 `cloud` (CSP) value for a DrsHub request cloud platform. DrsHub's request vocabulary
+   * uses the storage-type-ish `gs` for Google, whereas the DRS `cloud` field uses `gcp`.
+   */
+  private static String toDrsCloud(CloudPlatformEnum cloudPlatform) {
+    return switch (cloudPlatform) {
+      case GS -> "gcp";
+      case AZURE -> "azure";
+      case S3 -> "aws";
+    };
   }
 
   public static List<AccessMethod> getAccessMethods(

--- a/service/src/test/java/bio/terra/drshub/util/TestAccessMethodUtils.java
+++ b/service/src/test/java/bio/terra/drshub/util/TestAccessMethodUtils.java
@@ -91,6 +91,24 @@ public class TestAccessMethodUtils {
   }
 
   @Test
+  void testGetAccessMethodForCloud_prefersCloudFieldOverTypeAndPrefixHeuristics() {
+    // TDR types both its GCS passport method and its Azure method `https` -- a signed URL is
+    // `https` for every cloud, so `type`/access-id-prefix heuristics alone can't tell them apart.
+    // The DRS 1.5 `cloud` field can, and must be preferred when present.
+    var gcpPassportMethod =
+        new AccessMethod().accessId("gcp-passport-1").type(TypeEnum.HTTPS).cloud("gcp");
+    var azureMethod = new AccessMethod().accessId("az-1").type(TypeEnum.HTTPS).cloud("azure");
+    var methods = List.of(gcpPassportMethod, azureMethod);
+
+    assertThat(
+        AccessMethodUtils.getAccessMethodForCloud(methods, CloudPlatformEnum.GS).get(),
+        equalTo(gcpPassportMethod));
+    assertThat(
+        AccessMethodUtils.getAccessMethodForCloud(methods, CloudPlatformEnum.AZURE).get(),
+        equalTo(azureMethod));
+  }
+
+  @Test
   void testGetAccessMethods() {
     assertThat(
         AccessMethodUtils.getAccessMethods(drsObject, drsProvider),


### PR DESCRIPTION
> Note: I do not plan on merging this in the short term. 


## Summary
Split out of #262 to keep that PR minimal.

- `AccessMethodUtils.getAccessMethodForCloud` now prefers the DRS 1.5 `cloud` field when present to pick the right `AccessMethod` out of a DRS object's list for the requested cloud platform, falling back to the existing `type`/access-id-prefix heuristics when `cloud` is absent.

This is a different concern from #262's fix (which corrects the provider *config* lookup used for `supportsUserProject`/`requiresUserProjectOnRetry`). It's **not required** to fix the reported CTM-613 500: for the reported case (a single `https`-typed access method on the object), `AccessMethodUtils.getAccessMethod`'s existing "return first access method if nothing matched" fallback already resolves to the only candidate correctly, with or without this change.

Where it does matter: if a DRS object ever returns **multiple** `https`-typed access methods (e.g. a dual-cloud-hosted snapshot with both a GCS-passport method and an Azure method on the same object), the old type/access-id-prefix heuristics can't tell them apart and could silently return the wrong cloud's access method. This closes that gap.

Also currently inert in production either way, since it depends on TDR actually emitting the DRS 1.5 `cloud` field, which hasn't shipped yet.

## Test plan
- [x] `TestAccessMethodUtils` -- new test covers `getAccessMethodForCloud` disambiguating two `https`-typed methods by `cloud` alone
- [x] `./gradlew :service:test` -- full suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)