### PR TITLE
CTM-613: extend cloud-aware config lookup to AuthService and shouldFetchAccessUrl

### DIFF
--- a/service/src/main/java/bio/terra/drshub/config/DrsProviderInterface.java
+++ b/service/src/main/java/bio/terra/drshub/config/DrsProviderInterface.java
@@ -84,16 +84,13 @@ public interface DrsProviderInterface {
   /** Should Drshub call the DRS provider's `access` endpoint to get a signed URL. */
   default boolean shouldFetchAccessUrl(
       AccessMethod.TypeEnum accessMethodType,
+      @Nullable String cloud,
       List<String> requestedFields,
       boolean forceAccessUrl) {
     var fieldsOverlap = Fields.overlap(requestedFields, Fields.ACCESS_URL_FIELDS);
-    var accessMethodConfigs = getAccessMethodConfigs();
+    var accessMethodConfig = getAccessMethodConfig(accessMethodType, cloud);
     var accessMethodTypeMatches =
-        accessMethodConfigs.stream()
-            .anyMatch(
-                m ->
-                    m.getType().getReturnedEquivalent() == accessMethodType
-                        && m.isFetchAccessUrl());
+        accessMethodConfig != null && accessMethodConfig.isFetchAccessUrl();
 
     return fieldsOverlap && (accessMethodTypeMatches || forceAccessUrl);
   }

--- a/service/src/main/java/bio/terra/drshub/models/DrsHubAuthorization.java
+++ b/service/src/main/java/bio/terra/drshub/models/DrsHubAuthorization.java
@@ -4,15 +4,16 @@ import io.github.ga4gh.drs.model.AccessMethod;
 import io.github.ga4gh.drs.model.Authorizations;
 import java.util.List;
 import java.util.Optional;
-import java.util.function.Function;
+import java.util.function.BiFunction;
 
 /**
  * DrsHubAuthorization enables the mapping of an Authentication returned from a DRS Provider's
  * Options endpoint to the auth defined in DrsHub's config. Since the returned Authorization is only
  * available at runtime, but we have compile-time configs for each access type, which is only known
- * after we get object info, the `getAuthForAccessType` function allows the runtime type to be used
- * to get a lazily-evaluated bearer token or passport as needed.
+ * after we get object info, the `getAuthForAccessType` function allows the runtime type and DRS 1.5
+ * `cloud` (may be null for providers not yet emitting it) to be used to get a lazily-evaluated
+ * bearer token or passport as needed.
  */
 public record DrsHubAuthorization(
     Authorizations.SupportedTypesEnum drsAuthType,
-    Function<AccessMethod.TypeEnum, Optional<List<String>>> getAuthForAccessMethodType) {}
+    BiFunction<AccessMethod.TypeEnum, String, Optional<List<String>>> getAuthForAccessMethodType) {}

--- a/service/src/main/java/bio/terra/drshub/services/AuthService.java
+++ b/service/src/main/java/bio/terra/drshub/services/AuthService.java
@@ -143,15 +143,16 @@ public class AuthService {
       BearerToken bearerToken) {
     return switch (authType) {
       case NONE ->
-          new DrsHubAuthorization(authType, (AccessMethod.TypeEnum accessType) -> Optional.empty());
+          new DrsHubAuthorization(
+              authType, (AccessMethod.TypeEnum accessType, String cloud) -> Optional.empty());
       case BASICAUTH ->
           throw new DrsHubException(
               "DRSHub does not currently support basic username/password authentication");
       case BEARERAUTH ->
           new DrsHubAuthorization(
               authType,
-              (AccessMethod.TypeEnum accessType) ->
-                  switch (drsProvider.getAccessMethodByType(accessType).getAuth()) {
+              (AccessMethod.TypeEnum accessType, String cloud) ->
+                  switch (drsProvider.getAccessMethodConfig(accessType, cloud).getAuth()) {
                     case provider_access_token ->
                         getProviderAccessToken(components.toUriString(), drsProvider, bearerToken);
                     case current_request ->
@@ -161,7 +162,7 @@ public class AuthService {
                     // Check to see if the fallback auth is current_request or provider_access_token
                     case passport ->
                         drsProvider
-                            .getAccessMethodByType(accessType)
+                            .getAccessMethodConfig(accessType, cloud)
                             .getFallbackAuth()
                             .flatMap(
                                 auth ->
@@ -178,7 +179,8 @@ public class AuthService {
                   });
       case PASSPORTAUTH ->
           new DrsHubAuthorization(
-              authType, (AccessMethod.TypeEnum accessType) -> fetchPassports(bearerToken));
+              authType,
+              (AccessMethod.TypeEnum accessType, String cloud) -> fetchPassports(bearerToken));
     };
   }
 
@@ -216,16 +218,16 @@ public class AuthService {
       case current_request ->
           new DrsHubAuthorization(
               Authorizations.SupportedTypesEnum.BEARERAUTH,
-              accessType -> Optional.ofNullable(bearerToken.getToken()).map(List::of));
+              (accessType, cloud) -> Optional.ofNullable(bearerToken.getToken()).map(List::of));
       case provider_access_token ->
           new DrsHubAuthorization(
               Authorizations.SupportedTypesEnum.BEARERAUTH,
-              accessType ->
+              (accessType, cloud) ->
                   getProviderAccessToken(components.toUriString(), drsProvider, bearerToken));
       case passport ->
           new DrsHubAuthorization(
               Authorizations.SupportedTypesEnum.PASSPORTAUTH,
-              accessType -> fetchPassports(bearerToken));
+              (accessType, cloud) -> fetchPassports(bearerToken));
     };
   }
 

--- a/service/src/main/java/bio/terra/drshub/services/DrsResolutionService.java
+++ b/service/src/main/java/bio/terra/drshub/services/DrsResolutionService.java
@@ -207,12 +207,13 @@ public class DrsResolutionService {
     getDrsFileName(drsResponse).ifPresent(drsMetadataBuilder::fileName);
     drsMetadataBuilder.localizationPath(getLocalizationPath(drsProvider, drsResponse));
 
-    if (drsProvider.shouldFetchAccessUrl(accessMethodType, requestedFields, forceAccessUrl)) {
+    // DRS 1.5 `cloud` of the selected access method (null for providers not yet emitting it), used
+    // to select the per-cloud config so a GCS signed-URL method typed `https` is not matched to
+    // the Azure `https` config.
+    var accessMethodCloud = accessMethod.map(AccessMethod::getCloud).orElse(null);
+    if (drsProvider.shouldFetchAccessUrl(
+        accessMethodType, accessMethodCloud, requestedFields, forceAccessUrl)) {
       var accessId = accessMethod.map(AccessMethod::getAccessId).orElseThrow();
-      // DRS 1.5 `cloud` of the selected access method (null for providers not yet emitting it),
-      // used to select the per-cloud config so a GCS signed-URL method typed `https` is not
-      // matched to the Azure `https` config.
-      var accessMethodCloud = accessMethod.map(AccessMethod::getCloud).orElse(null);
       try {
         log.info("Requesting URL for {}", uriComponents.toUriString());
         var accessUrl =
@@ -324,6 +325,7 @@ public class DrsResolutionService {
                 accessId,
                 authorization,
                 accessMethodType,
+                accessMethodCloud,
                 uriComponents,
                 googleProject,
                 bearerToken,
@@ -341,6 +343,7 @@ public class DrsResolutionService {
                   accessId,
                   authorization,
                   accessMethodType,
+                  accessMethodCloud,
                   uriComponents,
                   googleProject,
                   bearerToken,
@@ -350,8 +353,7 @@ public class DrsResolutionService {
         }
       }
       if (accessUrl != null) {
-        auditLogEventBuilder.authType(
-            drsProvider.getAccessMethodConfig(accessMethodType, accessMethodCloud).getAuth());
+        auditLogEventBuilder.authType(accessMethodConfig.getAuth());
         return accessUrl;
       }
     }
@@ -364,12 +366,13 @@ public class DrsResolutionService {
       String accessId,
       DrsHubAuthorization authorization,
       TypeEnum accessMethodType,
+      String accessMethodCloud,
       UriComponents uriComponents,
       String googleProject,
       BearerToken bearerToken,
       boolean supportsUserProject) {
     Optional<List<String>> auth =
-        authorization.getAuthForAccessMethodType().apply(accessMethodType);
+        authorization.getAuthForAccessMethodType().apply(accessMethodType, accessMethodCloud);
 
     return switch (authorization.drsAuthType()) {
       case NONE -> drsApi.getAccessURL(objectId, accessId);

--- a/service/src/test/java/bio/terra/drshub/config/DrsProviderInterfaceTest.java
+++ b/service/src/test/java/bio/terra/drshub/config/DrsProviderInterfaceTest.java
@@ -44,10 +44,10 @@ class DrsProviderInterfaceTest extends BaseTest {
 
     assertFalse(
         passportDrsProvider.shouldFetchAccessUrl(
-            AccessMethod.TypeEnum.GS, Fields.ACCESS_URL_FIELDS, false));
+            AccessMethod.TypeEnum.GS, null, Fields.ACCESS_URL_FIELDS, false));
     assertFalse(
         passportDrsProvider.shouldFetchAccessUrl(
-            AccessMethod.TypeEnum.S3, Fields.ACCESS_URL_FIELDS, false));
+            AccessMethod.TypeEnum.S3, null, Fields.ACCESS_URL_FIELDS, false));
 
     var fenceProviderHost = getProviderHosts("fenceTokenOnly");
     var fenceTestUri = String.format("drs://%s:12345", fenceProviderHost.compactUriPrefix());
@@ -56,7 +56,30 @@ class DrsProviderInterfaceTest extends BaseTest {
 
     assertTrue(
         fenceDrsProvider.shouldFetchAccessUrl(
-            AccessMethod.TypeEnum.GS, Fields.ACCESS_URL_FIELDS, false));
+            AccessMethod.TypeEnum.GS, null, Fields.ACCESS_URL_FIELDS, false));
+  }
+
+  @Test
+  void testShouldFetchAccessUrl_disambiguatesByCloud() {
+    // Two `https`-typed configs (GCS passport + Azure) with different `fetchAccessUrl` settings.
+    // Only `cloud` can tell them apart -- type-only matching would pick whichever is listed first
+    // regardless of which cloud the resolved access method actually belongs to.
+    var azureConfig = createTestAccessMethodConfig(AccessMethodConfigTypeEnum.https, "azure");
+    azureConfig.setFetchAccessUrl(false);
+    var gcpConfig = createTestAccessMethodConfig(AccessMethodConfigTypeEnum.https, "gcp");
+    var drsProvider =
+        DrsProvider.create()
+            .setName("tdr")
+            .setHostRegex(".*")
+            .setMetadataAuthType(DrsAuthEnum.current_request)
+            .setAccessMethodConfigs(new ArrayList<>(List.of(azureConfig, gcpConfig)));
+
+    assertFalse(
+        drsProvider.shouldFetchAccessUrl(
+            AccessMethod.TypeEnum.HTTPS, "azure", Fields.ACCESS_URL_FIELDS, false));
+    assertTrue(
+        drsProvider.shouldFetchAccessUrl(
+            AccessMethod.TypeEnum.HTTPS, "gcp", Fields.ACCESS_URL_FIELDS, false));
   }
 
   @Test

--- a/service/src/test/java/bio/terra/drshub/controllers/VerifyPactDrsHubApiController.java
+++ b/service/src/test/java/bio/terra/drshub/controllers/VerifyPactDrsHubApiController.java
@@ -106,7 +106,8 @@ class VerifyPactsDrsHubApiController {
     context.setTarget(new MockMvcTestTarget(mockMvc));
   }
 
-  Optional<List<String>> getAuthForAccessMethodType(AccessMethod.TypeEnum accessMethodType) {
+  Optional<List<String>> getAuthForAccessMethodType(
+      AccessMethod.TypeEnum accessMethodType, String cloud) {
     return Optional.of(List.of("Bearer: test 123"));
   }
 

--- a/service/src/test/java/bio/terra/drshub/services/AuthServiceTest.java
+++ b/service/src/test/java/bio/terra/drshub/services/AuthServiceTest.java
@@ -12,6 +12,8 @@ import bio.terra.common.iam.BearerToken;
 import bio.terra.drshub.BaseTest;
 import bio.terra.drshub.DrsHubException;
 import bio.terra.drshub.config.DrsProvider;
+import bio.terra.drshub.config.ProviderAccessMethodConfig;
+import bio.terra.drshub.models.AccessMethodConfigTypeEnum;
 import bio.terra.drshub.models.DrsApi;
 import bio.terra.drshub.models.DrsAuthEnum;
 import bio.terra.drshub.models.DrsHubAuthorization;
@@ -117,7 +119,7 @@ class AuthServiceTest extends BaseTest {
 
     Set<Optional<List<String>>> secrets =
         authorizations.stream()
-            .map(a -> a.getAuthForAccessMethodType().apply(AccessMethod.TypeEnum.GS))
+            .map(a -> a.getAuthForAccessMethodType().apply(AccessMethod.TypeEnum.GS, null))
             .collect(Collectors.toSet());
 
     Set<Optional<List<String>>> expected =
@@ -143,7 +145,7 @@ class AuthServiceTest extends BaseTest {
 
     secrets =
         authorizations.stream()
-            .map(a -> a.getAuthForAccessMethodType().apply(AccessMethod.TypeEnum.GS))
+            .map(a -> a.getAuthForAccessMethodType().apply(AccessMethod.TypeEnum.GS, null))
             .collect(Collectors.toSet());
 
     expected =
@@ -153,6 +155,61 @@ class AuthServiceTest extends BaseTest {
 
     // Make sure ECM wasn't called a second time due to the cache
     verify(oidcApi).getProviderPassport(any());
+  }
+
+  @Test
+  void testMappingDrsAuthorizations_bearerAuthUsesCloudToDisambiguateHttpsConfigs() {
+    // TDR types both its GCS passport method and its Azure method `https` -- only the DRS 1.5
+    // `cloud` field tells them apart. The BEARERAUTH resolution path must use it (via
+    // getAccessMethodConfig), not fall through to whichever `https` config happens to be listed
+    // first, or it reintroduces the CTM-613 bug class for this auth path.
+    var azureConfig =
+        ProviderAccessMethodConfig.create()
+            .setType(AccessMethodConfigTypeEnum.https)
+            .setAuth(DrsAuthEnum.current_request)
+            .setFetchAccessUrl(true)
+            .setCloud("azure");
+    var gcpConfig =
+        ProviderAccessMethodConfig.create()
+            .setType(AccessMethodConfigTypeEnum.https)
+            .setAuth(DrsAuthEnum.provider_access_token)
+            .setFetchAccessUrl(true)
+            .setCloud("gcp");
+    var drsProvider =
+        DrsProvider.create()
+            .setName("tdr")
+            .setHostRegex(".*")
+            .setMetadataAuthType(DrsAuthEnum.current_request)
+            .setEcmProvider(Optional.of(ECMProviderEnum.fence))
+            .setAccessMethodConfigs(new ArrayList<>(List.of(azureConfig, gcpConfig)));
+
+    var uriComponents = UriComponentsBuilder.fromUriString("drs://test-host/object-1").build();
+    var bearerToken = new BearerToken("bearer-token-value");
+    var providerAccessToken = "provider-access-token-value";
+
+    when(drsApiFactory.getApiFromUriComponents(any(), any())).thenReturn(drsApi);
+    when(drsApi.optionsObject(any()))
+        .thenReturn(
+            new Authorizations()
+                .supportedTypes(List.of(Authorizations.SupportedTypesEnum.BEARERAUTH)));
+    when(externalCredsApiFactory.getOauthApi(any())).thenReturn(oauthApi);
+    when(oauthApi.getProviderAccessToken(any())).thenReturn(providerAccessToken);
+
+    var authorizations = authService.buildAuthorizations(drsProvider, uriComponents, bearerToken);
+    var bearerAuth =
+        authorizations.stream()
+            .filter(a -> a.drsAuthType() == Authorizations.SupportedTypesEnum.BEARERAUTH)
+            .findFirst()
+            .orElseThrow();
+
+    // Azure config says current_request -> resolves to the caller's bearer token.
+    assertEquals(
+        Optional.of(List.of(bearerToken.getToken())),
+        bearerAuth.getAuthForAccessMethodType().apply(AccessMethod.TypeEnum.HTTPS, "azure"));
+    // GCP config says provider_access_token -> resolves to the fence-provider token from ECM.
+    assertEquals(
+        Optional.of(List.of(providerAccessToken)),
+        bearerAuth.getAuthForAccessMethodType().apply(AccessMethod.TypeEnum.HTTPS, "gcp"));
   }
 
   @Test

--- a/service/src/test/java/bio/terra/drshub/services/DrsResolutionServiceTest.java
+++ b/service/src/test/java/bio/terra/drshub/services/DrsResolutionServiceTest.java
@@ -78,7 +78,7 @@ class DrsResolutionServiceTest {
       new DrsHubAuthorization(SupportedTypesEnum.PASSPORTAUTH, null);
   private static final DrsHubAuthorization BEARERAUTH =
       new DrsHubAuthorization(
-          SupportedTypesEnum.BEARERAUTH, (var e) -> Optional.of(List.of(TOKEN_VALUE)));
+          SupportedTypesEnum.BEARERAUTH, (var e, var c) -> Optional.of(List.of(TOKEN_VALUE)));
   private static final DrsObject DRS_OBJECT = new DrsObject().id("drs.id");
 
   private static final String accessId = "foo";
@@ -553,10 +553,11 @@ class DrsResolutionServiceTest {
     var tdrProvider = createTdrProviderWithRetryMode();
     var googleProject = "test-project";
     var passportAuth =
-        new DrsHubAuthorization(SupportedTypesEnum.PASSPORTAUTH, (var e) -> Optional.of(PASSPORTS));
+        new DrsHubAuthorization(
+            SupportedTypesEnum.PASSPORTAUTH, (var e, var c) -> Optional.of(PASSPORTS));
     var bearerAuth =
         new DrsHubAuthorization(
-            SupportedTypesEnum.BEARERAUTH, (var e) -> Optional.of(List.of(TOKEN_VALUE)));
+            SupportedTypesEnum.BEARERAUTH, (var e, var c) -> Optional.of(List.of(TOKEN_VALUE)));
 
     when(tdrApiFactory.getApi(TOKEN_VALUE)).thenReturn(tdrApi);
     when(tdrApi.postAccessURL(
@@ -591,10 +592,11 @@ class DrsResolutionServiceTest {
     var tdrProvider = createTdrProviderWithRetryMode();
     var googleProject = "test-project";
     var passportAuth =
-        new DrsHubAuthorization(SupportedTypesEnum.PASSPORTAUTH, (var e) -> Optional.of(PASSPORTS));
+        new DrsHubAuthorization(
+            SupportedTypesEnum.PASSPORTAUTH, (var e, var c) -> Optional.of(PASSPORTS));
     var bearerAuth =
         new DrsHubAuthorization(
-            SupportedTypesEnum.BEARERAUTH, (var e) -> Optional.of(List.of(TOKEN_VALUE)));
+            SupportedTypesEnum.BEARERAUTH, (var e, var c) -> Optional.of(List.of(TOKEN_VALUE)));
 
     when(tdrApiFactory.getApi(TOKEN_VALUE)).thenReturn(tdrApi);
     when(tdrApi.postAccessURL(any(DRSPassportRequestModel.class), any(), any(), any()))
@@ -619,10 +621,11 @@ class DrsResolutionServiceTest {
   @Test
   void passportAuthWithGoogleProject_noGoogleProject() throws Exception {
     var passportAuth =
-        new DrsHubAuthorization(SupportedTypesEnum.PASSPORTAUTH, (var e) -> Optional.of(PASSPORTS));
+        new DrsHubAuthorization(
+            SupportedTypesEnum.PASSPORTAUTH, (var e, var c) -> Optional.of(PASSPORTS));
     var bearerAuth =
         new DrsHubAuthorization(
-            SupportedTypesEnum.BEARERAUTH, (var e) -> Optional.of(List.of(TOKEN_VALUE)));
+            SupportedTypesEnum.BEARERAUTH, (var e, var c) -> Optional.of(List.of(TOKEN_VALUE)));
 
     when(drsApi.postAccessURL(Map.of("passports", PASSPORTS), PATH, accessId))
         .thenReturn(new AccessURL().url("https://example.com"));
@@ -652,7 +655,8 @@ class DrsResolutionServiceTest {
     var tdrProvider = createTdrProviderWithRetryMode();
     var googleProject = "test-project";
     var passportAuth =
-        new DrsHubAuthorization(SupportedTypesEnum.PASSPORTAUTH, (var e) -> Optional.of(PASSPORTS));
+        new DrsHubAuthorization(
+            SupportedTypesEnum.PASSPORTAUTH, (var e, var c) -> Optional.of(PASSPORTS));
 
     when(tdrApiFactory.getApi(TOKEN_VALUE)).thenReturn(tdrApi);
     when(tdrApi.postAccessURL(
@@ -688,7 +692,8 @@ class DrsResolutionServiceTest {
     var googleProject = "test-google-project";
     var ip = "test.ip";
     var passportAuth =
-        new DrsHubAuthorization(SupportedTypesEnum.PASSPORTAUTH, (var e) -> Optional.of(PASSPORTS));
+        new DrsHubAuthorization(
+            SupportedTypesEnum.PASSPORTAUTH, (var e, var c) -> Optional.of(PASSPORTS));
 
     when(tdrApiFactory.getApi(TOKEN_VALUE)).thenReturn(tdrApi);
     when(tdrApi.postAccessURL(
@@ -731,10 +736,11 @@ class DrsResolutionServiceTest {
     // route any passport-auth provider to TDR.
     var googleProject = "terra-dev-billing-project";
     var passportAuth =
-        new DrsHubAuthorization(SupportedTypesEnum.PASSPORTAUTH, (var e) -> Optional.of(PASSPORTS));
+        new DrsHubAuthorization(
+            SupportedTypesEnum.PASSPORTAUTH, (var e, var c) -> Optional.of(PASSPORTS));
     var bearerAuth =
         new DrsHubAuthorization(
-            SupportedTypesEnum.BEARERAUTH, (var e) -> Optional.of(List.of(TOKEN_VALUE)));
+            SupportedTypesEnum.BEARERAUTH, (var e, var c) -> Optional.of(List.of(TOKEN_VALUE)));
 
     when(drsApi.postAccessURL(Map.of("passports", PASSPORTS), PATH, accessId))
         .thenReturn(new AccessURL().url("https://fence.example.com/signed-url"));


### PR DESCRIPTION
> Note: I do not plan on merging this in the short term

## Summary
Stacked on #262. Split out separately since it's a bigger change (a functional-interface signature change touching ~10 call sites) than #262's core fix.

`getAccessMethodConfig(type, cloud)` from #262 fixed the passport/access-URL config lookup, but two other call sites still matched on `type` alone -- the same `https`-typed-for-every-cloud ambiguity #262 otherwise fixes:

- `AuthService`'s `BEARERAUTH` resolution path (`mapDrsAuthType`) used `getAccessMethodByType`, not the cloud-aware lookup.
- `DrsProviderInterface.shouldFetchAccessUrl` scanned all configs by `type` alone rather than resolving the specific config for the object.

Both are currently masked because TDR's `gs`/`https` `auth` and `fetchAccessUrl` settings happen to match, but would silently misroute auth or stop fetching access URLs for GCP-passport objects if either config ever diverges -- reintroducing the CTM-613 bug class via a different path than #262 touches.

This threads `cloud` through `DrsHubAuthorization`'s auth-resolution function (`Function` -> `BiFunction<AccessMethod.TypeEnum, String, ...>`) and through `shouldFetchAccessUrl`, and dedupes a redundant `getAccessMethodConfig` call in the audit-log path.

## Test plan
- [x] New `AuthServiceTest` case proves `BEARERAUTH` resolves differently for `cloud=azure` vs `cloud=gcp` on the same `https` type
- [x] New `DrsProviderInterfaceTest` case proves `shouldFetchAccessUrl` does the same for `fetchAccessUrl`
- [x] `./gradlew :service:test` -- full suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)