### PR TITLE
CTM-613 - Enable passing Requester Pays info for TDR case

### DIFF
--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -56,7 +56,8 @@ drshub:
         - type: https
           auth: current_request
           fetchAccessUrl: true # Used for Azure
-          requiresUserProjectOnRetry: false  # Azure doesn't have requester-pays
+          requiresUserProjectOnRetry: true # used for gcp, ignored for azure
+          supportsUserProject: true  # used for gcp, ignored for azure
     sage:
       name: Sage Bionetworks
       hostRegex: 'repo-dev\.dev\.sagebase\.org|repo-prod\.prod\.sagebase\.org'


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/CTM-613
## Summary

The HTTPS access method is shared for signed urls for files that live in both GCP and Azure. We originally did not send the "user project" information for the HTTPS access method because it is primarily used for Azure. However, this breaks for GCP signed urls. 

This change means that we will send requester-pays/user google project related information when required for gcp and Azure-backed signed urls. If DRS Hub doesn't have the google project info, it will fall back to not sending the google project. TDR will just drop/ignore this information in the azure case. 